### PR TITLE
feat(card-browser): implement 'Default search text'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserOptionsRepository.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserOptionsRepository.kt
@@ -47,18 +47,21 @@ class BrowserOptionsRepository(
     }
 
     suspend fun setCardsOrNotes(value: CardsOrNotes) {
+        if (cardsOrNotes.value == value) return
         Timber.i("setting cards/notes mode to %s", value)
         withCol { value.saveToCollection(this) }
         cardsOrNotes.value = value
     }
 
     fun setIsTruncated(value: Boolean) {
+        if (isTruncated.value == value) return
         Timber.d("setting truncated to %s", value)
         sharedPrefs.edit { putBoolean(PREF_IS_TRUNCATED, value) }
         isTruncated.value = value
     }
 
     suspend fun setIgnoreAccentsInSearch(value: Boolean) {
+        if (ignoreAccentsInSearch.value == value) return
         Timber.d("setting ignore accents in search to %s", value)
         withCol { config.ignoreAccentsInSearch = value }
         ignoreAccentsInSearch.value = value

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserOptionsRepository.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserOptionsRepository.kt
@@ -20,6 +20,7 @@ import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.model.CardsOrNotes
+import com.ichi2.anki.utils.ext.defaultBrowserSearch
 import com.ichi2.anki.utils.ext.ignoreAccentsInSearch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -40,10 +41,15 @@ class BrowserOptionsRepository(
     val ignoreAccentsInSearch: StateFlow<Boolean>
         field = MutableStateFlow(false)
 
+    /** @see com.ichi2.anki.libanki.Config.defaultBrowserSearch */
+    val defaultBrowserSearch: StateFlow<String>
+        field = MutableStateFlow("")
+
     /** Reads persisted values into the flows. Call once during ViewModel init. */
     suspend fun load() {
         cardsOrNotes.value = withCol { CardsOrNotes.fromCollection(this) }
         ignoreAccentsInSearch.value = withCol { config.ignoreAccentsInSearch }
+        defaultBrowserSearch.value = withCol { config.defaultBrowserSearch }
     }
 
     suspend fun setCardsOrNotes(value: CardsOrNotes) {
@@ -65,6 +71,13 @@ class BrowserOptionsRepository(
         Timber.d("setting ignore accents in search to %s", value)
         withCol { config.ignoreAccentsInSearch = value }
         ignoreAccentsInSearch.value = value
+    }
+
+    suspend fun setDefaultBrowserSearch(value: String) {
+        if (defaultBrowserSearch.value == value) return
+        Timber.d("setting default browser search to %s", value)
+        withCol { config.defaultBrowserSearch = value }
+        defaultBrowserSearch.value = value
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserOptionsRepository.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserOptionsRepository.kt
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.model.CardsOrNotes
+import com.ichi2.anki.utils.ext.ignoreAccentsInSearch
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import timber.log.Timber
+
+/**
+ * Source of truth for the values controlled by [com.ichi2.anki.dialogs.BrowserOptionsDialog]
+ */
+class BrowserOptionsRepository(
+    private val sharedPrefs: SharedPreferences,
+) {
+    val cardsOrNotes: StateFlow<CardsOrNotes>
+        field = MutableStateFlow(CardsOrNotes.CARDS)
+
+    val isTruncated: StateFlow<Boolean>
+        field = MutableStateFlow(sharedPrefs.getBoolean(PREF_IS_TRUNCATED, false))
+
+    val ignoreAccentsInSearch: StateFlow<Boolean>
+        field = MutableStateFlow(false)
+
+    /** Reads persisted values into the flows. Call once during ViewModel init. */
+    suspend fun load() {
+        cardsOrNotes.value = withCol { CardsOrNotes.fromCollection(this) }
+        ignoreAccentsInSearch.value = withCol { config.ignoreAccentsInSearch }
+    }
+
+    suspend fun setCardsOrNotes(value: CardsOrNotes) {
+        Timber.i("setting cards/notes mode to %s", value)
+        withCol { value.saveToCollection(this) }
+        cardsOrNotes.value = value
+    }
+
+    fun setIsTruncated(value: Boolean) {
+        Timber.d("setting truncated to %s", value)
+        sharedPrefs.edit { putBoolean(PREF_IS_TRUNCATED, value) }
+        isTruncated.value = value
+    }
+
+    suspend fun setIgnoreAccentsInSearch(value: Boolean) {
+        Timber.d("setting ignore accents in search to %s", value)
+        withCol { config.ignoreAccentsInSearch = value }
+        ignoreAccentsInSearch.value = value
+    }
+
+    companion object {
+        private const val PREF_IS_TRUNCATED = "isTruncated"
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -1079,6 +1079,11 @@ class CardBrowserFragment :
             Timber.d("syncing searchview state from chip updates")
             val filters = search.filters
 
+            // Handle default search text
+            if (search.query.isNotEmpty() && searchBar?.text.isNullOrEmpty()) {
+                launchCatchingTask { searchBar?.setText(search.toUserSpannable()) }
+            }
+
             decksChip?.text = filters.decks.firstOrNull()?.name ?: TR.sentenceCase.allDecks
             decksChip?.hasCheckedBackground = filters.decks.any()
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -1173,6 +1173,11 @@ class CardBrowserFragment :
             Timber.d("syncing searchview state from chip updates")
             val filters = search.filters
 
+            // Handle default search text
+            if (search.query.isNotEmpty() && searchBar?.text.isNullOrEmpty()) {
+                launchCatchingTask { searchBar?.setText(search.toUserSpannable()) }
+            }
+
             legacyDeckName?.text = filters.decks.firstOrNull()?.name ?: TR.sentenceCase.allDecks
             decksChip?.text = filters.decks.firstOrNull()?.name ?: TR.sentenceCase.allDecks
             decksChip?.hasCheckedBackground = filters.decks.any()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -20,7 +20,6 @@ import android.os.Bundle
 import android.os.Parcel
 import android.os.Parcelable
 import androidx.annotation.CheckResult
-import androidx.core.content.edit
 import androidx.core.os.BundleCompat
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -82,7 +81,6 @@ import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.settings.PrefsRepository
 import com.ichi2.anki.utils.ext.currentCardBrowse
 import com.ichi2.anki.utils.ext.getCardOrNull
-import com.ichi2.anki.utils.ext.ignoreAccentsInSearch
 import com.ichi2.anki.utils.ext.setUserFlagForCards
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
@@ -141,6 +139,8 @@ class CardBrowserViewModel(
     preferences: SharedPreferencesProvider,
     val isFragmented: Boolean,
     val savedStateHandle: SavedStateHandle,
+    private val browserOptionsRepository: BrowserOptionsRepository =
+        BrowserOptionsRepository(preferences.sharedPrefs()),
     private val manualInit: Boolean = false,
 ) : ViewModel(),
     SharedPreferencesProvider by preferences {
@@ -202,8 +202,8 @@ class CardBrowserViewModel(
      * Whether the browser is working in Cards mode or Notes mode.
      * default: [CARDS]
      * */
-    private val flowOfCardsOrNotes = MutableStateFlow(CARDS)
-    val cardsOrNotes get() = flowOfCardsOrNotes.value
+    val flowOfCardsOrNotes: StateFlow<CardsOrNotes> = browserOptionsRepository.cardsOrNotes
+    val cardsOrNotes: CardsOrNotes get() = flowOfCardsOrNotes.value
 
     /**
      * Ensures [focusedRow] points to a row in the current [cards] list, falling back to the
@@ -263,11 +263,10 @@ class CardBrowserViewModel(
             .map { it?.isNotEmpty() == true }
             .stateIn(viewModelScope, SharingStarted.Eagerly, initialValue = false)
 
-    val flowOfIsTruncated: MutableStateFlow<Boolean> =
-        MutableStateFlow(sharedPrefs().getBoolean("isTruncated", false))
-    val isTruncated get() = flowOfIsTruncated.value
+    val flowOfIsTruncated: StateFlow<Boolean> = browserOptionsRepository.isTruncated
+    val isTruncated: Boolean get() = flowOfIsTruncated.value
 
-    var shouldIgnoreAccents: Boolean = false
+    val shouldIgnoreAccents: Boolean get() = browserOptionsRepository.ignoreAccentsInSearch.value
 
     private val _selectedRows: MutableSet<CardOrNoteId> = Collections.synchronizedSet(LinkedHashSet())
 
@@ -550,15 +549,12 @@ class CardBrowserViewModel(
             }.launchIn(viewModelScope)
 
         viewModelScope.launch {
-            shouldIgnoreAccents = withCol { config.ignoreAccentsInSearch }
+            browserOptionsRepository.load()
 
             val initialDeckId = if (selectAllDecks) SelectableDeck.AllDecks else getInitialDeck()
             // PERF: slightly inefficient if the source was lastDeckId
             setSelectedDeck(initialDeckId)
             refreshBackendColumns()
-
-            val cardsOrNotes = withCol { CardsOrNotes.fromCollection(this@withCol) }
-            flowOfCardsOrNotes.update { cardsOrNotes }
 
             withCol {
                 sortTypeFlow.update { LegacySortType.fromCol(config, cardsOrNotes, prefs) }
@@ -794,32 +790,11 @@ class CardBrowserViewModel(
             }
     }
 
-    fun setCardsOrNotes(newValue: CardsOrNotes) =
-        viewModelScope.launch {
-            Timber.i("setting mode to %s", newValue)
-            withCol {
-                // Change this to only change the preference on a state change
-                newValue.saveToCollection(this@withCol)
-            }
-            flowOfCardsOrNotes.update { newValue }
-        }
+    fun setCardsOrNotes(newValue: CardsOrNotes) = viewModelScope.launch { browserOptionsRepository.setCardsOrNotes(newValue) }
 
-    fun setTruncated(value: Boolean) {
-        viewModelScope.launch {
-            flowOfIsTruncated.emit(value)
-        }
-        sharedPrefs().edit {
-            putBoolean("isTruncated", value)
-        }
-    }
+    fun setTruncated(value: Boolean) = viewModelScope.launch { browserOptionsRepository.setIsTruncated(value) }
 
-    fun setIgnoreAccents(value: Boolean) {
-        Timber.d("Setting ignore accent in search to: $value")
-        viewModelScope.launch {
-            shouldIgnoreAccents = value
-            withCol { config.ignoreAccentsInSearch = value }
-        }
-    }
+    fun setIgnoreAccents(value: Boolean) = viewModelScope.launch { browserOptionsRepository.setIgnoreAccentsInSearch(value) }
 
     fun selectAll(): Job? {
         if (!_selectedRows.addAll(cards)) return null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -268,6 +268,8 @@ class CardBrowserViewModel(
 
     val shouldIgnoreAccents: Boolean get() = browserOptionsRepository.ignoreAccentsInSearch.value
 
+    val defaultBrowserSearch: String get() = browserOptionsRepository.defaultBrowserSearch.value
+
     private val _selectedRows: MutableSet<CardOrNoteId> = Collections.synchronizedSet(LinkedHashSet())
 
     // immutable accessor for _selectedRows
@@ -551,6 +553,11 @@ class CardBrowserViewModel(
         viewModelScope.launch {
             browserOptionsRepository.load()
 
+            // Apply the default search (if available)
+            if (Prefs.devUsingCardBrowserSearchView) {
+                searchTerms = searchTerms.ifEmpty { defaultBrowserSearch }
+            }
+
             val initialDeckId = if (selectAllDecks) SelectableDeck.AllDecks else getInitialDeck()
             // PERF: slightly inefficient if the source was lastDeckId
             setSelectedDeck(initialDeckId)
@@ -795,6 +802,12 @@ class CardBrowserViewModel(
     fun setTruncated(value: Boolean) = viewModelScope.launch { browserOptionsRepository.setIsTruncated(value) }
 
     fun setIgnoreAccents(value: Boolean) = viewModelScope.launch { browserOptionsRepository.setIgnoreAccentsInSearch(value) }
+
+    fun setDefaultSearchText(text: String) =
+        viewModelScope.launch {
+            if (!Prefs.devUsingCardBrowserSearchView) return@launch
+            browserOptionsRepository.setDefaultBrowserSearch(text)
+        }
 
     fun selectAll(): Job? {
         if (!_selectedRows.addAll(cards)) return null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -63,6 +63,7 @@ import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.preferences.SharedPreferencesProvider
+import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.utils.ext.getCardOrNull
 import com.ichi2.anki.utils.ext.setUserFlagForCards
 import kotlinx.coroutines.Deferred
@@ -266,6 +267,8 @@ class CardBrowserViewModel(
     val isTruncated: Boolean get() = flowOfIsTruncated.value
 
     val shouldIgnoreAccents: Boolean get() = browserOptionsRepository.ignoreAccentsInSearch.value
+
+    val defaultBrowserSearch: String get() = browserOptionsRepository.defaultBrowserSearch.value
 
     private val _selectedRows: MutableSet<CardOrNoteId> = Collections.synchronizedSet(LinkedHashSet())
 
@@ -557,6 +560,11 @@ class CardBrowserViewModel(
         viewModelScope.launch {
             browserOptionsRepository.load()
 
+            // Apply the default search (if available)
+            if (Prefs.devUsingCardBrowserSearchView) {
+                searchTerms = searchTerms.ifEmpty { defaultBrowserSearch }
+            }
+
             val initialDeckId = if (selectAllDecks) SelectableDeck.AllDecks else getInitialDeck()
             // PERF: slightly inefficient if the source was lastDeckId
             setSelectedDeck(initialDeckId)
@@ -798,6 +806,12 @@ class CardBrowserViewModel(
     fun setTruncated(value: Boolean) = viewModelScope.launch { browserOptionsRepository.setIsTruncated(value) }
 
     fun setIgnoreAccents(value: Boolean) = viewModelScope.launch { browserOptionsRepository.setIgnoreAccentsInSearch(value) }
+
+    fun setDefaultSearchText(text: String) =
+        viewModelScope.launch {
+            if (!Prefs.devUsingCardBrowserSearchView) return@launch
+            browserOptionsRepository.setDefaultBrowserSearch(text)
+        }
 
     fun selectAll(): Job? {
         if (!_selectedRows.addAll(cards)) return null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import android.os.Parcel
 import android.os.Parcelable
 import androidx.annotation.CheckResult
-import androidx.core.content.edit
 import androidx.core.os.BundleCompat
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -65,7 +64,6 @@ import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.preferences.SharedPreferencesProvider
 import com.ichi2.anki.utils.ext.getCardOrNull
-import com.ichi2.anki.utils.ext.ignoreAccentsInSearch
 import com.ichi2.anki.utils.ext.setUserFlagForCards
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
@@ -128,6 +126,8 @@ class CardBrowserViewModel(
     preferences: SharedPreferencesProvider,
     val isFragmented: Boolean,
     val savedStateHandle: SavedStateHandle,
+    private val browserOptionsRepository: BrowserOptionsRepository =
+        BrowserOptionsRepository(preferences.sharedPrefs()),
     private val manualInit: Boolean = false,
 ) : ViewModel(),
     SharedPreferencesProvider by preferences {
@@ -191,8 +191,8 @@ class CardBrowserViewModel(
      * Whether the browser is working in Cards mode or Notes mode.
      * default: [CARDS]
      * */
-    private val flowOfCardsOrNotes = MutableStateFlow(CARDS)
-    val cardsOrNotes get() = flowOfCardsOrNotes.value
+    val flowOfCardsOrNotes: StateFlow<CardsOrNotes> = browserOptionsRepository.cardsOrNotes
+    val cardsOrNotes: CardsOrNotes get() = flowOfCardsOrNotes.value
 
     /**
      * Ensures [paneRow] points to a row in the current [cards] list, falling back to the
@@ -262,11 +262,10 @@ class CardBrowserViewModel(
             .map { it?.isNotEmpty() == true }
             .stateIn(viewModelScope, SharingStarted.Eagerly, initialValue = false)
 
-    val flowOfIsTruncated: MutableStateFlow<Boolean> =
-        MutableStateFlow(sharedPrefs().getBoolean("isTruncated", false))
-    val isTruncated get() = flowOfIsTruncated.value
+    val flowOfIsTruncated: StateFlow<Boolean> = browserOptionsRepository.isTruncated
+    val isTruncated: Boolean get() = flowOfIsTruncated.value
 
-    var shouldIgnoreAccents: Boolean = false
+    val shouldIgnoreAccents: Boolean get() = browserOptionsRepository.ignoreAccentsInSearch.value
 
     private val _selectedRows: MutableSet<CardOrNoteId> = Collections.synchronizedSet(LinkedHashSet())
 
@@ -556,15 +555,12 @@ class CardBrowserViewModel(
             }.launchIn(viewModelScope)
 
         viewModelScope.launch {
-            shouldIgnoreAccents = withCol { config.ignoreAccentsInSearch }
+            browserOptionsRepository.load()
 
             val initialDeckId = if (selectAllDecks) SelectableDeck.AllDecks else getInitialDeck()
             // PERF: slightly inefficient if the source was lastDeckId
             setSelectedDeck(initialDeckId)
             refreshBackendColumns()
-
-            val cardsOrNotes = withCol { CardsOrNotes.fromCollection(this@withCol) }
-            flowOfCardsOrNotes.update { cardsOrNotes }
 
             flowOfReverseDirection.update { (SortType.build(cardsOrNotes) as? SortType.CollectionOrdering)?.reverse }
 
@@ -797,32 +793,11 @@ class CardBrowserViewModel(
             }
     }
 
-    fun setCardsOrNotes(newValue: CardsOrNotes) =
-        viewModelScope.launch {
-            Timber.i("setting mode to %s", newValue)
-            withCol {
-                // Change this to only change the preference on a state change
-                newValue.saveToCollection(this@withCol)
-            }
-            flowOfCardsOrNotes.update { newValue }
-        }
+    fun setCardsOrNotes(newValue: CardsOrNotes) = viewModelScope.launch { browserOptionsRepository.setCardsOrNotes(newValue) }
 
-    fun setTruncated(value: Boolean) {
-        viewModelScope.launch {
-            flowOfIsTruncated.emit(value)
-        }
-        sharedPrefs().edit {
-            putBoolean("isTruncated", value)
-        }
-    }
+    fun setTruncated(value: Boolean) = viewModelScope.launch { browserOptionsRepository.setIsTruncated(value) }
 
-    fun setIgnoreAccents(value: Boolean) {
-        Timber.d("Setting ignore accent in search to: $value")
-        viewModelScope.launch {
-            shouldIgnoreAccents = value
-            withCol { config.ignoreAccentsInSearch = value }
-        }
-    }
+    fun setIgnoreAccents(value: Boolean) = viewModelScope.launch { browserOptionsRepository.setIgnoreAccentsInSearch(value) }
 
     fun selectAll(): Job? {
         if (!_selectedRows.addAll(cards)) return null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
@@ -18,7 +18,9 @@ package com.ichi2.anki.dialogs
 
 import android.app.Dialog
 import android.os.Bundle
+import android.text.Editable
 import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.ichi2.anki.CollectionManager.TR
@@ -27,6 +29,7 @@ import com.ichi2.anki.browser.BrowserColumnSelectionFragment
 import com.ichi2.anki.browser.CardBrowserViewModel
 import com.ichi2.anki.databinding.DialogBrowserOptionsBinding
 import com.ichi2.anki.model.CardsOrNotes
+import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.utils.create
 import com.ichi2.utils.negativeButton
@@ -52,6 +55,7 @@ class BrowserOptionsDialog : AppCompatDialogFragment(R.layout.dialog_browser_opt
         viewModel.setCardsOrNotes(dialogCardsOrNotes)
         viewModel.setTruncated(binding.truncateCheckBox.isChecked)
         viewModel.setIgnoreAccents(binding.ignoreAccentsCheckBox.isChecked)
+        viewModel.setDefaultSearchText(binding.defaultSearchText.text.orEmpty())
     }
 
     private val cardsOrNotes by lazy {
@@ -102,6 +106,15 @@ class BrowserOptionsDialog : AppCompatDialogFragment(R.layout.dialog_browser_opt
             isChecked = viewModel.shouldIgnoreAccents
         }
 
+        if (Prefs.devUsingCardBrowserSearchView) {
+            binding.defaultSearchInputLayout.apply {
+                isVisible = true
+                hint = TR.preferencesDefaultSearchText()
+                placeholderText = TR.preferencesDefaultSearchTextExample()
+            }
+            binding.defaultSearchText.setText(viewModel.defaultBrowserSearch)
+        }
+
         binding.browsingTextView.text = TR.preferencesBrowsing()
 
         return MaterialAlertDialogBuilder(requireContext()).create {
@@ -137,3 +150,6 @@ class BrowserOptionsDialog : AppCompatDialogFragment(R.layout.dialog_browser_opt
         }
     }
 }
+
+/** Returns the text content as a [String], or `""` if the receiver is `null`. */
+private fun Editable?.orEmpty(): String = this?.toString().orEmpty()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
@@ -49,19 +49,9 @@ class BrowserOptionsDialog : AppCompatDialogFragment(R.layout.dialog_browser_opt
 
     /** Persists updated options to the ViewModel */
     fun saveChanges() {
-        if (cardsOrNotes != dialogCardsOrNotes) {
-            viewModel.setCardsOrNotes(dialogCardsOrNotes)
-        }
-        val newTruncate = binding.truncateCheckBox.isChecked
-
-        if (newTruncate != isTruncated) {
-            viewModel.setTruncated(newTruncate)
-        }
-
-        val newIgnoreAccent = binding.ignoreAccentsCheckBox.isChecked
-        if (newIgnoreAccent != viewModel.shouldIgnoreAccents) {
-            viewModel.setIgnoreAccents(newIgnoreAccent)
-        }
+        viewModel.setCardsOrNotes(dialogCardsOrNotes)
+        viewModel.setTruncated(binding.truncateCheckBox.isChecked)
+        viewModel.setIgnoreAccents(binding.ignoreAccentsCheckBox.isChecked)
     }
 
     private val cardsOrNotes by lazy {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Config.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Config.kt
@@ -33,3 +33,12 @@ import com.ichi2.anki.libanki.Config
 var Config.ignoreAccentsInSearch
     get() = getBool(ConfigKey.Bool.IGNORE_ACCENTS_IN_SEARCH)
     set(value) = setBool(ConfigKey.Bool.IGNORE_ACCENTS_IN_SEARCH, value)
+
+/**
+ * Default search text for the card browser
+ *
+ * e.g. "deck:current"
+ */
+var Config.defaultBrowserSearch
+    get() = getString(ConfigKey.String.DEFAULT_SEARCH_TEXT)
+    set(value) = setString(ConfigKey.String.DEFAULT_SEARCH_TEXT, value)

--- a/AnkiDroid/src/main/res/layout/dialog_browser_options.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_browser_options.xml
@@ -93,6 +93,26 @@
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="16dp"
                 tools:text="Ignore accents in search (slower)"/>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/default_search_input_layout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+                app:expandedHintEnabled="false"
+                app:endIconMode="clear_text"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginTop="8dp"
+                android:visibility="gone"
+                tools:visibility="visible"
+                tools:hint="Default search text">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/default_search_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="text"
+                    tools:hint="e.g. 'deck:current'"/>
+            </com.google.android.material.textfield.TextInputLayout>
         </LinearLayout>
 
         <LinearLayout

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -7,6 +7,7 @@
         <item name="colorPrimaryDark">@color/material_light_blue_700</item>
         <item name="colorSurface">@color/white</item>
         <item name="colorOnSurface">@color/black</item>
+        <item name="android:textColorHint">#716C76</item>
         <item name="colorAccent">@color/material_blue_grey_700</item>
         <item name="colorPrimaryContainer">@color/white</item> <!-- Switch thumb color when disabled and being pressed -->
         <item name="colorOnPrimaryContainer">@color/white</item> <!-- FAB icons -->

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -83,6 +83,7 @@ import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.servicelayer.NoteService
 import com.ichi2.anki.setFlagFilterSync
 import com.ichi2.anki.settings.Prefs
+import com.ichi2.anki.utils.ext.defaultBrowserSearch
 import com.ichi2.anki.utils.ext.ignoreAccentsInSearch
 import com.ichi2.testutils.IntentAssert
 import com.ichi2.testutils.JvmTest
@@ -1849,6 +1850,47 @@ class CardBrowserViewModelTest : JvmTest() {
 
             assertThat("hello and hêllo are matched", rowCount, equalTo(2))
             assertThat("input is unchanged", searchTerms, equalTo("hello"))
+        }
+    }
+
+    @Test
+    fun `default search text is applied on init`() {
+        col.config.defaultBrowserSearch = "deck:current"
+        try {
+            Prefs.devUsingCardBrowserSearchView = true
+            runViewModelTest {
+                assertThat(searchTerms, equalTo("deck:current"))
+                assertThat(defaultBrowserSearch, equalTo("deck:current"))
+            }
+        } finally {
+            Prefs.devUsingCardBrowserSearchView = false
+        }
+    }
+
+    @Test
+    fun `intent search wins over default search text`() {
+        col.config.defaultBrowserSearch = "deck:current"
+        try {
+            Prefs.devUsingCardBrowserSearchView = true
+            runViewModelTest(options = DeepLink("tag:foo")) {
+                assertThat(searchTerms, equalTo("tag:foo"))
+            }
+        } finally {
+            Prefs.devUsingCardBrowserSearchView = false
+        }
+    }
+
+    @Test
+    fun `setDefaultSearchText round-trips through collection config`() {
+        try {
+            Prefs.devUsingCardBrowserSearchView = true
+            runViewModelTest {
+                setDefaultSearchText("tag:foo").join()
+                assertThat(defaultBrowserSearch, equalTo("tag:foo"))
+                assertThat(col.config.defaultBrowserSearch, equalTo("tag:foo"))
+            }
+        } finally {
+            Prefs.devUsingCardBrowserSearchView = false
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -69,6 +69,7 @@ import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.servicelayer.NoteService
 import com.ichi2.anki.setFlagFilterSync
 import com.ichi2.anki.settings.Prefs
+import com.ichi2.anki.utils.ext.defaultBrowserSearch
 import com.ichi2.anki.utils.ext.ignoreAccentsInSearch
 import com.ichi2.testutils.IntentAssert
 import com.ichi2.testutils.JvmTest
@@ -1852,6 +1853,47 @@ class CardBrowserViewModelTest : JvmTest() {
 
             assertThat("hello and hêllo are matched", rowCount, equalTo(2))
             assertThat("input is unchanged", searchTerms, equalTo("hello"))
+        }
+    }
+
+    @Test
+    fun `default search text is applied on init`() {
+        col.config.defaultBrowserSearch = "deck:current"
+        try {
+            Prefs.devUsingCardBrowserSearchView = true
+            runViewModelTest {
+                assertThat(searchTerms, equalTo("deck:current"))
+                assertThat(defaultBrowserSearch, equalTo("deck:current"))
+            }
+        } finally {
+            Prefs.devUsingCardBrowserSearchView = false
+        }
+    }
+
+    @Test
+    fun `intent search wins over default search text`() {
+        col.config.defaultBrowserSearch = "deck:current"
+        try {
+            Prefs.devUsingCardBrowserSearchView = true
+            runViewModelTest(options = DeepLink("tag:foo")) {
+                assertThat(searchTerms, equalTo("tag:foo"))
+            }
+        } finally {
+            Prefs.devUsingCardBrowserSearchView = false
+        }
+    }
+
+    @Test
+    fun `setDefaultSearchText round-trips through collection config`() {
+        try {
+            Prefs.devUsingCardBrowserSearchView = true
+            runViewModelTest {
+                setDefaultSearchText("tag:foo").join()
+                assertThat(defaultBrowserSearch, equalTo("tag:foo"))
+                assertThat(col.config.defaultBrowserSearch, equalTo("tag:foo"))
+            }
+        } finally {
+            Prefs.devUsingCardBrowserSearchView = false
         }
     }
 


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7

## Purpose / Description
Upstream functionality, only implemented in the new card browser

## Fixes
* Fixes #18618

## Approach

I performed a few initial refactors, partially as logic shouldn't be in the `saveChanges` method, partially to reduce the code in the ViewModel

* Adds a 'Default search text' control to the Browser options
* If set, uses this as the default search text
  * Only if the search text wasn't set through other means (intent etc...)

## How Has This Been Tested?
<img width="316" height="589" alt="Screenshot 2026-05-05 at 19 03 09" src="https://github.com/user-attachments/assets/1d04e860-eb55-4a67-835a-7d2098b2fc01" />

Unit tests

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
    - I have fixed all but a contrast warning(light mode only), which falsely detects that the border should meet the standard for text (3.0:1 is for for the border, it wants 4.5:1). This change would negatively impact the visual hierarchy: the border should be less prominent than the hint