### PR TITLE
refactor: extract 'unregisterReceiverSilently' to :common:android

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Context.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Context.kt
@@ -15,7 +15,6 @@
  */
 package com.ichi2.anki.utils.ext
 
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.res.TypedArray
 import android.graphics.Bitmap
@@ -24,7 +23,6 @@ import android.util.AttributeSet
 import androidx.annotation.AttrRes
 import androidx.annotation.StyleRes
 import com.ichi2.anki.CollectionHelper
-import timber.log.Timber
 import java.io.File
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
@@ -49,21 +47,6 @@ inline fun <T> Context.usingStyledAttributes(
 
     val typedArray = obtainStyledAttributes(set, attrs, defStyleAttr, defStyleRes)
     return typedArray.block().also { typedArray.recycle() }
-}
-
-/**
- * Unregisters a [BroadcastReceiver] from [Context] without throwing an [IllegalArgumentException]
- * if the receiver wasn't registered.
- *
- * @param receiver [BroadcastReceiver] to unregister
- * @see Context.unregisterReceiver
- */
-fun Context.unregisterReceiverSilently(receiver: BroadcastReceiver) {
-    try {
-        unregisterReceiver(receiver)
-    } catch (e: IllegalArgumentException) {
-        Timber.d(e, "BroadcastReceiver was not previously registered")
-    }
 }
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidgetConfig.kt
@@ -26,6 +26,7 @@ import androidx.core.os.BundleCompat
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.R
 import com.ichi2.anki.android.AnkiBroadcastReceiver
+import com.ichi2.anki.common.utils.ext.unregisterReceiverSilently
 import com.ichi2.anki.databinding.ActivityCardAnalysisWidgetConfigBinding
 import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.anki.dialogs.DeckSelectionDialog.DeckSelectionListener
@@ -33,7 +34,6 @@ import com.ichi2.anki.isCollectionEmpty
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.showThemedToast
-import com.ichi2.anki.utils.ext.unregisterReceiverSilently
 import com.ichi2.anki.withProgress
 import com.ichi2.widget.AppWidgetId.Companion.INVALID_APPWIDGET_ID
 import com.ichi2.widget.AppWidgetId.Companion.getAppWidgetId

--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
@@ -34,6 +34,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.R
 import com.ichi2.anki.android.AnkiBroadcastReceiver
+import com.ichi2.anki.common.utils.ext.unregisterReceiverSilently
 import com.ichi2.anki.databinding.WidgetDeckPickerConfigBinding
 import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.anki.dialogs.DeckSelectionDialog.DeckSelectionListener
@@ -45,7 +46,6 @@ import com.ichi2.anki.showThemedToast
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
-import com.ichi2.anki.utils.ext.unregisterReceiverSilently
 import com.ichi2.widget.AppWidgetId.Companion.INVALID_APPWIDGET_ID
 import com.ichi2.widget.AppWidgetId.Companion.getAppWidgetId
 import com.ichi2.widget.AppWidgetId.Companion.updateWidget

--- a/common/android/src/main/java/com/ichi2/anki/common/utils/ext/Context.kt
+++ b/common/android/src/main/java/com/ichi2/anki/common/utils/ext/Context.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Brayan Oliveira <69634269+brayandso@users.noreply.github.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.common.utils.ext
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import timber.log.Timber
+
+/**
+ * Unregisters a [BroadcastReceiver] from [Context] without throwing an [IllegalArgumentException]
+ * if the receiver wasn't registered.
+ *
+ * @param receiver [BroadcastReceiver] to unregister
+ * @see Context.unregisterReceiver
+ */
+fun Context.unregisterReceiverSilently(receiver: BroadcastReceiver) {
+    try {
+        unregisterReceiver(receiver)
+    } catch (e: IllegalArgumentException) {
+        Timber.d(e, "BroadcastReceiver was not previously registered")
+    }
+}


### PR DESCRIPTION


<!--- Please fill the necessary details below -->
## Purpose / Description
And one more, -> Removes a dependency on com.ichi2.anki.utils.ext from widget config activities, helping break circular dependencies for feature module extraction

## Fixes
* Fixes part of #20737

## Approach
See commit

## How Has This Been Tested?
Local build

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->