### PR TITLE
fix: avoid anchoring reviewer snackbar to hidden answer buttons

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1827,9 +1827,11 @@ abstract class AbstractFlashcardViewer :
     }
 
     override val baseSnackbarBuilder: SnackbarBuilder = {
-        // Configure the snackbar to avoid the bottom answer buttons
+        // Configure the snackbar to avoid the bottom answer buttons.
+        // The answer buttons are animated to GONE in fullscreen mode (see Reviewer.hideViewWithAnimation),
+        // so check visibility to avoid anchoring the snackbar to a hidden view (#20946).
         if (answerButtonsPosition == "bottom") {
-            anchorView = findViewById(R.id.answer_options_layout)
+            anchorView = findViewById<View>(R.id.answer_options_layout)?.takeIf { it.isVisible }
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki
 import android.app.Application
 import android.content.Intent
 import android.view.Menu
+import android.view.View
 import androidx.annotation.CheckResult
 import androidx.core.content.edit
 import androidx.core.os.BundleCompat
@@ -52,6 +53,7 @@ import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.preferences.PreferenceTestUtils
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.reviewer.ActionButtonStatus
+import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.testutils.common.Flaky
 import com.ichi2.testutils.common.OS
 import junit.framework.TestCase.assertEquals
@@ -62,6 +64,7 @@ import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.empty
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.not
+import org.hamcrest.Matchers.nullValue
 import org.json.JSONArray
 import org.junit.Assume.assumeTrue
 import org.junit.Ignore
@@ -152,6 +155,38 @@ class ReviewerTest : RobolectricTest() {
             )
 
         assertEquals("Animation from swipe should be inverse to the finishing one", expectedAnimation, actualAnimation)
+    }
+
+    @Test
+    fun `baseSnackbarBuilder has no anchor when answer buttons are hidden`() {
+        addBasicNote()
+        val reviewer = startReviewer()
+        val answerButtons = reviewer.findViewById<View>(R.id.answer_options_layout)
+        answerButtons.visibility = View.GONE
+
+        val snackbar = reviewer.showSnackbar("test")
+
+        assertThat(
+            "anchorView must be null when answer buttons layout is not visible",
+            snackbar?.anchorView,
+            nullValue(),
+        )
+    }
+
+    @Test
+    fun `baseSnackbarBuilder anchors to answer buttons when visible`() {
+        addBasicNote()
+        val reviewer = startReviewer()
+        val answerButtons = reviewer.findViewById<View>(R.id.answer_options_layout)
+        answerButtons.visibility = View.VISIBLE
+
+        val snackbar = reviewer.showSnackbar("test")
+
+        assertThat(
+            "anchorView is the answer buttons layout when visible",
+            snackbar?.anchorView,
+            equalTo(answerButtons),
+        )
     }
 
     @Test


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
In FullScreenMode.FULLSCREEN_ALL_GONE, the answer buttons layout is animated to View.GONE when the system UI auto-hides. Snackbars shown during that window (e.g. via undoAndShowSnackbar) anchored to the hidden view and tripped the visibility check in showSnackbar. Guard the anchor with takeIf { it.isVisible }, mirroring the fixapplied to DeckPicker in #20766.

## Fixes
* Fixes #20946

## Approach
NA

## How Has This Been Tested?
Google emulator API 35, I have verified it doesnt occur in new study screen only in old one

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->