### PR TITLE
Disable Save button in Change Note Type when there are no changes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
@@ -70,6 +70,7 @@ import com.ichi2.anki.sync.launchCatchingRequiringOneWaySync
 import com.ichi2.anki.ui.BasicItemSelectedListener
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.InitStatus
+import com.ichi2.anki.utils.ext.launchCollectionInLifecycleScope
 import com.ichi2.anki.withProgress
 import com.ichi2.utils.LanguageUtil
 import com.ichi2.utils.boldList
@@ -156,6 +157,15 @@ class ChangeNoteTypeDialog : AnalyticsDialogFragment(R.layout.dialog_change_note
         Timber.d("setting up dialog")
         setupNoteTypeSpinner(binding)
         setupViewPagerAndTabs(binding)
+        bindSaveButtonState(binding)
+    }
+
+    private fun bindSaveButtonState(binding: DialogChangeNoteTypeBinding) {
+        // disabled by default until hasChangesFlow emits true
+        binding.btnSave.isEnabled = false
+        viewModel.hasChangesFlow.launchCollectionInLifecycleScope {
+            binding.btnSave.isEnabled = it
+        }
     }
 
     private fun setupNoteTypeSpinner(binding: DialogChangeNoteTypeBinding) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeViewModel.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -196,6 +197,25 @@ class ChangeNoteTypeViewModel(
                 started = SharingStarted.Eagerly,
                 initialValue = !inputNoteType.isCloze,
             )
+    }
+
+    /**
+     * Whether the current state differs from the initial state (same input note type, default maps).
+     * Used to enable/disable the Save button.
+     */
+    val hasChangesFlow: StateFlow<Boolean> by lazy {
+        combine(outputNoteTypeFlow, fieldChangeMapFlow, templateChangeMapFlow) { outputNoteType, fieldMap, templateMap ->
+            when {
+                outputNoteType.id != inputNoteType.id -> true
+                fieldMap != rebuildFieldMap(inputNoteType) -> true
+                templateMap != rebuildTemplateMap(inputNoteType) -> true
+                else -> false
+            }
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = false,
+        )
     }
 
     // Derived Flows


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Currently in Change Note Type, clicking Save without making any changes shows a No changes to save dialog.

## Approach
Instead of showing a dialog, Save button is now disabled when there are no pending changes.

## How Has This Been Tested?
Emulator API 35 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->