### PR TITLE
refactor(deps): replace androidx.media with media3

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -418,7 +418,6 @@ dependencies {
     implementation libs.androidx.exifinterface
     implementation libs.androidx.fragment.ktx
     implementation libs.androidx.lifecycle.process
-    implementation libs.androidx.media
     implementation libs.androidx.preference.ktx
     implementation libs.androidx.recyclerview
     implementation libs.androidx.sqlite.framework

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
@@ -17,15 +17,18 @@
 package com.ichi2.anki.cardviewer
 
 import android.content.Context
-import android.media.AudioAttributes
 import android.media.AudioManager
 import android.media.MediaPlayer
 import android.net.Uri
 import androidx.annotation.CheckResult
+import androidx.annotation.OptIn
 import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
-import androidx.media.AudioFocusRequestCompat
-import androidx.media.AudioManagerCompat
+import androidx.media3.common.AudioAttributes
+import androidx.media3.common.C.AUDIO_CONTENT_TYPE_MUSIC
+import androidx.media3.common.audio.AudioFocusRequestCompat
+import androidx.media3.common.audio.AudioManagerCompat
+import androidx.media3.common.util.UnstableApi
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.common.annotations.NeedsTest
@@ -39,6 +42,7 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 /** Player for (`[sound:...]`): [SoundOrVideoTag]  */
+@OptIn(UnstableApi::class)
 @NeedsTest("CardSoundConfig.autoplay should mean that video also isn't played automatically")
 class SoundTagPlayer(
     private val soundUriBase: String,
@@ -49,7 +53,7 @@ class SoundTagPlayer(
     private val music =
         AudioAttributes
             .Builder()
-            .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+            .setContentType(AUDIO_CONTENT_TYPE_MUSIC)
             .build()
 
     /**
@@ -118,7 +122,7 @@ class SoundTagPlayer(
                 } else {
                     (soundUriBase + Uri.encode(tag.filename)).toUri()
                 }
-            setAudioAttributes(music)
+            setAudioAttributes(music.platformAudioAttributes)
             setOnErrorListener { mp, what, extra ->
                 Timber.w("Media error %d", what)
                 abandonAudioFocus()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,8 +43,6 @@ androidxExifinterface = "1.4.2"
 androidxFragmentKtx = "1.8.9"
 # https://developer.android.com/jetpack/androidx/releases/lifecycle
 androidxLifecycleProcess = "2.10.0"
-# https://developer.android.com/jetpack/androidx/releases/media
-androidxMedia = "1.7.1"
 # https://developer.android.com/jetpack/androidx/releases/media3
 androidxMedia3 = "1.10.0"
 # https://developer.android.com/jetpack/androidx/releases/preference
@@ -146,7 +144,6 @@ androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "andr
 androidx-media3-exoplayer-dash = { module = "androidx.media3:media3-exoplayer-dash", version.ref = "androidxMedia3" }
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "androidxMedia3" }
 androidx-preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = "androidxPreferenceKtx" }
-androidx-media = { module = "androidx.media:media", version.ref = "androidxMedia" }
 androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "androidxTestUiAutomator" }
 androidx-webkit = { module = "androidx.webkit:webkit", version.ref = "androidxWebkit" }
 androidx-viewpager2 = { module = "androidx.viewpager2:viewpager2", version.ref = "androidxViewpager2" }


### PR DESCRIPTION
## Purpose / Description
androidx.media:1.8.0 is deprecated

## Fixes
* Fixes https://github.com/ankidroid/Anki-Android/pull/20972

## Approach
Use `media3` instead

## How Has This Been Tested?

⚠️ Untested, trusting Google that their compat classes are reasonable

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)