### PR TITLE
test: screenshot test for all activities

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupUnderBackupTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupUnderBackupTest.kt
@@ -21,11 +21,11 @@ import com.ichi2.anki.instantnoteeditor.InstantNoteEditorActivity
 import com.ichi2.anki.preferences.PreferencesActivity
 import com.ichi2.testutils.ActivityList
 import com.ichi2.testutils.ActivityList.ActivityLaunchParam
+import com.ichi2.testutils.skipTest
 import com.ichi2.utils.ExceptionUtil.getFullStackTrace
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Assert
-import org.junit.Assume.assumeThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -110,7 +110,7 @@ $stackTrace""",
         reason: String,
     ) {
         if (launcher!!.simpleName == activityName) {
-            assumeThat("$activityName $reason", true, equalTo(false))
+            skipTest("$activityName $reason")
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AllActivitiesScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AllActivitiesScreenshotTest.kt
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: 2026 David Allison <davidallisongithub@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+package com.ichi2.anki
+
+import android.app.Activity
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.core.content.edit
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import com.ichi2.anki.account.AccountActivity
+import com.ichi2.anki.instantnoteeditor.InstantNoteEditorActivity
+import com.ichi2.anki.multimedia.MultimediaActivity
+import com.ichi2.anki.preferences.PreferencesActivity
+import com.ichi2.anki.preferences.sharedPrefs
+import com.ichi2.anki.previewer.CardViewerActivity
+import com.ichi2.anki.utils.ConfigAwareSingleFragmentActivity
+import com.ichi2.testutils.ActivityList
+import com.ichi2.testutils.ActivityList.ActivityLaunchParam
+import com.ichi2.testutils.BackupManagerTestUtilities
+import com.ichi2.testutils.skipTest
+import com.ichi2.utils.dp
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.ParameterizedRobolectricTestRunner
+
+/**
+ * Captures a baseline screenshot for every activity declared in the manifest.
+ *
+ * @see ActivityList.allActivitiesAndIntents
+ *
+ * `./gradlew :AnkiDroid:verifyRoborazziPlayDebug -Pscreenshot --tests "com.ichi2.anki.AllActivitiesScreenshotTest"`
+ *
+ * TODO: Split each activity into its own per-class screenshot test
+ */
+@RunWith(ParameterizedRobolectricTestRunner::class)
+class AllActivitiesScreenshotTest : ScreenshotTest() {
+    init {
+        setPhoneQualifiers()
+    }
+
+    @ParameterizedRobolectricTestRunner.Parameter
+    @JvmField
+    var launcher: ActivityLaunchParam? = null
+
+    // Used for display and the screenshot filename (e.g. "DeckPicker" or "DeckPicker_edgeToEdge")
+    @ParameterizedRobolectricTestRunner.Parameter(1)
+    @JvmField
+    var displayName: String? = null
+
+    @ParameterizedRobolectricTestRunner.Parameter(2)
+    @JvmField
+    var configure: (Activity.() -> Unit)? = null
+
+    @Before
+    override fun setUp() {
+        // Same exclusions as ActivityStartupUnderBackupTest — onCreate fails standalone for these.
+        notYetHandled(IntentHandler::class.java.simpleName, "Not working (or implemented) - inherits from Activity")
+        notYetHandled(IntentHandler2::class.java.simpleName, "Not working (or implemented) - inherits from Activity")
+        notYetHandled(
+            PreferencesActivity::class.java.simpleName,
+            "Not working (or implemented) - inherits from AppCompatPreferenceActivity",
+        )
+        notYetHandled(
+            SingleFragmentActivity::class.java.simpleName,
+            "Implemented, but the test fails because the activity throws if a specific intent extra isn't set",
+        )
+        notYetHandled(InstantNoteEditorActivity::class.java.simpleName, "Single instance activity so should be used")
+
+        // Fragment-host activities: need a 'fragmentName' intent extra to render anything.
+        // TODO: split these into per-class screenshot tests that pass a real fragment.
+        notYetHandled(ConfigAwareSingleFragmentActivity::class.java.simpleName, "Needs 'fragmentName' intent extra")
+        notYetHandled(CardViewerActivity::class.java.simpleName, "Needs 'fragmentName' intent extra")
+        notYetHandled(MultimediaActivity::class.java.simpleName, "Needs 'fragmentName' intent extra")
+        notYetHandled(AccountActivity::class.java.simpleName, "Needs 'fragmentName' intent extra")
+
+        // TODO: split into a per-class test that creates a real note type before launching.
+        notYetHandled(CardTemplateEditor::class.java.simpleName, "Needs a real note type in the collection")
+
+        super.setUp()
+
+        // Setup for DeckPicker
+        ensureCollectionLoadIsSynchronous()
+        setIntroductionSlidesShown(true)
+        BackupManagerTestUtilities.setupSpaceForBackup(targetContext)
+        // suppress the periodic 'backup your collection' prompt so the screenshot is just the activity
+        targetContext.sharedPrefs().edit { putBoolean("backupPromptDisabled", true) }
+    }
+
+    @After
+    fun tearDownBackup() {
+        BackupManagerTestUtilities.reset()
+    }
+
+    @Test
+    fun screenshot() {
+        val activity =
+            startActivityNormallyOpenCollectionWithIntent(
+                launcher!!.activity,
+                launcher!!.buildIntent(targetContext),
+            )
+        configure!!(activity)
+        captureScreen(displayName!!)
+    }
+
+    private fun notYetHandled(
+        activityName: String,
+        reason: String,
+    ) {
+        if (launcher!!.simpleName == activityName) {
+            skipTest("$activityName $reason")
+        }
+    }
+
+    companion object {
+        private val regular: Activity.() -> Unit = {}
+        private val edgeToEdge: Activity.() -> Unit = { simulateEdgeToEdge() }
+
+        @ParameterizedRobolectricTestRunner.Parameters(name = "{1}")
+        @JvmStatic
+        fun initParameters(): Collection<Array<Any>> =
+            ActivityList.allActivitiesAndIntents().flatMap { launcher ->
+                listOf(
+                    arrayOf<Any>(launcher, launcher.simpleName, regular),
+                    arrayOf<Any>(launcher, "${launcher.simpleName}_edgeToEdge", edgeToEdge),
+                )
+            }
+    }
+}
+
+/**
+ * Inject realistic system bars for edge to edge.
+ *
+ * Mirrors the helper from `DeckPickerScreenshotTest` on the `edge-2-edge` branch.
+ *
+ * WARN: Does not match reality. There are issues with element placement and scrolling lists. [FAB in Deck Picker]
+ */
+private fun Activity.simulateEdgeToEdge() {
+    val insets =
+        WindowInsetsCompat
+            .Builder()
+            .setInsets(WindowInsetsCompat.Type.statusBars(), Insets.of(0, 24.dp.toPx(this), 0, 0))
+            .setInsets(WindowInsetsCompat.Type.navigationBars(), Insets.of(0, 0, 0, 48.dp.toPx(this)))
+            .build()
+    ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
+
+    val decor = window.decorView as ViewGroup
+    val navBarOverlay =
+        View(this).apply {
+            setBackgroundColor(0x80000000.toInt())
+        }
+    decor.addView(
+        navBarOverlay,
+        FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, 48.dp.toPx(this), Gravity.BOTTOM),
+    )
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.app.Application
 import android.content.Context
 import android.content.Intent
@@ -273,7 +274,7 @@ open class RobolectricTest :
         }
 
         @JvmStatic // Using protected members which are not @JvmStatic in the superclass companion is unsupported yet
-        protected fun <T : AnkiActivity?> startActivityNormallyOpenCollectionWithIntent(
+        protected fun <T : Activity?> startActivityNormallyOpenCollectionWithIntent(
             testClass: RobolectricTest,
             clazz: Class<T>?,
             i: Intent?,
@@ -350,14 +351,14 @@ open class RobolectricTest :
         return collectionModels.byName(noteTypeName)!!.deepClone()
     }
 
-    internal fun <T : AnkiActivity?> startActivityNormallyOpenCollectionWithIntent(
+    internal fun <T : Activity?> startActivityNormallyOpenCollectionWithIntent(
         clazz: Class<T>?,
         i: Intent?,
     ): T = startActivityNormallyOpenCollectionWithIntent(this, clazz, i)
 
-    internal inline fun <reified T : AnkiActivity?> startRegularActivity(): T = startRegularActivity(null)
+    internal inline fun <reified T : Activity?> startRegularActivity(): T = startRegularActivity(null)
 
-    internal inline fun <reified T : AnkiActivity?> startRegularActivity(i: Intent? = null): T =
+    internal inline fun <reified T : Activity?> startRegularActivity(i: Intent? = null): T =
         startActivityNormallyOpenCollectionWithIntent(T::class.java, i)
 
     fun equalFirstField(

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ScreenshotTest.kt
@@ -16,10 +16,12 @@
 package com.ichi2.anki
 
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.RoborazziOptions
 import com.github.takahirom.roborazzi.captureScreenRoboImage
 import com.github.takahirom.roborazzi.provideRoborazziContext
 import org.junit.experimental.categories.Category
+import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.GraphicsMode
 import java.io.File
 
@@ -31,6 +33,16 @@ interface ScreenshotTestCategory
 @Category(ScreenshotTestCategory::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 abstract class ScreenshotTest : RobolectricTest() {
+    /** Pixel-class phone in portrait, light theme. */
+    protected fun setPhoneQualifiers() {
+        RuntimeEnvironment.setQualifiers(RobolectricDeviceQualifiers.MediumPhone)
+    }
+
+    /** Required for [DeckPicker.fragmented] to be true. */
+    protected fun setTabletQualifiers() {
+        RuntimeEnvironment.setQualifiers(RobolectricDeviceQualifiers.MediumTablet)
+    }
+
     /**
      * Captures a screenshot to `build/outputs/roborazzi/<TestClass>/<name>.png`.
      *

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/ActivityList.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/ActivityList.kt
@@ -113,7 +113,9 @@ object ActivityList {
 
         fun build(context: Context): ActivityController<out Activity> =
             Robolectric
-                .buildActivity(activity, intentBuilder.apply(context))
+                .buildActivity(activity, buildIntent(context))
+
+        fun buildIntent(context: Context): Intent = intentBuilder.apply(context)
 
         val className: String = activity.name
 

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssert.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssert.kt
@@ -15,6 +15,7 @@
  */
 package com.ichi2.testutils
 
+import org.junit.AssumptionViolatedException
 import kotlin.test.junit5.JUnit5Asserter
 
 /** Asserts that the expression is `false` with an optional [message]. */
@@ -27,3 +28,6 @@ fun assertFalse(
     // JUnitAsserter doesn't contain it, so we add it in
     JUnit5Asserter.assertTrue(message, !actual)
 }
+
+/** Unconditionally skips the current test with [reason] reported as the skip message. */
+fun skipTest(reason: String): Nothing = throw AssumptionViolatedException(reason)


### PR DESCRIPTION
**Assisted-by: Claude Opus 4.7 - all**


## Purpose / Description
* Prep for edge to edge: #17334

## Approach
The same pattern as `ActivityStartupUnderBackupTest`


## How Has This Been Tested?

`./gradlew :AnkiDroid:recordRoborazziPlayDebug -Pscreenshot --tests "com.ichi2.anki.AllActivitiesScreenshotTest"`


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->