### PR TITLE
Fix: Sync Media Fail Notifications are expandable and copyable

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -535,6 +535,11 @@
                 />
         </receiver>
 
+        <!-- Copy Sync Error Message to Clipboard -->
+        <receiver
+            android:name="com.ichi2.anki.receiver.CopyToClipboardReceiver"
+            android:exported="false" />
+
         <!-- "Add Note" widget -->
         <receiver
             android:name="com.ichi2.widget.AddNoteWidget"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/receiver/CopyToClipboardReceiver.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/receiver/CopyToClipboardReceiver.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2026 LUwUcifer <luwucifwer@proton.me>
+package com.ichi2.anki.receiver
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationManagerCompat
+import com.ichi2.anki.R
+import com.ichi2.anki.common.utils.android.showThemedToast
+import com.ichi2.anki.notifications.NotificationId
+import com.ichi2.utils.copyToClipboard
+import timber.log.Timber
+
+class CopyToClipboardReceiver : BroadcastReceiver() {
+    override fun onReceive(
+        context: Context,
+        intent: Intent,
+    ) {
+        val text =
+            intent.getStringExtra(EXTRA_SYNC_ERROR_LOG) ?: run {
+                Timber.w("CopyToClipboardReceiver: no error log found")
+                showThemedToast(context, R.string.something_wrong, shortLength = true)
+                return
+            }
+        NotificationManagerCompat.from(context).cancel(NotificationId.SYNC_MEDIA)
+        context.copyToClipboard(text)
+    }
+
+    companion object {
+        const val EXTRA_SYNC_ERROR_LOG = "COPY ERROR"
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
@@ -134,6 +134,9 @@ object SentenceCase {
     context(_: Fragment)
     val toggleSuspend get() = TR.browsingToggleSuspend().toSentenceCase(R.string.sentence_toggle_suspend)
 
+    context(_: Context)
+    val copyToClipboard get() = TR.qtMiscCopyToClipboard().toSentenceCase(R.string.sentence_copy_to_clipboard)
+
     context(_: Fragment)
     val findAndReplace get() = TR.browsingFindAndReplace().toSentenceCase(R.string.sentence_find_and_replace)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
@@ -94,6 +94,11 @@ class SyncMediaWorker(
                 setContentTitle(CollectionManager.TR.syncMediaFailed())
                 throwable.localizedMessage?.let { message ->
                     setContentText(message)
+                    setStyle(
+                        NotificationCompat
+                            .BigTextStyle()
+                            .bigText(message),
+                    )
                 }
             }
             Timber.d("SyncMediaWorker: showing failure notification")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
@@ -16,7 +16,9 @@
 package com.ichi2.anki.worker
 
 import android.app.Notification
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.Build
 import androidx.core.app.NotificationCompat
@@ -37,9 +39,12 @@ import anki.sync.SyncAuth
 import anki.sync.syncAuth
 import com.ichi2.anki.Channel
 import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.cancelMediaSync
 import com.ichi2.anki.notifications.NotificationId
+import com.ichi2.anki.receiver.CopyToClipboardReceiver
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.ext.trySetForeground
 import com.ichi2.utils.Permissions
 import kotlinx.coroutines.CancellationException
@@ -91,13 +96,18 @@ class SyncMediaWorker(
         } catch (throwable: Throwable) {
             Timber.w(throwable, "SyncMediaWorker failed")
             notify {
-                setContentTitle(CollectionManager.TR.syncMediaFailed())
+                setContentTitle(TR.syncMediaFailed())
                 throwable.localizedMessage?.let { message ->
                     setContentText(message)
                     setStyle(
                         NotificationCompat
                             .BigTextStyle()
                             .bigText(message),
+                    )
+                    addAction(
+                        R.drawable.baseline_content_copy_24,
+                        with(applicationContext) { TR.sentenceCase.copyToClipboard },
+                        getCopyToClipboardIntent(message),
                     )
                 }
             }
@@ -134,7 +144,7 @@ class SyncMediaWorker(
 
     override suspend fun getForegroundInfo(): ForegroundInfo {
         val title = applicationContext.getString(R.string.syncing_media)
-        val cancelTitle = CollectionManager.TR.syncAbortButton()
+        val cancelTitle = TR.syncAbortButton()
         val notification =
             buildNotification {
                 setContentTitle(title)
@@ -148,6 +158,19 @@ class SyncMediaWorker(
         } else {
             ForegroundInfo(NotificationId.SYNC_MEDIA, notification)
         }
+    }
+
+    private fun getCopyToClipboardIntent(text: String): PendingIntent {
+        val intent =
+            Intent(applicationContext, CopyToClipboardReceiver::class.java).apply {
+                putExtra(CopyToClipboardReceiver.EXTRA_SYNC_ERROR_LOG, text)
+            }
+        return PendingIntent.getBroadcast(
+            applicationContext,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT,
+        )
     }
 
     private fun notify(notification: Notification) = notificationManager?.notify(NotificationId.SYNC_MEDIA, notification)
@@ -169,7 +192,7 @@ class SyncMediaWorker(
 
     private fun getProgressNotification(progress: CharSequence): Notification {
         val title = applicationContext.getString(R.string.syncing_media)
-        val cancelTitle = CollectionManager.TR.syncAbortButton()
+        val cancelTitle = TR.syncAbortButton()
 
         return buildNotification {
             setContentTitle(title)

--- a/AnkiDroid/src/main/res/values/sentence-case.xml
+++ b/AnkiDroid/src/main/res/values/sentence-case.xml
@@ -85,4 +85,5 @@ undoActionUndone()
     <string name="sentence_change_deck" maxLength="28">Change deck</string>
     <string name="sentence_toggle_mark">Toggle mark</string>
     <string name="sentence_create_deck">Create deck</string>
+    <string name="sentence_copy_to_clipboard">Copy to clipboard</string>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
@@ -68,6 +68,7 @@ class SentenceCaseTest : RobolectricTest() {
                     assertThat(TR.sentenceCase.checkDatabase, equalTo("Check database"))
                     assertThat(TR.sentenceCase.checkMediaTitle, equalTo("Check media"))
                     assertThat(TR.sentenceCase.checkMediaAction, equalTo("Check media"))
+                    assertThat(TR.sentenceCase.copyToClipboard, equalTo("Copy to clipboard"))
                     assertThat(TR.sentenceCase.frontTemplate, equalTo("Front template"))
                     assertThat(TR.sentenceCase.backTemplate, equalTo("Back template"))
                     assertThat(TR.sentenceCase.renameDeck, equalTo("Rename deck"))


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
SyncMediaWorker fail throwable notification could not be expanded or opened

## Fixes
* Fixes #20826 

## Approach

1. Adds attribute .bigText to make text expandable
2. Adds addAction for a button that copies error message and instantly closes the message upon the action
3. Uses a custom receiver for serving pendingIntent required for addAction

## How Has This Been Tested?

Tested on local device

## Learning (optional, can help others)

1. https://stackoverflow.com/questions/14291436/copy-to-clipboard-by-notification-action#14294660
2. https://developer.android.com/develop/ui/views/touch-and-input/copy-paste#Copying
3. https://developer.android.com/develop/ui/views/notifications/build-notification#Actions

## Checklist

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->