### PR TITLE
fix(note-editor): MathJax Block

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/MathJaxFormat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/MathJaxFormat.kt
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.noteeditor
+
+import com.ichi2.anki.CollectionManager.TR
+
+/** Options for inserting MathJax equation types via the toolbar */
+enum class MathJaxFormat(
+    val prefix: String,
+    val suffix: String,
+) {
+    /** Display-math block: `\[ E=mc^2 \]` */
+    BLOCK(prefix = "\\[", suffix = "\\]"),
+
+    /**
+     * [mhchem](https://mhchem.github.io/MathJax-mhchem/) chemistry equation: `\( \ce{ H2O } \)`
+     */
+    CHEMISTRY(prefix = "\\( \\ce{", suffix = "} \\)"),
+    ;
+
+    fun toTextWrapper() = Toolbar.TextWrapper(prefix = prefix, suffix = suffix)
+
+    fun label(): String =
+        when (this) {
+            BLOCK -> TR.editingMathjaxBlock()
+            CHEMISTRY -> TR.editingMathjaxChemistry()
+        }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -332,7 +332,7 @@ class Toolbar : FrameLayout {
 
         val mathjaxOptions =
             arrayOf(
-                MathJaxOption(TR.editingMathjaxBlock(), prefix = "\\[\\", suffix = "\\]"),
+                MathJaxOption(TR.editingMathjaxBlock(), prefix = "\\[", suffix = "\\]"),
                 MathJaxOption(TR.editingMathjaxChemistry(), prefix = "\\( \\ce{", suffix = "} \\)"),
             )
         AlertDialog.Builder(context).show {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -429,8 +429,8 @@ class Toolbar : FrameLayout {
 
     /**
      * A [TextFormatter] which wraps the selected string with [prefix] and [suffix]
-     * If there's no selected, the cursor is in the middle of the prefix and suffix
-     * If there is text selected, the whole string is selected
+     * If there's no selection, the cursor is placed in the middle of the prefix and suffix
+     * If text is selected and wrapped, the whole string is selected
      */
     class TextWrapper(
         private val prefix: String,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -48,7 +48,6 @@ import androidx.core.view.children
 import androidx.core.view.isVisible
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import com.ichi2.anki.AnkiDroidApp
-import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.NoteEditorFragment
 import com.ichi2.anki.R
 import com.ichi2.anki.compat.CompatHelper
@@ -322,22 +321,11 @@ class Toolbar : FrameLayout {
      * Displays a dialog that allows the user to insert a MathJax equation in different formats.
      */
     private fun displayInsertMathJaxEquationsDialog() {
-        data class MathJaxOption(
-            val label: String,
-            val prefix: String,
-            val suffix: String,
-        ) {
-            fun toTextWrapper() = TextWrapper(prefix = this.prefix, suffix = this.suffix)
-        }
-
-        val mathjaxOptions =
-            arrayOf(
-                MathJaxOption(TR.editingMathjaxBlock(), prefix = "\\[", suffix = "\\]"),
-                MathJaxOption(TR.editingMathjaxChemistry(), prefix = "\\( \\ce{", suffix = "} \\)"),
-            )
+        val options = MathJaxFormat.entries
+        val labels = options.map { it.label() }.toTypedArray()
         AlertDialog.Builder(context).show {
-            setItems(mathjaxOptions.map(MathJaxOption::label).toTypedArray()) { _, index ->
-                onFormat(mathjaxOptions[index].toTextWrapper())
+            setItems(labels) { _, index ->
+                onFormat(options[index].toTextWrapper())
             }
             title(R.string.insert_mathjax)
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/noteeditor/MathJaxFormatTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/noteeditor/MathJaxFormatTest.kt
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.noteeditor
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+
+class MathJaxFormatTest {
+    @Test
+    fun `block wraps text in display-math delimiters`() {
+        assertThat(
+            MathJaxFormat.BLOCK
+                .toTextWrapper()
+                .format("E=mc^2")
+                .result,
+            equalTo("""\[E=mc^2\]"""),
+        )
+    }
+
+    @Test
+    fun `chemistry wraps text in mhchem ce delimiters`() {
+        assertThat(
+            MathJaxFormat.CHEMISTRY
+                .toTextWrapper()
+                .format("H2O")
+                .result,
+            equalTo("""\( \ce{H2O} \)"""),
+        )
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7

## Purpose / Description
Was: `\[\\]`
Now: `\[\]`

## Fixes
* Fixes #20961

## How Has This Been Tested?
Unit tested

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)