### PR TITLE
fix(ExportDialogFragment.kt) : TransactionTooLargeException 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -1335,7 +1335,12 @@ class CardBrowserFragment :
 
     fun exportSelected() {
         val (type, selectedIds) = activityViewModel.querySelectionExportData() ?: return
-        ExportDialogFragment.newInstance(type, selectedIds).show(parentFragmentManager, "exportDialog")
+        ExportDialogFragment
+            .newInstance(
+                requireContext().externalCacheDir ?: requireContext().cacheDir,
+                type,
+                selectedIds,
+            ).show(parentFragmentManager, "exportDialog")
     }
 
     fun showOptionsDialog() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -1600,6 +1600,21 @@ class IdsFile(
     }
 }
 
+/** Attempt to delete the associated [IdsFile] and logs the result */
+fun IdsFile.removeSafely(owner: String) {
+    runCatching { delete() }
+        .onFailure { throwable ->
+            Timber.w(
+                throwable,
+                "Exception when removing IdsFile of $owner",
+            )
+        }.onSuccess { status ->
+            Timber.i(
+                "$owner associated IdsFile was deleted: $status",
+            )
+        }
+}
+
 /**
  * Determines if a card can be repositioned.
  *

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/FindAndReplaceDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/FindAndReplaceDialogFragment.kt
@@ -178,15 +178,7 @@ class FindAndReplaceDialogFragment : AnalyticsDialogFragment() {
 
     /** Attempt to delete the associated [IdsFile] and logs the result */
     private fun removeIdsFile() {
-        runCatching { idsFile.delete() }
-            .onFailure { throwable ->
-                Timber.w(
-                    throwable,
-                    "Exception when removing IdsFile of FindAndReplaceDialogFragment",
-                )
-            }.onSuccess { status ->
-                Timber.i("FindAndReplaceDialogFragment associated IdsFile was deleted: $status")
-            }
+        idsFile.removeSafely(TAG)
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
@@ -15,6 +15,7 @@ package com.ichi2.anki.export
 
 import android.app.Dialog
 import android.content.Context
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
@@ -38,6 +39,8 @@ import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
+import com.ichi2.anki.browser.IdsFile
+import com.ichi2.anki.browser.removeSafely
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.time.getTimestamp
 import com.ichi2.anki.compat.CompatHelper.Companion.getSerializableCompat
@@ -50,6 +53,7 @@ import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.DeckNameId
 import com.ichi2.anki.requireAnkiActivity
 import com.ichi2.anki.ui.BasicItemSelectedListener
+import com.ichi2.anki.utils.ext.requireParcelable
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
 import kotlinx.coroutines.launch
@@ -61,6 +65,13 @@ import java.io.File
  */
 class ExportDialogFragment : DialogFragment() {
     private lateinit var binding: DialogExportOptionsBinding
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        if (arguments?.containsKey(ARG_IDS_FILE) == true) {
+            removeIdsFile()
+        }
+    }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         binding = DialogExportOptionsBinding.inflate(requireActivity().layoutInflater, null, false)
@@ -327,17 +338,15 @@ class ExportDialogFragment : DialogFragment() {
     private fun buildExportLimit(): ExportLimit =
         when (arguments?.getSerializableCompat<ExportType>(ARG_TYPE)) {
             ExportType.Notes -> {
-                val selectedNotesIds =
-                    arguments?.getLongArray(ARG_EXPORTED_IDS)
-                        ?: error("Requested export for selected notes but no notes ids were passed in!")
-                exportLimit { noteIds = noteIds { this.noteIds.addAll(selectedNotesIds.toList()) } }
+                val ids = requireArguments().requireParcelable<IdsFile>(ARG_IDS_FILE).getIds()
+
+                exportLimit { noteIds = noteIds { this.noteIds.addAll(ids) } }
             }
 
             ExportType.Cards -> {
-                val selectedCardIds =
-                    arguments?.getLongArray(ARG_EXPORTED_IDS)
-                        ?: error("Requested export for selected cards but no cards ids were passed in!")
-                exportLimit { cardIds = cardIds { this.cids.addAll(selectedCardIds.toList()) } }
+                val ids = requireArguments().requireParcelable<IdsFile>(ARG_IDS_FILE).getIds()
+
+                exportLimit { cardIds = cardIds { this.cids.addAll(ids) } }
             }
             // notes/cards weren't selected so export the chosen decks
             null -> {
@@ -351,6 +360,13 @@ class ExportDialogFragment : DialogFragment() {
                 }
             }
         }
+
+    /** Attempt to delete the associated [IdsFile] and logs the result */
+    private fun removeIdsFile() {
+        val idsFile = requireArguments().requireParcelable<IdsFile>(ARG_IDS_FILE)
+
+        idsFile.removeSafely("ExportDialogFragment")
+    }
 
     private fun getExportRootFile() =
         File(requireActivity().externalCacheDir, "export").also {
@@ -420,7 +436,7 @@ class ExportDialogFragment : DialogFragment() {
     companion object {
         private const val ARG_DECK_ID = "arg_deck_id"
         private const val ARG_TYPE = "arg_type"
-        private const val ARG_EXPORTED_IDS = "arg_exported_ids"
+        private const val ARG_IDS_FILE = "arg_ids_file"
 
         /**
          * Create a new instance of this dialog without any initial constraints(for example when
@@ -440,13 +456,16 @@ class ExportDialogFragment : DialogFragment() {
          * Create a new instance of this dialog targeting a selection of cards or notes for export.
          */
         fun newInstance(
+            cacheDir: File,
             type: ExportType,
             ids: List<Long>,
         ) = ExportDialogFragment().apply {
+            val idsFile = IdsFile(cacheDir, ids, "export")
+
             arguments =
                 Bundle().apply {
                     putSerializable(ARG_TYPE, type)
-                    putLongArray(ARG_EXPORTED_IDS, ids.toLongArray())
+                    putParcelable(ARG_IDS_FILE, idsFile)
                 }
         }
     }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
_Export Dialog crashed when >60k browsed cards are selected and the user puts the app in the background._

One small refactor in `FindAndReplaceDialogFragment.kt` that was modified to use new extension method for cleanup due to recurring code.

## Fixes
* Fixes #20509 

## Approach
_Imitated the approach used in `FindAndReplaceDialogFragment.kt` to deal with this issue by using class `IdsFile` rather than using `Bundle`, which was overflowing when the capacity exceeded, thereby causing the crash._

_Used extension method for cleanup operation._

## How Has This Been Tested?

Tested on my phone (Android 14, Xiaomi / HyperOS) using a debug build. 

> I reproduced the issue. It
> 
> * directed me to the **main screen**: when I waited for some time (maybe 10 seconds or so)
> * showed **error/crash**: when I re-opened instantly

Both these observations have been tested. Video attached as evidence.

## Learning (optional, can help others)

_In `ExportDialogFragment.kt`, there is a scope for **code refactoring** and **cleanup**._ This would have shrunk this PR by some lines. But I intentionally avioided it in this PR as it do not fit in this scope.

https://github.com/user-attachments/assets/27126003-72c2-45b4-9b7e-bd5a51d035b5



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->