### PR TITLE
fix(themes): align night theme default with XML preference

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -362,7 +362,7 @@ open class PrefsRepository(
 
     val appTheme: AppTheme by enumPref(R.string.app_theme_key, AppTheme.FOLLOW_SYSTEM)
     val dayTheme: DayTheme by enumPref(R.string.day_theme_key, DayTheme.LIGHT)
-    val nightTheme: NightTheme by enumPref(R.string.night_theme_key, NightTheme.DARK)
+    val nightTheme: NightTheme by enumPref(R.string.night_theme_key, NightTheme.BLACK)
 
     //endregion
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The in-code default for `nightTheme` was `NightTheme.DARK` while the XML preference default was `theme_black_value` (BLACK). On a fresh install with the system in dark mode, the app rendered the gray DARK theme but the Settings UI showed "Black" as selected forcing users to tap Dark then Black to commit a value and actually get a black appearance.

## Fixes
NA

## Approach
_How does this change address the problem?_

## How Has This Been Tested?
Pixel 10

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->