### PR TITLE
privacy: do not log rollover alarm time

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/widget/DayRolloverAlarm.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/DayRolloverAlarm.kt
@@ -134,7 +134,8 @@ private fun AlarmManager.setWindowSafe(
 ) = try {
     setWindow(type, windowStartMillis, windowLengthMillis, operation)
     val delta = (windowStartMillis - TimeManager.time.intTimeMS()).milliseconds
-    Timber.i("scheduled day rollover alarm at %s (in %s)", Date(windowStartMillis), delta)
+    Timber.i("scheduled day rollover")
+    Timber.d("rollover alarm scheduled for %s (in %s)", Date(windowStartMillis), delta)
 } catch (e: SecurityException) {
     // #6332 - Too Many Alarms on Samsung Devices
     Timber.w(e, "too many alarms — could not schedule alarm")


### PR DESCRIPTION
I'd rather not log user timezones, or information which could imply them

Only appears in crash reports.

Untested

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)