### PR TITLE
docs: add README to lint-rules module

### DIFF
--- a/lint-rules/README.md
+++ b/lint-rules/README.md
@@ -10,19 +10,21 @@ This module contains custom Android lint checks for AnkiDroid.
    - id - unique identifier
    - briefDescription - short summary
    - explanation - detailed description
-   - category - issue category
-   - priority - priority level
-   - severity - severity level
+   - category - use constants from Category class
+   - priority - use constants from Priority class
+   - severity - use constants from Severity class
 4. Add the issue to IssueRegistry.kt
 
 See DirectDateFormatDetector.kt for a small example.
+Link: https://github.com/ankidroid/Anki-Android/blob/main/lint-rules/src/main/java/com/ichi2/anki/lint/DirectDateFormatDetector.kt
 
 ## How to run checks locally
 
 ### Terminal
 
 ./gradlew :lint-rules:assemble
-./gradlew lint
+
+This refreshes the checks in the IDE. Alternatively, run ./gradlew lint to check the whole codebase.
 
 ### Android Studio
 
@@ -30,3 +32,7 @@ See DirectDateFormatDetector.kt for a small example.
 2. Build -> Rebuild Project
 3. Restart Android Studio
 4. Analyze -> Run Inspection by Name -> Type "Lint"
+
+## Documentation
+
+Android Lint Documentation: https://developer.android.com/studio/write/lint

--- a/lint-rules/README.md
+++ b/lint-rules/README.md
@@ -1,0 +1,66 @@
+# Lint Rules Module
+
+This module contains custom Android lint checks for the AnkiDroid project.
+
+## Module Structure
+
+```
+lint-rules/
+├── src/main/java/com/ichi2/anki/lint/
+│   ├── IssueRegistry.kt      # Register all lint issues here
+│   ├── *.kt                   # Individual Detector classes
+└── build.gradle.kts           # Build configuration
+```
+
+## How to Add a New Lint Check
+
+### Step 1: Create a Detector Class
+
+Create a new `.kt` file in `com.ichi2/anki/lint/` (e.g., `MyCustomDetector.kt`).
+
+**Example:** Look at `DirectDateFormatDetector.kt` - it's a small, simple example to copy.
+
+### Step 2: Define the Issue
+
+Inside your Detector, define an `Issue` object with:
+- `id` - Unique identifier
+- `briefDescription` - Short summary
+- `explanation` - Detailed description
+- `category` - Issue category
+- `priority` - Priority level
+- `severity` - Severity level
+
+### Step 3: Register the Issue
+
+Open `IssueRegistry.kt` and add your new `Issue` to the `ISSUES` list:
+
+```kotlin
+val ISSUES = listOf(
+    // ... existing issues ...
+    MyCustomDetector.ISSUE
+)
+```
+
+## How to Run a Check Locally in Android Studio
+
+### Option 1: Terminal (Fastest)
+
+```bash
+# Build the lint-rules module
+./gradlew :lint-rules:assemble
+
+# Run all lint checks
+./gradlew lint
+```
+
+### Option 2: Android Studio Workflow
+
+1. Make your changes in `lint-rules/`
+2. Rebuild: **Build** → **Rebuild Project**
+3. **Restart Android Studio** (important!)
+4. Run: **Analyze** → **Run Inspection by Name** → Type "Lint"
+
+## Related Resources
+
+- [Android Lint Documentation](https://developer.android.com/studio/write/lint)
+- [Writing Custom Lint Rules](https://googlesamples.github.io/android-custom-lint-rules/)

--- a/lint-rules/README.md
+++ b/lint-rules/README.md
@@ -35,4 +35,4 @@ This refreshes the checks in the IDE. Alternatively, run ./gradlew lint to check
 
 ## Documentation
 
-Android Lint Documentation: https://developer.android.com/studio/write/lint
+Custom Lint Rules Documentation: https://github.com/googlesamples/android-custom-lint-rules

--- a/lint-rules/README.md
+++ b/lint-rules/README.md
@@ -1,66 +1,32 @@
 # Lint Rules Module
 
-This module contains custom Android lint checks for the AnkiDroid project.
+This module contains custom Android lint checks for AnkiDroid.
 
-## Module Structure
+## How to add a new lint check
 
-```
-lint-rules/
-├── src/main/java/com/ichi2/anki/lint/
-│   ├── IssueRegistry.kt      # Register all lint issues here
-│   ├── *.kt                   # Individual Detector classes
-└── build.gradle.kts           # Build configuration
-```
+1. Create a new .kt file in com.ichi2.anki.lint/
+2. Create a class that extends Detector
+3. Define an Issue object with:
+   - id - unique identifier
+   - briefDescription - short summary
+   - explanation - detailed description
+   - category - issue category
+   - priority - priority level
+   - severity - severity level
+4. Add the issue to IssueRegistry.kt
 
-## How to Add a New Lint Check
+See DirectDateFormatDetector.kt for a small example.
 
-### Step 1: Create a Detector Class
+## How to run checks locally
 
-Create a new `.kt` file in `com.ichi2/anki/lint/` (e.g., `MyCustomDetector.kt`).
+### Terminal
 
-**Example:** Look at `DirectDateFormatDetector.kt` - it's a small, simple example to copy.
-
-### Step 2: Define the Issue
-
-Inside your Detector, define an `Issue` object with:
-- `id` - Unique identifier
-- `briefDescription` - Short summary
-- `explanation` - Detailed description
-- `category` - Issue category
-- `priority` - Priority level
-- `severity` - Severity level
-
-### Step 3: Register the Issue
-
-Open `IssueRegistry.kt` and add your new `Issue` to the `ISSUES` list:
-
-```kotlin
-val ISSUES = listOf(
-    // ... existing issues ...
-    MyCustomDetector.ISSUE
-)
-```
-
-## How to Run a Check Locally in Android Studio
-
-### Option 1: Terminal (Fastest)
-
-```bash
-# Build the lint-rules module
 ./gradlew :lint-rules:assemble
-
-# Run all lint checks
 ./gradlew lint
-```
 
-### Option 2: Android Studio Workflow
+### Android Studio
 
-1. Make your changes in `lint-rules/`
-2. Rebuild: **Build** → **Rebuild Project**
-3. **Restart Android Studio** (important!)
-4. Run: **Analyze** → **Run Inspection by Name** → Type "Lint"
-
-## Related Resources
-
-- [Android Lint Documentation](https://developer.android.com/studio/write/lint)
-- [Writing Custom Lint Rules](https://googlesamples.github.io/android-custom-lint-rules/)
+1. Make changes in lint-rules/
+2. Build -> Rebuild Project
+3. Restart Android Studio
+4. Analyze -> Run Inspection by Name -> Type "Lint"


### PR DESCRIPTION
Fixes #20978

## Summary
Adds a README.md file to the `:lint-rules` module.

## Contents
- How to add a new lint check
- How to run checks locally

## Testing
Documentation only - no code changes.