### PR TITLE
fix: handle import dialog events via ViewModel lifecycle

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -61,6 +61,7 @@ import androidx.core.view.updatePadding
 import androidx.draganddrop.DropHelper
 import androidx.fragment.app.FragmentContainerView
 import androidx.fragment.app.commit
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -129,9 +130,9 @@ import com.ichi2.anki.dialogs.DialogHandlerMessage
 import com.ichi2.anki.dialogs.EditDeckDescriptionDialog
 import com.ichi2.anki.dialogs.EmptyCardsDialogFragment
 import com.ichi2.anki.dialogs.FatalErrorDialog
-import com.ichi2.anki.dialogs.ImportDialog.ImportDialogListener
 import com.ichi2.anki.dialogs.ImportFileSelectionFragment.ApkgImportResultLauncherProvider
 import com.ichi2.anki.dialogs.ImportFileSelectionFragment.CsvImportResultLauncherProvider
+import com.ichi2.anki.dialogs.ImportViewModel
 import com.ichi2.anki.dialogs.SchedulerUpgradeDialog
 import com.ichi2.anki.dialogs.SyncErrorDialog
 import com.ichi2.anki.dialogs.SyncErrorDialog.Companion.newInstance
@@ -233,7 +234,7 @@ import com.ichi2.anki.common.android.R as CommonR
  *   * Blocks the UI and displays sync progress when syncing
  * * Displaying 'General' AnkiDroid options: backups, import, 'check media' etc...
  *   * General handler for error/global dialogs (search for 'as DeckPicker')
- *   * Such as import: [ImportDialogListener]
+ *   * Such as import: [ImportViewModel]
  * * A Floating Action Button [floatingActionMenu] allowing the user to quickly add notes/cards.
  * * A custom image as a background can be added: [applyDeckPickerBackground]
  */
@@ -244,7 +245,6 @@ import com.ichi2.anki.common.android.R as CommonR
 open class DeckPicker :
     NavigationDrawerActivity(),
     SyncErrorDialogListener,
-    ImportDialogListener,
     OnRequestPermissionsResultCallback,
     ChangeManager.Subscriber,
     ImportColpkgListener,
@@ -253,6 +253,8 @@ open class DeckPicker :
     CsvImportResultLauncherProvider,
     CollectionPermissionScreenLauncher {
     val viewModel: DeckPickerViewModel by viewModels()
+
+    private val importViewModel: ImportViewModel by viewModels()
 
     private lateinit var binding: ActivityHomescreenBinding
 
@@ -868,6 +870,9 @@ open class DeckPicker :
         viewModel.flowOfStartupResponse.filterNotNull().launchCollectionInLifecycleScope(::onStartupResponse)
         viewModel.flowOfShowContextMenu.launchCollectionInLifecycleScope(::showDeckPickerContextMenu)
         viewModel.flowOfShowRightClickContextMenu.launchCollectionInLifecycleScope(::showDeckPickerRightClickContextMenu)
+        // navigation should be done on RESUMED
+        importViewModel.importAddFlow.launchCollectionInLifecycleScope(Lifecycle.State.RESUMED, ::importAdd)
+        importViewModel.importReplaceFlow.launchCollectionInLifecycleScope(Lifecycle.State.RESUMED, ::importReplace)
     }
 
     private val onReceiveContentListener =
@@ -1919,13 +1924,13 @@ open class DeckPicker :
     }
 
     // Callback to import a file -- adding it to existing collection
-    override fun importAdd(importPath: String) {
+    fun importAdd(importPath: String) {
         Timber.d("importAdd() for file %s", importPath)
         startActivity(AnkiPackageImporterFragment.getIntent(this, importPath))
     }
 
     // Callback to import a file -- replacing the existing collection
-    override fun importReplace(importPath: String) {
+    fun importReplace(importPath: String) {
         Timber.d("importReplace() for file %s", importPath)
         importColpkg(importPath)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.kt
@@ -19,7 +19,9 @@ package com.ichi2.anki.dialogs
 import android.os.Bundle
 import androidx.annotation.CheckResult
 import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.activityViewModels
 import com.ichi2.anki.R
+import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.dialogs.ImportDialog.Type.DIALOG_IMPORT_ADD_CONFIRM
 import com.ichi2.anki.dialogs.ImportDialog.Type.DIALOG_IMPORT_REPLACE_CONFIRM
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
@@ -28,12 +30,9 @@ import com.ichi2.utils.positiveButton
 import timber.log.Timber
 import java.net.URLDecoder
 
+@NeedsTest("integration test: ImportDialog => DeckPicker")
 class ImportDialog : AsyncDialogFragment() {
-    interface ImportDialogListener {
-        fun importAdd(importPath: String)
-
-        fun importReplace(importPath: String)
-    }
+    private val importViewModel: ImportViewModel by activityViewModels()
 
     private val dialogType: Type
         get() = Type.fromCode(requireArguments().getInt(IMPORT_DIALOG_TYPE_KEY))
@@ -52,7 +51,7 @@ class ImportDialog : AsyncDialogFragment() {
                     .setTitle(R.string.import_title)
                     .setMessage(res().getString(R.string.import_dialog_message_add, displayFileName))
                     .positiveButton(R.string.import_message_add) {
-                        (activity as ImportDialogListener).importAdd(packagePath)
+                        importViewModel.triggerImportAdd(packagePath)
                         activity?.dismissAllDialogFragments()
                     }.negativeButton(R.string.dialog_cancel)
                     .create()
@@ -62,7 +61,7 @@ class ImportDialog : AsyncDialogFragment() {
                     .setTitle(R.string.import_title)
                     .setMessage(res().getString(R.string.import_message_replace_confirm, displayFileName))
                     .positiveButton(R.string.dialog_positive_replace) {
-                        (activity as ImportDialogListener).importReplace(packagePath)
+                        importViewModel.triggerImportReplace(packagePath)
                         activity?.dismissAllDialogFragments()
                     }.negativeButton(R.string.dialog_cancel)
                     .create()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportViewModel.kt
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Georgios Michelakis <michelakisgio@gmail.com>
+
+package com.ichi2.anki.dialogs
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.launch
+
+class ImportViewModel : ViewModel() {
+    val importAddFlow: SharedFlow<String>
+        field = MutableSharedFlow<String>(extraBufferCapacity = 1)
+
+    val importReplaceFlow: SharedFlow<String>
+        field = MutableSharedFlow<String>(extraBufferCapacity = 1)
+
+    fun triggerImportAdd(path: String) =
+        viewModelScope.launch {
+            importAddFlow.emit(path)
+        }
+
+    fun triggerImportReplace(path: String) =
+        viewModelScope.launch {
+            importReplaceFlow.emit(path)
+        }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Flow.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Flow.kt
@@ -62,10 +62,20 @@ fun <T> Flow<T>.launchCollectionInLifecycleScope(block: suspend (T) -> Unit) {
     }
 }
 
+// Workaround a bug in overload resolution. Replace with the following when the compiler is fixed:
+//  state: Lifecycle.State = Lifecycle.State.STARTED
 context(activity: AnkiActivity)
 fun <T> Flow<T>.launchCollectionInLifecycleScope(block: suspend (T) -> Unit) {
+    launchCollectionInLifecycleScope(Lifecycle.State.STARTED, block)
+}
+
+context(activity: AnkiActivity)
+fun <T> Flow<T>.launchCollectionInLifecycleScope(
+    state: Lifecycle.State,
+    block: suspend (T) -> Unit,
+) {
     activity.lifecycleScope.launch {
-        activity.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        activity.lifecycle.repeatOnLifecycle(state) {
             this@launchCollectionInLifecycleScope.collect {
                 if (isRobolectric) {
                     // hack: lifecycleScope/runOnUiThread do not handle our


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Fix a crash where import dialog handling could run after activity changes and assume a DeckPicker-like context.
The issue is an async UI event path that may outlive the originating screen, causing invalid activity assumptions and ClassCastException in rare lifecycle transitions.

## Fixes
* Related to  #5075 

## Approach
Introduced an import event pipeline through a dedicated ImportViewModel.
ImportDialog now emits import actions as ViewModel events instead of relying only on direct activity casting.
AnkiActivity observes those events with lifecycle awareness, so dialog-triggered import actions are consumed only when the UI is in a safe state.
Kept backward-compatible behavior: if the current activity already implements ImportDialogListener, handling still works directly.
Net effect: removes brittle activity assumptions and aligns async dialog consumption with lifecycle-safe delivery.

## How Has This Been Tested?

Build and run AnkiDroid in debug mode.
Start app flow that can trigger import confirmation dialogs.
Trigger lifecycle transitions around dialog timing

Test configuration used:
Android debug build
Emulator/device setup used for local development
Pre-commit hooks passed during commit, including ktlint

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->