### PR TITLE
fix(card-browser): error message when entering 'and'

### DIFF
--- a/AnkiDroid/proguard-rules.pro
+++ b/AnkiDroid/proguard-rules.pro
@@ -31,6 +31,9 @@
 -keep class androidx.appcompat.view.menu.MenuItemImpl { *; } # .utils.ext.MenuItemImpl
 -keep class com.ichi2.anki.settings.PrefsRepository { *; } # PrefsRepository.notificationsPermissionRequested
 
+# used via exception.toString()
+-keepnames class * extends java.lang.Throwable
+
 # Ignore unused packages
 -dontwarn javax.naming.**
 -dontwarn org.ietf.jgss.**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -47,6 +47,7 @@ import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.dialogs.DatabaseErrorDialog
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType
 import com.ichi2.anki.exception.StorageAccessException
+import com.ichi2.anki.libanki.exception.InvalidSearchException
 import com.ichi2.anki.pages.DeckOptionsDestination
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.utils.openUrl
@@ -115,13 +116,14 @@ fun CoroutineScope.launchCatching(
         } catch (cancellationException: CancellationException) {
             // CancellationException should be re-thrown to propagate it to the parent coroutine
             throw cancellationException
-        } catch (backendException: BackendException) {
-            Timber.w(backendException)
-            val message = backendException.localizedMessage ?: backendException.toString()
-            errorMessageHandler.invoke(message)
         } catch (exception: Exception) {
             Timber.w(exception)
-            errorMessageHandler.invoke(exception.toString())
+            val message =
+                when (exception) {
+                    is BackendException, is InvalidSearchException -> exception.localizedMessage
+                    else -> null
+                } ?: exception.toString()
+            errorMessageHandler.invoke(message)
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CoroutineHelpersTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CoroutineHelpersTest.kt
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 David Allison <davidallisongithub@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki
+
+import com.ichi2.anki.libanki.exception.InvalidSearchException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.runTest
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+
+class CoroutineHelpersTest {
+    @Test
+    fun `launchCatching does not include class names for InvalidSearchException`() =
+        runTest {
+            val underlying = IllegalStateException("Invalid search: an and")
+            val captured = captureErrorMessage { throw InvalidSearchException(underlying) }
+
+            assertThat(captured, equalTo("Invalid search: an and"))
+        }
+
+    private suspend fun CoroutineScope.captureErrorMessage(block: suspend CoroutineScope.() -> Unit): String? {
+        var captured: String? = null
+        launchCatching(
+            errorMessageHandler = { captured = it },
+            block = block,
+        ).join()
+        return captured
+    }
+}

--- a/libanki/src/main/java/com/ichi2/anki/libanki/exception/InvalidSearchException.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/exception/InvalidSearchException.kt
@@ -18,4 +18,4 @@ package com.ichi2.anki.libanki.exception
 
 class InvalidSearchException(
     e: Exception,
-) : IllegalArgumentException(e)
+) : IllegalArgumentException(e.message, e)


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - test

## Purpose / Description
* Exception class names were mangled
* Exception class names were shown

## Fixes
* Fixes #20995
* Fixes #20996
* Fixes #20998

## Approach
* proguard rule
* special-case libanki `InvalidSearchException`


## How Has This Been Tested?
Unit tested

API 37 emulator 

<img width="332" height="248" alt="Screenshot 2026-05-08 at 15 00 08" src="https://github.com/user-attachments/assets/9646d3b8-7f29-443f-95f1-bb9c70bf1f56" />

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)