### PR TITLE
Fix card/notes export as text and sharing

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -62,6 +62,7 @@ import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.ShortcutGroupProvider
 import com.ichi2.anki.android.input.shortcut
 import com.ichi2.anki.common.annotations.LegacyNotifications
+import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.compat.CompatHelper
@@ -71,6 +72,7 @@ import com.ichi2.anki.dialogs.DatabaseErrorDialog
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.CustomExceptionData
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType
 import com.ichi2.anki.dialogs.DialogHandler
+import com.ichi2.anki.dialogs.ExportReadyDialog.Companion.ARG_SHARE_AS_TEXT
 import com.ichi2.anki.dialogs.ExportReadyDialog.Companion.KEY_EXPORT_PATH
 import com.ichi2.anki.dialogs.ExportReadyDialog.Companion.REQUEST_EXPORT_SAVE
 import com.ichi2.anki.dialogs.ExportReadyDialog.Companion.REQUEST_EXPORT_SHARE
@@ -81,6 +83,7 @@ import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.receiver.SdCardReceiver
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.utils.ext.requireString
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.workarounds.AppLoadedFromBackupWorkaround.showedActivityFailedScreen
 import com.ichi2.compat.customtabs.CustomTabActivityHelper
@@ -152,7 +155,8 @@ open class AnkiActivity(
         }
         supportFragmentManager.setFragmentResultListener(REQUEST_EXPORT_SHARE, this) { _, bundle ->
             shareFile(
-                bundle.getString(KEY_EXPORT_PATH) ?: error("Missing required exportPath!"),
+                path = bundle.requireString(KEY_EXPORT_PATH),
+                asText = bundle.getBoolean(ARG_SHARE_AS_TEXT, false),
             )
         }
         if (savedInstanceState != null) {
@@ -704,7 +708,11 @@ open class AnkiActivity(
         super.onSaveInstanceState(outState)
     }
 
-    private fun shareFile(path: String) {
+    @NeedsTest("#20993 verify that the proper mime type is used for the share intent")
+    private fun shareFile(
+        path: String,
+        asText: Boolean = false,
+    ) {
         // Make sure the file actually exists
         val attachment = File(path)
         if (!attachment.exists()) {
@@ -723,10 +731,12 @@ open class AnkiActivity(
                 showThemedToast(this, resources.getString(R.string.apk_share_error), false)
                 return
             }
+        val targetMimeType = if (asText) "text/plain" else "application/apkg"
+
         val sendIntent =
             ShareCompat
                 .IntentBuilder(this)
-                .setType("application/apkg")
+                .setType(targetMimeType)
                 .setStream(uri)
                 .setSubject(getString(R.string.export_email_subject, attachment.name))
                 .setHtmlText(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackendExporting.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackendExporting.kt
@@ -90,7 +90,7 @@ fun AnkiActivity.exportSelectedNotes(
                 )
             }
         }
-        showAsyncDialogFragment(ExportReadyDialog.newInstance(exportPath))
+        showAsyncDialogFragment(ExportReadyDialog.newInstance(exportPath, asText = true))
     }
 }
 
@@ -110,7 +110,7 @@ fun AnkiActivity.exportSelectedCards(
                 exportCardsCsv(exportPath, withHtml, limit)
             }
         }
-        showAsyncDialogFragment(ExportReadyDialog.newInstance(exportPath))
+        showAsyncDialogFragment(ExportReadyDialog.newInstance(exportPath, asText = true))
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -88,12 +88,12 @@ class IntentHandler : AbstractIntentHandler() {
         when (launchType) {
             LaunchType.FILE_IMPORT ->
                 runIfStoragePermissions {
-                    handleFileImport(fileIntent, reloadIntent, action)
+                    handleFileImport(intent, reloadIntent, action)
                     finish()
                 }
             LaunchType.TEXT_IMPORT ->
                 runIfStoragePermissions {
-                    onSelectedCsvForImport(fileIntent)
+                    onSelectedCsvForImport(intent)
                     finish()
                 }
             LaunchType.IMAGE_IMPORT ->
@@ -127,15 +127,6 @@ class IntentHandler : AbstractIntentHandler() {
             failureMessageId = R.string.about_ankidroid_error_copy_debug_info,
         )
     }
-
-    private val fileIntent: Intent
-        get() {
-            return if (intent.action == Intent.ACTION_SEND) {
-                IntentCompat.getParcelableExtra(intent, Intent.EXTRA_STREAM, Intent::class.java) ?: intent
-            } else {
-                intent
-            }
-        }
 
     /**
      * Execute the runnable if one of the two following conditions are satisfied:

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportReadyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportReadyDialog.kt
@@ -29,6 +29,8 @@ import com.ichi2.utils.positiveButton
 class ExportReadyDialog : AsyncDialogFragment() {
     private val exportPath
         get() = requireArguments().getString(KEY_EXPORT_PATH) ?: error("Missing required argument: exportPath!")
+    private val asText: Boolean
+        get() = requireArguments().getBoolean(ARG_SHARE_AS_TEXT, false)
 
     override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
         val dialog = AlertDialog.Builder(requireActivity())
@@ -43,7 +45,10 @@ class ExportReadyDialog : AsyncDialogFragment() {
             }.negativeButton(R.string.export_choice_share) {
                 parentFragmentManager.setFragmentResult(
                     REQUEST_EXPORT_SHARE,
-                    bundleOf(KEY_EXPORT_PATH to exportPath),
+                    Bundle().apply {
+                        putString(KEY_EXPORT_PATH, exportPath)
+                        putBoolean(ARG_SHARE_AS_TEXT, asText)
+                    },
                 )
             }
 
@@ -90,10 +95,17 @@ class ExportReadyDialog : AsyncDialogFragment() {
         const val REQUEST_EXPORT_SAVE = "request_export_save"
         const val REQUEST_EXPORT_SHARE = "request_export_share"
         const val KEY_EXPORT_PATH = "key_export_path"
+        const val ARG_SHARE_AS_TEXT = "arg_share_as_text"
 
-        fun newInstance(exportPath: String) =
-            ExportReadyDialog().apply {
-                arguments = bundleOf(KEY_EXPORT_PATH to exportPath)
-            }
+        fun newInstance(
+            exportPath: String,
+            asText: Boolean = false,
+        ) = ExportReadyDialog().apply {
+            arguments =
+                Bundle().apply {
+                    putString(KEY_EXPORT_PATH, exportPath)
+                    putBoolean(ARG_SHARE_AS_TEXT, asText)
+                }
+        }
     }
 }


### PR DESCRIPTION
## Purpose / Description

When sharing notes and card as a text file we created the share intent for an _application/apkg_ which then failed. I passed a flag to distinguish between creating a share intent for an apkg or text file so the import succeeds.

## Fixes
* Fixes #20993

## How Has This Been Tested?

Checked exporting everything and sharing back.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

