### PR TITLE
fix(release): workaround for gawk regex bug

### DIFF
--- a/tools/lib/increase-version.awk
+++ b/tools/lib/increase-version.awk
@@ -5,8 +5,9 @@
 #
 
 1 {
-    prefix = gensub(/^(.*[^0-9])([0-9]+)$/, "\\1", "1")
-    testingversion = gensub(/^(.*[^0-9])([0-9]+)$/, "\\2", "1")
+    # strip the numeric suffix, obtaining '12.4alpha'
+    prefix = gensub(/[0-9]+$/, "", "1")
+    testingversion = substr($0, length(prefix) + 1)
 
     next_testingversion = (1*testingversion)+1
     printf "%s%s\n", prefix, next_testingversion


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - diagnostics

## Purpose / Description


gawk 5.4.0 did not work correctly with `increase-version.awk` due to new MinRX matchers

<details>

<summary>5.4.0 announcement</summary>

> This release includes a new regular expression matcher, MinRX, written by Mike Haertel, the original author of GNU grep. It's available from https://github.com/mikehaertel/minrx.
> 
> This matcher is fully POSIX compliant, which the current GNU matchers are not. In particular it follows POSIX rules for finding the longest leftmost submatches.  It is also more strict as to regular expression syntax, but primarily in a few corner cases that normal, correct, regular expression usage should not encounter.
> 
> Because regular expression matching is such a fundamental part of awk/gawk, the original GNU matchers are still included in gawk.  In order to use them, give a value to the GAWK_GNU_MATCHERS environment variable before invoking gawk.
> 
> If you find a difference in behavior between the new and original matchers, please report it. In particular if it adversely affects your current application(s).  Note that if the difference is due to being fully POSIX compliant, then you should consider revising your application. Please use the gawkbug script to report any issues, as would be done for any other bug. See node Bugs in the manual for more details; it's online at https://www.gnu.org/software/gawk/manual/html_node/Bugs.html.
> 
> PLEASE NOTE! The original GNU matchers will eventually be removed from gawk.  So, please take the time to notice and report any issues in the MinRX matcher, so that they can be ironed out sooner rather than later.

</details>

-- https://lists.gnu.org/archive/html/info-gnu/2026-02/msg00011.html


```sh
echo "12.4alpha9" | GAWK_GNU_MATCHERS=1 gawk -f tools/lib/increase-version.awk
# expected: 12.4alpha10
echo "12.4alpha9" | gawk -f tools/lib/increase-version.awk 
# actual: 12.4alpha913.4
```

## Approach
This fix obtains the prefix by stripping the numeric suffix from the string, then substrings to obtain the suffix.

I did not use the workaround flag `GAWK_GNU_MATCHERS=1`, but have reported the bug upstream so others will benefit from the fix.


## How Has This Been Tested?

```
➜  Anki-Android git:(screenshot-test-1) ✗ echo "12.4alpha9" | gawk -f tools/lib/increase-version.awk
12.4alpha10
➜  Anki-Android git:(screenshot-test-1) ✗ echo "12.4" | gawk -f tools/lib/increase-version.awk
12.5
➜  Anki-Android git:(screenshot-test-1) ✗ echo "1.2.3" | gawk -f tools/lib/increase-version.awk
1.2.4
```

**Changes:**
'123' previously returned 123124, now 124 ✅

## Learning
5.4.0 release: https://lists.gnu.org/archive/html/info-gnu/2026-02/msg00011.html
My bug report: https://lists.gnu.org/archive/html/bug-gawk/2026-05/msg00009.html

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)