### PR TITLE
fix(card-browser): render code blocks in error messages

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -51,6 +51,7 @@ import com.ichi2.anki.pages.DeckOptionsDestination
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.utils.openUrl
 import com.ichi2.utils.create
+import com.ichi2.utils.formatErrorMessage
 import com.ichi2.utils.message
 import com.ichi2.utils.neutralButton
 import com.ichi2.utils.positiveButton
@@ -287,7 +288,7 @@ fun Context.showError(
             .Builder(this)
             .create {
                 title(R.string.vague_error)
-                message(text = message)
+                message(text = formatErrorMessage(message))
                 positiveButton(R.string.dialog_ok)
                 if (crashReportData?.helpAction != null) {
                     neutralButton(R.string.help)

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ErrorMessageFormatter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ErrorMessageFormatter.kt
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 Aryan Jaiswal <aryanjaiswal123123@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.utils
+
+import android.text.Spannable
+import android.text.SpannableStringBuilder
+import android.text.style.TypefaceSpan
+
+private val PRE_TAG_REGEX = Regex("<pre>(.*?)</pre>", RegexOption.DOT_MATCHES_ALL)
+
+/**
+ * Renders `<pre>...</pre>` blocks from backend error messages as monospaced
+ * text instead of leaking the raw markup to the user.
+ */
+fun formatErrorMessage(message: String): CharSequence {
+    val matches = PRE_TAG_REGEX.findAll(message).toList()
+    if (matches.isEmpty()) return message
+
+    val builder = SpannableStringBuilder()
+    var cursor = 0
+    for (match in matches) {
+        builder.append(message, cursor, match.range.first)
+
+        val codeStart = builder.length
+        builder.append(match.groupValues[1])
+        val codeEnd = builder.length
+
+        builder.setSpan(TypefaceSpan("monospace"), codeStart, codeEnd, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+
+        cursor = match.range.last + 1
+    }
+    if (cursor < message.length) {
+        builder.append(message, cursor, message.length)
+    }
+    return builder
+}

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ErrorMessageFormatter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ErrorMessageFormatter.kt
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 Aryan Jaiswal <aryanjaiswal123123@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.utils
+
+import android.content.Context
+import android.text.Spannable
+import android.text.SpannableStringBuilder
+import android.text.style.BackgroundColorSpan
+import android.text.style.TypefaceSpan
+import androidx.annotation.ColorInt
+import com.ichi2.themes.Themes
+
+private val PRE_TAG_REGEX = Regex("<pre>(.*?)</pre>", RegexOption.DOT_MATCHES_ALL)
+
+/**
+ * Renders `<pre>...</pre>` blocks from backend error messages as monospaced
+ * code blocks instead of leaking the raw markup to the user.
+ */
+fun formatErrorMessage(
+    message: String,
+    @ColorInt codeBackgroundColor: Int,
+): CharSequence {
+    val matches = PRE_TAG_REGEX.findAll(message).toList()
+    if (matches.isEmpty()) return message
+
+    val builder = SpannableStringBuilder()
+    var cursor = 0
+    for (match in matches) {
+        builder.append(message, cursor, match.range.first)
+
+        val codeStart = builder.length
+        builder.append(match.groupValues[1])
+        val codeEnd = builder.length
+
+        builder.setSpan(TypefaceSpan("monospace"), codeStart, codeEnd, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+        builder.setSpan(BackgroundColorSpan(codeBackgroundColor), codeStart, codeEnd, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+
+        cursor = match.range.last + 1
+    }
+    if (cursor < message.length) {
+        builder.append(message, cursor, message.length)
+    }
+    return builder
+}
+
+fun Context.formatErrorMessage(message: String): CharSequence =
+    formatErrorMessage(
+        message,
+        Themes.getColorFromAttr(this, com.google.android.material.R.attr.colorSurfaceContainerHighest),
+    )

--- a/AnkiDroid/src/test/java/com/ichi2/utils/ErrorMessageFormatterTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ErrorMessageFormatterTest.kt
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 Aryan Jaiswal <aryanjaiswal123123@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.utils
+
+import android.graphics.Color
+import android.text.Spanned
+import android.text.style.TypefaceSpan
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.EmptyApplicationCategory
+import com.ichi2.testutils.EmptyApplication
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.not
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
+class ErrorMessageFormatterTest {
+    @Test
+    fun `plain message is returned unchanged`() {
+        val input = "Invalid search: an `and` was found but it is not connecting two search terms."
+        assertThat(formatErrorMessage(input, Color.GRAY).toString(), equalTo(input))
+    }
+
+    @Test
+    fun `pre tags are replaced with a monospace span`() {
+        val input = "<pre>regex parse error:\n    (?i)i[\n        ^\nerror: unclosed character class</pre>"
+
+        val output = formatErrorMessage(input, Color.GRAY) as Spanned
+
+        assertThat(output.toString(), not(containsString("<pre>")))
+        assertThat(output.toString(), not(containsString("</pre>")))
+        assertThat(output.toString(), equalTo("regex parse error:\n    (?i)i[\n        ^\nerror: unclosed character class"))
+
+        val typefaceSpans = output.getSpans(0, output.length, TypefaceSpan::class.java)
+        assertThat(typefaceSpans.size, equalTo(1))
+        assertThat(typefaceSpans[0].family, equalTo("monospace"))
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/utils/ErrorMessageFormatterTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ErrorMessageFormatterTest.kt
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Aryan Jaiswal <aryanjaiswal123123@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.utils
+
+import android.text.Spanned
+import android.text.style.TypefaceSpan
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.EmptyApplicationCategory
+import com.ichi2.testutils.EmptyApplication
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.not
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
+class ErrorMessageFormatterTest {
+    @Test
+    fun `plain message is returned unchanged`() {
+        val input = "Invalid search: an `and` was found but it is not connecting two search terms."
+        assertThat(formatErrorMessage(input).toString(), equalTo(input))
+    }
+
+    @Test
+    fun `pre tags are replaced with a monospace span`() {
+        val input = "<pre>regex parse error:\n    (?i)i[\n        ^\nerror: unclosed character class</pre>"
+
+        val output = formatErrorMessage(input) as Spanned
+
+        assertThat(output.toString(), not(containsString("<pre>")))
+        assertThat(output.toString(), not(containsString("</pre>")))
+        assertThat(output.toString(), equalTo("regex parse error:\n    (?i)i[\n        ^\nerror: unclosed character class"))
+
+        val typefaceSpans = output.getSpans(0, output.length, TypefaceSpan::class.java)
+        assertThat(typefaceSpans.size, equalTo(1))
+        assertThat(typefaceSpans[0].family, equalTo("monospace"))
+    }
+}


### PR DESCRIPTION

<img width="369" height="753" alt="Screenshot 2026-05-09 at 1 04 05 AM" src="https://github.com/user-attachments/assets/d690c7d9-6154-4fcf-9231-91fe163b42b6" />

## Purpose / Description

When a card-browser search produces an error wrapped in `<pre>...</pre>`
by the Anki backend (e.g. `re:b[` triggers a regex parse error), the
error dialog displayed the literal `<pre>` and `</pre>` tags instead
of rendering the code block. Anki Desktop renders these via Qt's HTML
support; AnkiDroid uses a plain `TextView`, so the markup leaked
through.

## Fixes

* Fixes #21001

## Approach

* Add `formatErrorMessage(message, codeBackgroundColor)` in
  `com.ichi2.utils` that strips `<pre>` tags and applies
  `TypefaceSpan("monospace")` + `BackgroundColorSpan` to the inner
  content.
* Add a `Context.formatErrorMessage(message)` extension that resolves
  the code-block background from `?attr/colorSurfaceContainerHighest`
  via the existing `Themes.getColorFromAttr` helper, so it adapts to
  light/dark themes.
* Call it from `Context.showError` so every error dialog benefits.
* Whitespace inside the `<pre>` block is preserved so caret indicators
  (e.g. `^` under the offending character of a regex) stay aligned.

## How Has This Been Tested?

* New unit tests in `ErrorMessageFormatterTest`:
  * plain message passes through unchanged
  * `<pre>regex parse error: …</pre>` becomes plain text with a
    `TypefaceSpan("monospace")` over the code range
* Manually verified by searching `re:b[` and `and` in the card browser
  on a debug build.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)