### PR TITLE
fix: avoid SecurityException when sharing an image to the note editor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaImageFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaImageFragment.kt
@@ -275,11 +275,8 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
     }
 
     private fun handleImageUri() {
-        fun processExternalImage(uri: Uri): Uri? = internalizeUri(uri)?.let { Uri.fromFile(it) }
-
         if (imageUri != null) {
-            val internalUri = imageUri?.let { processExternalImage(it) }
-            handleSelectImageIntent(internalUri)
+            handleSelectImageIntent(imageUri)
         } else {
             handleSelectedImageOptions()
         }
@@ -577,10 +574,10 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
         Timber.i("Loading non-SVG image using WebView")
 
         try {
-            val internalFile = internalizeUri(imageUri)?.takeIf { it.exists() }
+            val internalFile = resolveUriToFile(imageUri)?.takeIf { it.exists() }
             if (internalFile == null) {
                 Timber.w(
-                    "loadImage() unable to internalize image from Uri %s",
+                    "loadImage() unable to resolve image from Uri %s",
                     imageUri,
                 )
                 showSomethingWentWrong()
@@ -651,9 +648,13 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
      */
     private fun loadSvgFromUri(uri: Uri): String? =
         try {
-            context?.contentResolver?.openInputStreamSafe(uri)?.use { inputStream ->
-                inputStream.convertToString()
-            }
+            val inputStream =
+                if (uri.scheme == ContentResolver.SCHEME_FILE) {
+                    uri.path?.let { File(it).inputStream() }
+                } else {
+                    context?.contentResolver?.openInputStreamSafe(uri)
+                }
+            inputStream?.use { it.convertToString() }
         } catch (e: Exception) {
             Timber.w(e, "Error reading SVG from URI")
             null


### PR DESCRIPTION


<!--- Please fill the necessary details below -->
## Purpose / Description
Fixes security exception

## Fixes
* Didn't raise a issue but here https://forums.ankiweb.net/t/photo-cropping-doesnt-work-on-an-older-device-galaxy-note-8-android-9/69655

## Approach
See commmit

## How Has This Been Tested?
API 28 Google emulator

## Learning (optional, can help others)
NA


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->