### PR TITLE
test: device and theme screenshot properties

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -260,6 +260,11 @@ android {
                     // ./gradlew testFullDebugUnitTest -Pscreenshot
                     if (project.hasProperty("screenshot")) {
                         includeTags "com.ichi2.anki.ScreenshotTestCategory"
+
+                        // ./gradlew :AnkiDroid:recordRoborazziPlayDebug -Pscreenshot -Ptheme=dark
+                        systemProperty "screenshot.theme", project.findProperty("theme") ?: "light"
+                        // ./gradlew :AnkiDroid:recordRoborazziPlayDebug -Pscreenshot -Pdevice=tablet
+                        systemProperty "screenshot.device", project.findProperty("device") ?: "phone"
                     } else {
                         excludeTags "com.ichi2.anki.ScreenshotTestCategory"
                     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -360,7 +360,7 @@ open class PrefsRepository(
 
     //region Appearance
 
-    val appTheme: AppTheme by enumPref(R.string.app_theme_key, AppTheme.FOLLOW_SYSTEM)
+    var appTheme: AppTheme by enumPref(R.string.app_theme_key, AppTheme.FOLLOW_SYSTEM)
     val dayTheme: DayTheme by enumPref(R.string.day_theme_key, DayTheme.LIGHT)
     val nightTheme: NightTheme by enumPref(R.string.night_theme_key, NightTheme.BLACK)
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AllActivitiesScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AllActivitiesScreenshotTest.kt
@@ -40,10 +40,6 @@ import org.robolectric.ParameterizedRobolectricTestRunner
  */
 @RunWith(ParameterizedRobolectricTestRunner::class)
 class AllActivitiesScreenshotTest : ScreenshotTest() {
-    init {
-        setPhoneQualifiers()
-    }
-
     @ParameterizedRobolectricTestRunner.Parameter
     @JvmField
     var launcher: ActivityLaunchParam? = null

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ScreenshotTest.kt
@@ -20,6 +20,9 @@ import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.RoborazziOptions
 import com.github.takahirom.roborazzi.captureScreenRoboImage
 import com.github.takahirom.roborazzi.provideRoborazziContext
+import com.ichi2.anki.settings.Prefs
+import com.ichi2.anki.settings.enums.AppTheme
+import org.junit.Before
 import org.junit.experimental.categories.Category
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.GraphicsMode
@@ -33,6 +36,31 @@ interface ScreenshotTestCategory
 @Category(ScreenshotTestCategory::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 abstract class ScreenshotTest : RobolectricTest() {
+    var fileNamePrefix = ""
+
+    @Before
+    open fun applyGlobalConfig() {
+        applyDeviceConfig()
+        applyThemeConfig()
+    }
+
+    protected open fun applyDeviceConfig() {
+        if (System.getProperty("screenshot.device") == "tablet") {
+            setTabletQualifiers()
+            fileNamePrefix += "tablet_"
+        } else {
+            setPhoneQualifiers()
+        }
+    }
+
+    protected open fun applyThemeConfig() {
+        if (System.getProperty("screenshot.theme") == "dark") {
+            RuntimeEnvironment.setQualifiers("+night")
+            Prefs.appTheme = AppTheme.NIGHT
+            fileNamePrefix += "dark_"
+        }
+    }
+
     /** Pixel-class phone in portrait, light theme. */
     protected fun setPhoneQualifiers() {
         RuntimeEnvironment.setQualifiers(RobolectricDeviceQualifiers.MediumPhone)
@@ -54,7 +82,8 @@ abstract class ScreenshotTest : RobolectricTest() {
         val classDir = "build/outputs/roborazzi/${this.javaClass.simpleName}"
         val diffDir = File("$classDir/diffs")
         // baseline is always in the root for the class, copied to /diffs/ if a change occurred
-        val baseline = File("$classDir/$name.png")
+        val fileName = "$fileNamePrefix$name.png"
+        val baseline = File(classDir, fileName)
         captureScreenRoboImage(
             filePath = baseline.path,
             roborazziOptions = provideRoborazziContext().options.withCompareOutputDir(diffDir.path),

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/StudyScreenScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/StudyScreenScreenshotTest.kt
@@ -24,7 +24,6 @@ import com.ichi2.anki.settings.enums.ToolbarPosition
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
 class StudyScreenScreenshotTest(
@@ -35,7 +34,6 @@ class StudyScreenScreenshotTest(
         Prefs.toolbarPosition = config.toolbarPosition
         Prefs.showAnswerButtons = config.showAnswerButtons
         Prefs.frameStyle = config.frameStyle
-        RuntimeEnvironment.setQualifiers(config.qualifier.toString())
     }
 
     @Test
@@ -64,27 +62,17 @@ class StudyScreenScreenshotTest(
             val styles = FrameStyle.entries
             // val styles = listOf(FrameStyle.BOX)
 
-            val devices =
-                listOf(
-                    Qualifier("Phone", 411, 914, "420dpi"),
-                    Qualifier("Tablet", 1280, 800, "xhdpi"),
-                )
-            // val devices = listOf(Qualifier("Phone", 411, 914, "420dpi"))
-
             val configs = mutableListOf<Array<TestConfig>>()
             for (pos in positions) {
                 for (btn in buttonStates) {
                     for (style in styles) {
-                        for (dev in devices) {
-                            val config =
-                                TestConfig(
-                                    pos,
-                                    btn,
-                                    style,
-                                    dev,
-                                )
-                            configs.add(arrayOf(config))
-                        }
+                        val config =
+                            TestConfig(
+                                pos,
+                                btn,
+                                style,
+                            )
+                        configs.add(arrayOf(config))
                     }
                 }
             }
@@ -100,23 +88,9 @@ class StudyScreenScreenshotTest(
         val toolbarPosition: ToolbarPosition,
         val showAnswerButtons: Boolean,
         val frameStyle: FrameStyle,
-        val qualifier: Qualifier,
     ) {
         override fun toString(): String =
-            "${qualifier.name}_toolbar=${toolbarPosition.name}_" +
+            "toolbar=${toolbarPosition.name}_" +
                 "frameStyle=${frameStyle.name}_buttons=$showAnswerButtons"
-    }
-}
-
-data class Qualifier(
-    val name: String,
-    val widthDp: Int,
-    val heightDp: Int,
-    val dpi: String,
-    val nightMode: Boolean = false,
-) {
-    override fun toString(): String {
-        val nightString = if (nightMode) "night" else "notnight"
-        return "w${widthDp}dp-h${heightDp}dp-$nightString-$dpi"
     }
 }


### PR DESCRIPTION
global properties to run tests with a tablet frame and/or dark theme

It also sets the `MediumPhone` qualifier by default, so tests like `AllActivitiesScreenshotTest` don't need to set it manually

add -Ptheme=dark to use dark theme and -Pdevice=tablet to use a tablet frame

## How Has This Been Tested?

./gradlew :AnkiDroid:recordRoborazziPlayDebug -Pscreenshot -Ptheme=dark

./gradlew :AnkiDroid:recordRoborazziPlayDebug -Pscreenshot -Pdevice=tablet

./gradlew :AnkiDroid:recordRoborazziPlayDebug -Pscreenshot -Ptheme=dark -Pdevice=tablet

<img width="2236" height="973" alt="image" src="https://github.com/user-attachments/assets/f44d8bc5-b118-4a60-aed9-b12db528eda2" />


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->