### PR TITLE
providing the selected kind to launch custom study to provide user's intent

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -149,7 +149,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
             val option = selectedSubDialog ?: return@setFragmentResultListener
             val selectedCardStateIndex = viewModel.selectedCardStateIndex
             if (selectedCardStateIndex == AdapterView.INVALID_POSITION) return@setFragmentResultListener
-            val kind = CustomStudyCardState.entries[selectedCardStateIndex].kind
+            val kind = viewModel.selectedKind
             val cardsAmount = userInputValue ?: 100 // the default value
             launchCustomStudy(option, cardsAmount, kind, tagsToInclude, emptyList())
         }
@@ -404,7 +404,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
                             }
                         // skip tag selection if there's no tags to select
                         if (nids.isEmpty()) {
-                            launchCustomStudy(contextMenuOption, n)
+                            launchCustomStudy(contextMenuOption, n, viewModel.selectedKind)
                             return@launchCatchingTask
                         }
                         if (isAdded) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyViewModel.kt
@@ -18,6 +18,9 @@ package com.ichi2.anki.dialogs.customstudy
 import android.widget.AdapterView
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import anki.scheduler.CustomStudyRequest.Cram.CramKind
+import com.ichi2.anki.common.annotations.NeedsTest
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyCardState
 import com.ichi2.anki.libanki.Deck
 import com.ichi2.anki.libanki.DeckId
 
@@ -41,6 +44,20 @@ class CustomStudyViewModel(
     /** Required [DeckId] of the [Deck] for which the custom study session is being built. */
     val deckId: DeckId
         get() = savedStateHandle.get<DeckId>(KEY_DID) ?: error("Deck id was not provided!")
+
+    /*
+     * Translates the user's selection into a specific study type.
+     * This prevents the app from "forgetting" user's choice (e.g., Due Cards)
+     * even if the tag selection screen is skipped.
+     */
+    @NeedsTest("Verify that selectedCardStateIndex correctly maps to the corresponding CramKind")
+    val selectedKind: CramKind
+        get() =
+            if (selectedCardStateIndex != AdapterView.INVALID_POSITION) {
+                CustomStudyCardState.entries[selectedCardStateIndex].kind
+            } else {
+                CramKind.CRAM_KIND_NEW
+            }
 
     companion object {
         /**


### PR DESCRIPTION
Providing the selected kind to launch custom study

<!--- Please fill the necessary details below -->
## Purpose / Description
 The user's chosen option was overriden for custom study 

## Fixes
* Fixes #20970


## Approach
 It was a smaller bug the launch custom study was using the default parameter

## How Has This Been Tested?

https://github.com/user-attachments/assets/c70012d4-78b2-4bbe-8a51-31e3e3059d2f


I tested this in realme c30s

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ✅] You have a descriptive commit message with a short title (first line, max 50 chars).
- [✅ ] You have commented your code, particularly in hard-to-understand areas
- [✅ ] You have performed a self-review of your own code
- [✅ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->