### PR TITLE
Fix ExportReady dialog async handling

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -28,6 +28,7 @@ import android.widget.ProgressBar
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
 import androidx.annotation.AttrRes
 import androidx.annotation.LayoutRes
 import androidx.annotation.StringRes
@@ -49,6 +50,7 @@ import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.viewbinding.ViewBinding
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.snackbar.Snackbar
@@ -77,6 +79,8 @@ import com.ichi2.anki.dialogs.ExportReadyDialog.Companion.KEY_EXPORT_PATH
 import com.ichi2.anki.dialogs.ExportReadyDialog.Companion.REQUEST_EXPORT_SAVE
 import com.ichi2.anki.dialogs.ExportReadyDialog.Companion.REQUEST_EXPORT_SHARE
 import com.ichi2.anki.dialogs.SimpleMessageDialog
+import com.ichi2.anki.dialogs.handleExportReadyRequest
+import com.ichi2.anki.dialogs.viewmodel.ExportReadyViewModel
 import com.ichi2.anki.exception.SystemStorageException
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.preferences.sharedPrefs
@@ -92,6 +96,7 @@ import com.ichi2.compat.customtabs.CustomTabsHelper
 import com.ichi2.themes.Themes
 import com.ichi2.utils.AdaptionUtil
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -105,6 +110,8 @@ open class AnkiActivity(
 ) : AppCompatActivity(contentLayoutId ?: 0),
     ShortcutGroupProvider,
     AnkiActivityProvider {
+    val exportReadyViewModel by viewModels<ExportReadyViewModel>()
+
     /**
      * Receiver that informs us when a broadcast listen in [broadcastsActions] is received.
      *
@@ -159,6 +166,13 @@ open class AnkiActivity(
                 asText = bundle.getBoolean(ARG_SHARE_AS_TEXT, false),
             )
         }
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                exportReadyViewModel.exportReadyDestination.filterNotNull().collect(::handleExportReadyRequest)
+            }
+        }
+
         if (savedInstanceState != null) {
             val restoredValue = savedInstanceState.getString(KEY_EXPORT_FILE_NAME) ?: return
             fileExportPath = restoredValue

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackendExporting.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackendExporting.kt
@@ -1,16 +1,6 @@
-/*
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2023 lukstbit <52494258+lukstbit@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 David Allison <davidallisongithub@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
 package com.ichi2.anki
 
 import anki.import_export.ExportLimit

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackendExporting.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackendExporting.kt
@@ -16,7 +16,7 @@ package com.ichi2.anki
 import anki.import_export.ExportLimit
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
-import com.ichi2.anki.dialogs.ExportReadyDialog
+import com.ichi2.anki.dialogs.viewmodel.ExportReadyViewModel.ExportReadyParams
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.exportAnkiPackage
 import com.ichi2.anki.libanki.exportCardsCsv
@@ -40,7 +40,7 @@ fun AnkiActivity.exportApkgPackage(
         withProgress(extractProgress = onProgress) {
             withCol { exportAnkiPackage(exportPath, withScheduling, withDeckConfigs, withMedia, limit, legacy) }
         }
-        showAsyncDialogFragment(ExportReadyDialog.newInstance(exportPath))
+        exportReadyViewModel.registerExportReadyRequest(ExportReadyParams(exportPath))
     }
 }
 
@@ -58,7 +58,7 @@ fun AnkiActivity.exportCollectionPackage(
         withProgress(extractProgress = onProgress) {
             withCol { exportCollectionPackage(exportPath, withMedia, legacy) }
         }
-        showAsyncDialogFragment(ExportReadyDialog.newInstance(exportPath))
+        exportReadyViewModel.registerExportReadyRequest(ExportReadyParams(exportPath))
     }
 }
 
@@ -90,7 +90,7 @@ fun AnkiActivity.exportSelectedNotes(
                 )
             }
         }
-        showAsyncDialogFragment(ExportReadyDialog.newInstance(exportPath, asText = true))
+        exportReadyViewModel.registerExportReadyRequest(ExportReadyParams(exportPath, asText = true))
     }
 }
 
@@ -110,7 +110,7 @@ fun AnkiActivity.exportSelectedCards(
                 exportCardsCsv(exportPath, withHtml, limit)
             }
         }
-        showAsyncDialogFragment(ExportReadyDialog.newInstance(exportPath, asText = true))
+        exportReadyViewModel.registerExportReadyRequest(ExportReadyParams(exportPath, asText = true))
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
@@ -100,7 +100,7 @@ class DialogHandler(
  *
  * Restoration + handling is performed in [AnkiActivity.onResume].
  * It is assumed that the [DeckPicker] will be the inheritor of AnkiActivity at this time.
- * As this is provided as the intent from [AnkiActivity.showSimpleNotification]
+ * As this is provided as the intent from [AnkiActivity.showExportReadyNotification]
  */
 abstract class DialogHandlerMessage protected constructor(
     val which: WhichDialogHandler,
@@ -124,7 +124,6 @@ abstract class DialogHandlerMessage protected constructor(
                 WhichDialogHandler.MSG_SHOW_SYNC_ERROR_DIALOG -> SyncErrorDialog.SyncErrorDialogMessageHandler.fromMessage(message)
                 WhichDialogHandler.MSG_SHOW_DATABASE_ERROR_DIALOG -> DatabaseErrorDialog.ShowDatabaseErrorDialog.fromMessage(message)
                 WhichDialogHandler.MSG_DO_SYNC -> IntentHandler.Companion.DoSync()
-                WhichDialogHandler.MSG_EXPORT_READY -> ExportReadyDialog.ExportReadyDialogMessage.fromMessage(message)
             }
     }
 
@@ -139,7 +138,6 @@ abstract class DialogHandlerMessage protected constructor(
         MSG_SHOW_SYNC_ERROR_DIALOG(3),
         MSG_SHOW_DATABASE_ERROR_DIALOG(6),
         MSG_DO_SYNC(8),
-        MSG_EXPORT_READY(10),
         ;
 
         companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportReadyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportReadyDialog.kt
@@ -17,18 +17,20 @@
 package com.ichi2.anki.dialogs
 
 import android.os.Bundle
-import android.os.Message
 import androidx.appcompat.app.AlertDialog
 import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.R
-import com.ichi2.anki.utils.ext.showDialogFragment
+import com.ichi2.anki.dialogs.viewmodel.ExportReadyViewModel.ExportReadyParams
+import com.ichi2.anki.utils.ext.requireString
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
+import timber.log.Timber
 
-class ExportReadyDialog : AsyncDialogFragment() {
+class ExportReadyDialog : DialogFragment() {
     private val exportPath
-        get() = requireArguments().getString(KEY_EXPORT_PATH) ?: error("Missing required argument: exportPath!")
+        get() = requireArguments().requireString(KEY_EXPORT_PATH)
     private val asText: Boolean
         get() = requireArguments().getBoolean(ARG_SHARE_AS_TEXT, false)
 
@@ -36,7 +38,7 @@ class ExportReadyDialog : AsyncDialogFragment() {
         val dialog = AlertDialog.Builder(requireActivity())
 
         dialog
-            .setTitle(notificationTitle)
+            .setTitle(getString(R.string.export_ready_title))
             .positiveButton(R.string.export_choice_save_to) {
                 parentFragmentManager.setFragmentResult(
                     REQUEST_EXPORT_SAVE,
@@ -55,42 +57,6 @@ class ExportReadyDialog : AsyncDialogFragment() {
         return dialog.create()
     }
 
-    override val notificationTitle: String
-        get() = res().getString(R.string.export_ready_title)
-
-    override val notificationMessage: String? = null
-
-    override val dialogHandlerMessage: DialogHandlerMessage
-        get() = ExportReadyDialogMessage(exportPath)
-
-    /** Export ready dialog message*/
-    class ExportReadyDialogMessage(
-        private val exportPath: String,
-    ) : DialogHandlerMessage(
-            which = WhichDialogHandler.MSG_EXPORT_READY,
-            analyticName = "ExportReadyDialog",
-        ) {
-        override fun handleAsyncMessage(activity: AnkiActivity) {
-            // we may be called via any AnkiActivity but export is a DeckPicker thing
-            activity
-                .requireDeckPickerOrShowError()
-                ?.showDialogFragment(newInstance(exportPath))
-        }
-
-        override fun toMessage(): Message =
-            Message.obtain().apply {
-                what = this@ExportReadyDialogMessage.what
-                data = bundleOf("exportPath" to exportPath)
-            }
-
-        companion object {
-            fun fromMessage(message: Message): ExportReadyDialogMessage {
-                val exportPath = message.data.getString("exportPath")!!
-                return ExportReadyDialogMessage(exportPath)
-            }
-        }
-    }
-
     companion object {
         const val REQUEST_EXPORT_SAVE = "request_export_save"
         const val REQUEST_EXPORT_SHARE = "request_export_share"
@@ -107,5 +73,28 @@ class ExportReadyDialog : AsyncDialogFragment() {
                     putBoolean(ARG_SHARE_AS_TEXT, asText)
                 }
         }
+    }
+}
+
+/**
+ * Handles the last part of the export process where we show the [ExportReadyDialog] fragment. The
+ * method will either show the dialog if possible or save it to show it later.
+ */
+internal fun AnkiActivity.handleExportReadyRequest(params: ExportReadyParams) {
+    runCatching {
+        Timber.i("Attempting to show ExportReadyDialog...")
+        val dialog = ExportReadyDialog.newInstance(params.exportPath, params.asText)
+        dialog.show(supportFragmentManager, "ExportReadyDialog")
+    }.onFailure { exception ->
+        if (exception !is IllegalStateException) throw exception
+        Timber.w(
+            exception,
+            "Failed to show ExportReadyDialog, activity is likely paused.",
+        )
+        // TODO the previous code was showing a notification here which allowed the user to come
+        //  back to the activity, after the main ui refactor see if this is more feasible to implement
+    }.onSuccess {
+        Timber.i("ExportReadyDialog is displayed, clearing any stored requests...")
+        exportReadyViewModel.clearExportReadyRequest()
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/viewmodel/ExportReadyViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/viewmodel/ExportReadyViewModel.kt
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 lukstbit <52494258+lukstbit@users.noreply.github.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+package com.ichi2.anki.dialogs.viewmodel
+
+import android.os.Parcelable
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import com.ichi2.anki.AnkiActivity
+import com.ichi2.anki.dialogs.ExportReadyDialog
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.parcelize.Parcelize
+import timber.log.Timber
+
+/**
+ * [ViewModel] that implements actions related to the final part of exporting apkg/text in the base
+ * [AnkiActivity] class
+ * @see ExportReadyDialog
+ * @see AnkiActivity
+ */
+class ExportReadyViewModel(
+    private val savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+    val exportReadyDestination: StateFlow<ExportReadyParams?>
+        field = savedStateHandle.getMutableStateFlow(ARG_EXPORT_READY_PARAMS, null)
+
+    fun registerExportReadyRequest(params: ExportReadyParams) {
+        Timber.d("Export ready dialog requested")
+        savedStateHandle[ARG_EXPORT_READY_PARAMS] = params
+    }
+
+    fun clearExportReadyRequest() {
+        Timber.d("Clearing export ready dialog request")
+        savedStateHandle[ARG_EXPORT_READY_PARAMS] = null
+    }
+
+    /** Encapsulates the data needed to start a new instance of [ExportReadyDialog] */
+    @Parcelize
+    data class ExportReadyParams(
+        val exportPath: String,
+        val asText: Boolean = false,
+    ) : Parcelable
+
+    companion object {
+        private const val ARG_EXPORT_READY_PARAMS = "arg_export_ready_params"
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/AsyncDialogFragmentsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/AsyncDialogFragmentsTest.kt
@@ -44,13 +44,6 @@ class AsyncDialogFragmentsTest {
     }
 
     @Test
-    fun `ExportReadyDialog does not require context`() {
-        val instance = ExportReadyDialog()
-        assertDoesNotThrow("message required a context") { instance.notificationMessage }
-        assertDoesNotThrow("title required a context") { instance.notificationTitle }
-    }
-
-    @Test
     fun `ImportDialog does not require context`() {
         for (dialogType in ImportDialog.Type.entries) {
             val instance = ImportDialog.newInstance(dialogType, "path")


### PR DESCRIPTION
## Purpose / Description

Fixes(IMO) the issue where the _ExportReadyDialog_ that was shown in response to an export request was sometimes shown(and crashed) when the original activity was sent to the background and a new one was at the top.

I didn't figure out how this happens but you can kind of simulate this with the changes below in BackendExporting.kt:

```patch
diff --git a/AnkiDroid/src/main/java/com/ichi2/anki/BackendExporting.kt b/AnkiDroid/src/main/java/com/ichi2/anki/BackendExporting.kt
index d2c0b2f682..b691344af6 100644
--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackendExporting.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackendExporting.kt
@@ -13,6 +13,7 @@
  */
 package com.ichi2.anki
 
+import android.content.Intent
 import anki.import_export.ExportLimit
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
@@ -20,6 +21,7 @@ import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.exportAnkiPackage
 import com.ichi2.anki.libanki.exportCardsCsv
 import com.ichi2.anki.libanki.exportNotesCsv
+import kotlinx.coroutines.delay
 import net.ankiweb.rsdroid.exceptions.BackendInvalidInputException
 
 fun AnkiActivity.exportApkgPackage(
@@ -41,6 +43,8 @@ fun AnkiActivity.exportApkgPackage(
                 exportAnkiPackage(exportPath, withScheduling, withDeckConfigs, withMedia, limit, legacy)
             }
         }
+        startActivity(Intent(this@exportApkgPackage, CardBrowser::class.java))
+        delay(2000)
         ankiBaseViewModel.registerExportReadyRequest(exportPath)
     }
 }
```

and using the export apkg feature.

Note: I added the new AnkiViewModel in a _base_ package, didn't figure out a better location, feel free to propose a different place.

## Fixes
* Related to #5075 

## How Has This Been Tested?

Checked exporting things, ran tests.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
