### PR TITLE
chore(architecture): add `anki-common` module skeleton

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -403,6 +403,7 @@ dependencies {
     annotationProcessor libs.auto.service
 
     // modules
+    implementation project(":anki-common")
     implementation project(":common")
     implementation project(":common:android")
     implementation project(":compat")

--- a/anki-common/README.md
+++ b/anki-common/README.md
@@ -1,0 +1,23 @@
+# `:anki-common`
+
+This module exists to break circular dependencies when `:AnkiDroid` is split into feature modules.
+
+## What belongs here
+
+- Common types and features which depend on `:libanki` and are not part of [`pylib`](https://github.com/ankitects/anki/blob/main/pylib/)
+
+## What does not belong here
+
+- Feature-specific business logic should be in `:AnkiDroid` or feature modules.
+- Common code which does not depend on `:libanki` should be in `:common`
+
+## Why this module exists
+
+- `:libanki` aims to be a 1:1 implementation of upstream `pylib` which defines domain types (`CardId` etc...).
+  - AnkiDroid specific extensions need strong justification for inclusion in `:libanki`
+- `:libanki` depends on `:common`. Common code which needs domain types would cause a circular dependency if placed in `:common`.
+
+## Future direction
+
+This module is currently an Android library because `:libanki` is.
+When `:libanki` becomes a JVM library, this module splits into a pure-JVM half and an Android half (mirroring the existing `:common` / `:common:android` pair), with the JVM half holding everything that doesn't require the Android framework.

--- a/anki-common/build.gradle.kts
+++ b/anki-common/build.gradle.kts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 David Allison <davidallisongithub@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import com.android.build.api.dsl.LibraryExtension
+
+plugins {
+    id("ankidroid.android.library")
+}
+
+configure<LibraryExtension> {
+    // code should live inside com.ichi2.anki
+    // namespace must be unique for resources generation.
+    namespace = "com.ichi2.anki.ankicommon"
+    buildFeatures.buildConfig = false
+}
+
+dependencies {
+    implementation(project(":common"))
+    implementation(project(":libanki"))
+}

--- a/anki-common/src/main/AndroidManifest.xml
+++ b/anki-common/src/main/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- SPDX-FileCopyrightText: 2026 David Allison <davidallisongithub@gmail.com> -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<manifest>
+
+</manifest>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -121,7 +121,7 @@ subprojects {
                     compilerArgs += "-XXLanguage:+ExplicitBackingFields"
                 }
 
-                if (project.path !in listOf(":api", ":common", ":common:android")) {
+                if (project.path !in listOf(":anki-common", ":api", ":common", ":common:android")) {
                     compilerArgs += "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
                 }
                 if (project.path != ":api") {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,7 @@ dependencyResolutionManagement {
 
 // alphabetical ordering rather than dependency-tree ordering to avoid bikeshedding
 include(
+    ":anki-common",
     ":api",
     ":AnkiDroid",
     ":common",


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - almost all

## Purpose / Description
This is designed for common files which also depend on libanki, therefore cannot be inside `common` or `common:android`.

Initially, this is to implement the `Destination` concern: navigation between Activities needs `DeckId` (can't be in `:common`), and wouldn't be able to have circular dependencies, so couldn't live in feature modules when we move to them

## Fixes
* Related #20558
* Related https://github.com/ankidroid/Anki-Android/issues/20737
* Split from https://github.com/ankidroid/Anki-Android/pull/21023

## Approach

See `README.md`

For example, `CollectionManager` should live here:
* Not in libanki
* libanki dependency
* Common code



## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)