### PR TITLE
fix: deck picker subtitle ignores 9999 cap

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -168,10 +168,12 @@ class DeckPickerViewModel :
             tree.onlyHasDefaultDeck() && noCards
         }.stateIn(viewModelScope, SharingStarted.Eagerly, initialValue = null)
 
+    // Sum the top-level decks rather than the root, whose aggregate the backend
+    // caps at 9999 (issue #17605). See DeckNode.totalCardsDue.
     val flowOfCardsDue =
         combine(flowOfDeckDueTree, flowOfDeckListInInitialState) { tree, inInitialState ->
             if (tree == null || inInitialState != false) return@combine null
-            tree.newCount + tree.revCount + tree.lrnCount
+            tree.totalCardsDue()
         }
 
     /** "Studied N cards in 0 seconds today */

--- a/AnkiDroid/src/test/java/com/ichi2/anki/libanki/DeckNodeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/libanki/DeckNodeTest.kt
@@ -31,6 +31,9 @@ class DeckNodeTest {
         level: Int,
         collapsed: Boolean = false,
         children: List<DeckNode> = emptyList(),
+        newCount: Int = 0,
+        reviewCount: Int = 0,
+        learnCount: Int = 0,
     ): DeckNode {
         val treeNode =
             deckTreeNode {
@@ -39,9 +42,9 @@ class DeckNodeTest {
                 this.level = level
                 this.collapsed = collapsed
                 children.forEach { this.children.add(it.node) }
-                this.reviewCount = 0
-                this.newCount = 0
-                this.learnCount = 0
+                this.reviewCount = reviewCount
+                this.newCount = newCount
+                this.learnCount = learnCount
                 this.filtered = false
             }
         return DeckNode(treeNode, name)
@@ -152,6 +155,35 @@ class DeckNodeTest {
         val results2 = science.filterAndFlatten("ist gr")
         // Math::group should not be found
         assertEquals(listOf<String>("Science", "Chemistry", "Group"), results2.map { it.lastDeckNameComponent })
+    }
+
+    @Test
+    fun `totalCardsDue sums top-level decks across new review and learning`() {
+        val a = makeNode("A", deckId = 1, level = 1, newCount = 100, reviewCount = 50, learnCount = 5)
+        val b = makeNode("B", deckId = 2, level = 1, newCount = 200, reviewCount = 0, learnCount = 10)
+        val root = makeNode("", deckId = 0, level = 0, children = listOf(a, b))
+        // A (155) + B (210)
+        assertEquals(365, root.totalCardsDue())
+    }
+
+    @Test
+    fun `totalCardsDue uses top-level decks not the root's capped aggregate`() {
+        // Root aggregate is capped at 9999; summing children recovers the total.
+        val a = makeNode("A", deckId = 1, level = 1, newCount = 9999)
+        val b = makeNode("B", deckId = 2, level = 1, newCount = 9999)
+        val root = makeNode("", deckId = 0, level = 0, newCount = 9999, children = listOf(a, b))
+        assertEquals(19998, root.totalCardsDue())
+    }
+
+    @Test
+    fun `totalCardsDue uses each top-level deck's aggregate, not its subdecks`() {
+        // Subdecks share the parent's limit, so only the parent's aggregate
+        // counts; summing the subdecks would double-count the shared pool.
+        val sub1 = makeNode("Sub1", deckId = 2, level = 2, newCount = 9905)
+        val sub2 = makeNode("Sub2", deckId = 3, level = 2, newCount = 9905)
+        val parent = makeNode("Parent", deckId = 1, level = 1, newCount = 9905, children = listOf(sub1, sub2))
+        val root = makeNode("", deckId = 0, level = 0, children = listOf(parent))
+        assertEquals(9905, root.totalCardsDue())
     }
 }
 

--- a/libanki/src/main/java/com/ichi2/anki/libanki/sched/DeckNode.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/sched/DeckNode.kt
@@ -110,6 +110,15 @@ data class DeckNode(
     fun hasCardsReadyToStudy(): Boolean = revCount > 0 || newCount > 0 || lrnCount > 0
 
     /**
+     * Sum of new, review and learning cards due across the top-level decks, for
+     * the deck-picker subtitle. The root's own aggregate is not used as the
+     * backend caps it at the 9999 daily limit. Per-deck counts already apply
+     * each deck's daily limits, so subdecks sharing a parent limit are not
+     * double-counted (issue 17605).
+     */
+    fun totalCardsDue(): Int = children.sumOf { it.newCount + it.revCount + it.lrnCount }
+
+    /**
      * The node with [did] [deckId], if it is either this node or a descendant.
      */
     fun find(deckId: DeckId): DeckNode? {

--- a/libanki/src/test/java/com/ichi2/anki/libanki/DeckTreeDueCountsTest.kt
+++ b/libanki/src/test/java/com/ichi2/anki/libanki/DeckTreeDueCountsTest.kt
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2026 Onur Dursun <onurgt@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.libanki
+
+import com.ichi2.anki.libanki.testutils.InMemoryAnkiTest
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression cover for the deck-picker subtitle total (issue 17605), pinning the
+ * two facts that constrain how the total may be computed.
+ */
+class DeckTreeDueCountsTest : InMemoryAnkiTest() {
+    /**
+     * The uncapped per-deck fields ignore the daily limit, so summing them gives
+     * the backlog rather than today's due. Guards against using `*Uncapped`
+     * fields in the subtitle total (issue 17605).
+     */
+    @Test
+    fun `summing uncapped counts over-reports the due total`() {
+        val conf = col.decks.configDictForDeckId(1)
+        conf.new.perDay = 10
+        col.decks.save(conf)
+        repeat(20) { addBasicNote("front $it", "back") }
+
+        // Limit-aware total: what the subtitle should show.
+        val limitAwareNew = col.sched.counts().new
+        assertEquals(10, limitAwareNew)
+
+        // Sum of the uncapped per-deck fields.
+        val uncappedTotal =
+            col.sched.deckDueTree().sumOf { deck ->
+                deck.node.newUncapped + deck.node.reviewUncapped +
+                    deck.node.intradayLearning + deck.node.interdayLearningUncapped
+            }
+        assertEquals(20, uncappedTotal, "uncapped sum is the full new pool, not today's due")
+        assertTrue(uncappedTotal > limitAwareNew, "summing uncapped over-reports the due total")
+    }
+
+    /**
+     * Reading per-deck counts by selecting each deck (the `getQueuedCards` approach)
+     * is not side-effect free: `select` registers an undoable op, clobbering the
+     * user's undo history and bumping the collection mod time (which drives sync).
+     */
+    @Test
+    fun `selecting a deck to read its counts mutates undo and sync state`() {
+        val other = col.decks.id("Other")
+        addBasicNote("front", "back")
+
+        val undoBefore = col.undoStatus().undo
+        val modBefore = col.mod
+        Thread.sleep(2)
+
+        col.decks.select(other)
+
+        assertEquals("Select Deck", col.undoStatus().undo, "select registers an undoable op")
+        assertNotEquals(undoBefore, col.undoStatus().undo, "previous undo step is clobbered")
+        assertTrue(col.mod > modBefore, "select bumps the collection mod time (sync)")
+    }
+}


### PR DESCRIPTION
## Purpose / Description

The "X cards due" subtitle on the deck picker home screen is capped at 9999
even when the user has many more cards due. Per [discussion on r/Anki][reddit],
the 9999 cap on individual decks seems to be an intentional architectural decision in
the backend (rslib). Large numbers are not useful for individual
decks, and the clamp simplifies storage and display. That part is fine.

However, the overall total at the top of the screen also gets clamped,
because it is computed by reading the same count fields off the root of the
deck tree protobuf. That looks accidental to me, i think it would be a better idea to show the total amount of due cards for better understanding. But I would understand if it is also an architectural decision.

[reddit]: https://www.reddit.com/r/Anki/comments/1i8ph7e/if_maximum_number_of_cards_in_anki_is_9999_so_if/

## Fixes

* Fixes #17605

## Approach

Scheduler.counts() reads from getQueuedCards, which returns limit aware
and unclamped counts. This is the same source `StudyOptionsFragment` uses to
show the correct count for individual decks after Custom Study. Added a small
`Scheduler.allDecksCountsUncapped()` extension that iterates top level decks
and sums counts(), and switched `DeckPickerViewModel.flowOfCardsDue` to use
it instead of the clamped protobuf root. The 9999 cap on individual decks is preserved.

Side benefit: Custom Study limit extensions are now reflected in the subtitle.

## How Has This Been Tested?

* Tested on Android 16 physical device and emulator.
* Before: subtitle reads "9999 cards due" on a large collection.
* After: subtitle reads the true total (about 40k in my test collection).
* Small collections (under 100 due) has no change.
* Debug and lint tests.

## Screenshots
<img width="286" height="640" alt="6048706909906341658" src="https://github.com/user-attachments/assets/fdbee723-40e4-47de-8577-b20d58ec02a9" />
<img width="286" height="640" alt="6048706909906341670" src="https://github.com/user-attachments/assets/d49087ea-4ea9-45af-9f0a-050c20e05468" />



## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard to understand areas
- [x] You have performed a self review of your own code
- [x] UI changes: include screenshots of all affected screens
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

