### PR TITLE
refactor: move 9 strings to the backend translations

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -633,6 +633,10 @@ open class CardTemplateEditor :
                 binding.mainLayout.addView(cardView, 0)
             }
 
+            binding.bottomNavigation.menu
+                .findItem(R.id.styling_edit)
+                .title = TR.cardTemplatesTemplateStyling()
+
             binding.bottomNavigation.setOnItemSelectedListener { item: MenuItem ->
                 val currentSelectedId = item.itemId
                 templateEditor.tabToViewId[cardIndex] = currentSelectedId
@@ -1560,13 +1564,15 @@ open class CardTemplateEditor :
         ) {
             fun toMarkdown(context: Context) =
                 // backticks are not supported by old reddit
-                buildString {
-                    appendLine("**${context.getString(R.string.card_template_editor_front)}**\n")
-                    appendLine("```html\n$front\n```\n")
-                    appendLine("**${context.getString(R.string.card_template_editor_back)}**\n")
-                    appendLine("```html\n$back\n```\n")
-                    appendLine("**${context.getString(R.string.card_template_editor_styling)}**\n")
-                    append("```css\n$style\n```")
+                with(context) {
+                    buildString {
+                        appendLine("**${TR.sentenceCase.frontTemplate}**\n")
+                        appendLine("```html\n$front\n```\n")
+                        appendLine("**${TR.sentenceCase.backTemplate}**\n")
+                        appendLine("```html\n$back\n```\n")
+                        appendLine("**${TR.cardTemplatesTemplateStyling()}**\n")
+                        append("```css\n$style\n```")
+                    }
                 }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1028,6 +1028,7 @@ open class DeckPicker :
         menu.findItem(R.id.action_export_collection)?.title = TR.actionsExport()
         menu.findItem(R.id.action_check_database)?.title = TR.sentenceCase.checkDatabase
         menu.findItem(R.id.action_check_media)?.title = TR.sentenceCase.checkMediaAction
+        menu.findItem(R.id.action_deck_delete)?.title = TR.sentenceCase.deleteDeck
         setupMediaSyncMenuItem(menu)
         // redraw menu synchronously to avoid flicker
         updateMenuFromState(menu)
@@ -2148,7 +2149,7 @@ open class DeckPicker :
                     shortcut("C") { this.sentenceCase.checkDatabase },
                     shortcut("D", R.string.new_deck),
                     shortcut("F", R.string.new_dynamic_deck),
-                    if (fragmented) shortcut("DEL", R.string.contextmenu_deckpicker_delete_deck) else null,
+                    if (fragmented) shortcut("DEL") { this.sentenceCase.deleteDeck } else null,
                     if (fragmented) shortcut("Shift+DEL", R.string.delete_deck_without_confirmation) else null,
                     if (fragmented) shortcut("R", R.string.rename_deck) else null,
                     shortcut("P", R.string.open_settings),

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -135,6 +135,9 @@ class StudyOptionsFragment :
         menuInflater: MenuInflater,
     ) {
         menuInflater.inflate(R.menu.study_options_fragment, menu)
+        menu.findItem(R.id.action_rebuild)?.title = TR.actionsRebuild()
+        menu.findItem(R.id.action_custom_study)?.title = TR.sentenceCase.customStudy
+        menu.findItem(R.id.action_unbury)?.title = TR.studyingUnbury()
     }
 
     override fun onResume() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/account/LoggedInFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/account/LoggedInFragment.kt
@@ -36,6 +36,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.dialogs.help.HelpDialog
 import com.ichi2.anki.pages.RemoveAccountFragment
 import com.ichi2.anki.settings.Prefs
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.utils.ext.isCompactWidth
 import com.ichi2.anki.utils.ext.removeFragmentFromContainer
@@ -77,7 +78,10 @@ class LoggedInFragment : Fragment(R.layout.fragment_my_account_logged_in) {
         view.findViewById<TextView>(R.id.username_logged_in).text = Prefs.username
 
         view.findViewById<Button>(R.id.privacy_policy_button).setOnClickListener { openAnkiDroidPrivacyPolicy() }
-        view.findViewById<Button>(R.id.logout_button).setOnClickListener { logout() }
+        view.findViewById<Button>(R.id.logout_button).apply {
+            text = TR.sentenceCase.logOut
+            setOnClickListener { logout() }
+        }
         view.findViewById<Button>(R.id.remove_account_button).setOnClickListener { openRemoveAccountScreen() }
 
         loggedInLogo = view.findViewById(R.id.login_logo)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/account/LoginFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/account/LoginFragment.kt
@@ -46,6 +46,7 @@ import com.ichi2.anki.account.AccountActivity.Companion.START_FROM_DECKPICKER
 import com.ichi2.anki.dialogs.help.HelpDialog
 import com.ichi2.anki.getEndpoint
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.utils.ext.isCompactWidth
 import com.ichi2.anki.utils.ext.showDialogFragment
@@ -97,6 +98,7 @@ class LoginFragment : Fragment(R.layout.fragment_my_account) {
         password = view.findViewById(R.id.password)
         loginLogo = view.findViewById(R.id.login_logo)
         loginButton = view.findViewById(R.id.login_button)
+        loginButton.text = TR.sentenceCase.logIn
 
         initListeners()
         initObservers()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/DeckPickerMenuContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/DeckPickerMenuContentProvider.kt
@@ -38,7 +38,7 @@ class DeckPickerMenuContentProvider(
     override fun populateMenu(menu: Menu) {
         val options = createOptionsList()
         options.forEachIndexed { index, option ->
-            menu.add(0, index, index, option.optionName)
+            menu.add(0, index, index, option.label(deckPicker))
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
@@ -22,6 +22,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
@@ -29,6 +30,7 @@ import com.ichi2.anki.compat.requireSerializableCompat
 import com.ichi2.anki.contextmenu.DeckPickerMenuContentProvider
 import com.ichi2.anki.dialogs.DeckPickerContextMenu.DeckPickerContextMenuOption
 import com.ichi2.anki.libanki.DeckId
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.ext.requireLong
 import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.utils.title
@@ -80,21 +82,23 @@ class DeckPickerContextMenu : AnalyticsDialogFragment() {
         ;
 
         fun label(context: Context): String =
-            when (this) {
-                RENAME_DECK -> context.getString(R.string.rename_deck)
-                DECK_OPTIONS -> context.getString(R.string.menu__deck_options)
-                CUSTOM_STUDY -> context.getString(R.string.custom_study)
-                DELETE_DECK -> context.getString(R.string.contextmenu_deckpicker_delete_deck)
-                EXPORT_DECK -> context.getString(R.string.export_deck)
-                UNBURY -> context.getString(R.string.unbury)
-                CUSTOM_STUDY_REBUILD -> context.getString(R.string.rebuild_cram_label)
-                CUSTOM_STUDY_EMPTY -> context.getString(R.string.empty_cram_label)
-                CREATE_SUBDECK -> context.getString(R.string.create_subdeck)
-                CREATE_SHORTCUT -> context.getString(R.string.create_shortcut)
-                BROWSE_CARDS -> context.getString(R.string.browse_cards)
-                EDIT_DESCRIPTION -> context.getString(R.string.edit_deck_description)
-                ADD_CARD -> context.getString(R.string.menu_add)
-                SCHEDULE_REMINDERS -> context.getString(R.string.schedule_reminders_do_not_translate)
+            with(context) {
+                when (this@DeckPickerContextMenuOption) {
+                    RENAME_DECK -> TR.sentenceCase.renameDeck
+                    DECK_OPTIONS -> TR.sentenceCase.deckOptions
+                    CUSTOM_STUDY -> TR.sentenceCase.customStudy
+                    DELETE_DECK -> TR.sentenceCase.deleteDeck
+                    EXPORT_DECK -> getString(R.string.export_deck)
+                    UNBURY -> TR.studyingUnbury()
+                    CUSTOM_STUDY_REBUILD -> TR.actionsRebuild()
+                    CUSTOM_STUDY_EMPTY -> getString(R.string.empty_cram_label)
+                    CREATE_SUBDECK -> getString(R.string.create_subdeck)
+                    CREATE_SHORTCUT -> getString(R.string.create_shortcut)
+                    BROWSE_CARDS -> getString(R.string.browse_cards)
+                    EDIT_DESCRIPTION -> getString(R.string.edit_deck_description)
+                    ADD_CARD -> TR.actionsAdd()
+                    SCHEDULE_REMINDERS -> getString(R.string.schedule_reminders_do_not_translate)
+                }
             }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
@@ -16,8 +16,8 @@
 package com.ichi2.anki.dialogs
 
 import android.app.Dialog
+import android.content.Context
 import android.os.Bundle
-import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.FragmentActivity
@@ -45,7 +45,7 @@ class DeckPickerContextMenu : AnalyticsDialogFragment() {
             .Builder(requireActivity())
             .title(text = requireArguments().getString(ARG_DECK_NAME))
             .setItems(
-                options.map { resources.getString(it.optionName) }.toTypedArray(),
+                options.map { it.label(requireContext()) }.toTypedArray(),
             ) { _, index: Int ->
                 parentFragmentManager.setDeckPickerContextMenuResult(
                     DeckPickerContextMenuResult(
@@ -62,23 +62,40 @@ class DeckPickerContextMenu : AnalyticsDialogFragment() {
             requireArguments().getBoolean(ARG_DECK_HAS_BURIED_IN_DECK),
         )
 
-    enum class DeckPickerContextMenuOption(
-        @StringRes val optionName: Int,
-    ) {
-        RENAME_DECK(R.string.rename_deck),
-        DECK_OPTIONS(R.string.menu__deck_options),
-        CUSTOM_STUDY(R.string.custom_study),
-        DELETE_DECK(R.string.contextmenu_deckpicker_delete_deck),
-        EXPORT_DECK(R.string.export_deck),
-        UNBURY(R.string.unbury),
-        CUSTOM_STUDY_REBUILD(R.string.rebuild_cram_label),
-        CUSTOM_STUDY_EMPTY(R.string.empty_cram_label),
-        CREATE_SUBDECK(R.string.create_subdeck),
-        CREATE_SHORTCUT(R.string.create_shortcut),
-        BROWSE_CARDS(R.string.browse_cards),
-        EDIT_DESCRIPTION(R.string.edit_deck_description),
-        ADD_CARD(R.string.menu_add),
-        SCHEDULE_REMINDERS(R.string.schedule_reminders_do_not_translate),
+    enum class DeckPickerContextMenuOption {
+        RENAME_DECK,
+        DECK_OPTIONS,
+        CUSTOM_STUDY,
+        DELETE_DECK,
+        EXPORT_DECK,
+        UNBURY,
+        CUSTOM_STUDY_REBUILD,
+        CUSTOM_STUDY_EMPTY,
+        CREATE_SUBDECK,
+        CREATE_SHORTCUT,
+        BROWSE_CARDS,
+        EDIT_DESCRIPTION,
+        ADD_CARD,
+        SCHEDULE_REMINDERS,
+        ;
+
+        fun label(context: Context): String =
+            when (this) {
+                RENAME_DECK -> context.getString(R.string.rename_deck)
+                DECK_OPTIONS -> context.getString(R.string.menu__deck_options)
+                CUSTOM_STUDY -> context.getString(R.string.custom_study)
+                DELETE_DECK -> context.getString(R.string.contextmenu_deckpicker_delete_deck)
+                EXPORT_DECK -> context.getString(R.string.export_deck)
+                UNBURY -> context.getString(R.string.unbury)
+                CUSTOM_STUDY_REBUILD -> context.getString(R.string.rebuild_cram_label)
+                CUSTOM_STUDY_EMPTY -> context.getString(R.string.empty_cram_label)
+                CREATE_SUBDECK -> context.getString(R.string.create_subdeck)
+                CREATE_SHORTCUT -> context.getString(R.string.create_shortcut)
+                BROWSE_CARDS -> context.getString(R.string.browse_cards)
+                EDIT_DESCRIPTION -> context.getString(R.string.edit_deck_description)
+                ADD_CARD -> context.getString(R.string.menu_add)
+                SCHEDULE_REMINDERS -> context.getString(R.string.schedule_reminders_do_not_translate)
+            }
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
@@ -78,7 +78,7 @@ class SyncErrorDialog : AsyncDialogFragment() {
                 // User not logged in; take them to login screen
                 dialog
                     .setIcon(R.drawable.ic_sync_problem)
-                    .setPositiveButton(R.string.log_in) { _, _ ->
+                    .setPositiveButton(TR.sentenceCase.logIn) { _, _ ->
                         requireSyncErrorDialogListener().loginToSyncServer()
                     }.setNegativeButton(R.string.dialog_cancel) { _, _ -> }
                     .create()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
@@ -94,6 +94,9 @@ object SentenceCase {
     context(_: Fragment)
     val checkMediaAction get() = TR.mediaCheckCheckMediaAction().toSentenceCase(R.string.sentence_check_media)
 
+    context(_: Context)
+    val customStudy get() = TR.actionsCustomStudy().toSentenceCase(R.string.sentence_custom_study)
+
     context(_: Fragment)
     val customStudy get() = TR.actionsCustomStudy().toSentenceCase(R.string.sentence_custom_study)
 
@@ -136,6 +139,15 @@ object SentenceCase {
 
     context(_: Context)
     val backTemplate get() = TR.cardTemplatesBackTemplate().toSentenceCase(R.string.sentence_back_template)
+
+    context(_: Context)
+    val renameDeck get() = TR.actionsRenameDeck().toSentenceCase(R.string.sentence_rename_deck)
+
+    context(_: Context)
+    val deckOptions get() = TR.deckConfigTitle().toSentenceCase(R.string.sentence_deck_options)
+
+    context(_: Context)
+    val deleteDeck get() = TR.decksDeleteDeck().toSentenceCase(R.string.sentence_delete_deck)
 }
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
@@ -130,6 +130,12 @@ object SentenceCase {
 
     context(_: Fragment)
     val findAndReplace get() = TR.browsingFindAndReplace().toSentenceCase(R.string.sentence_find_and_replace)
+
+    context(_: Context)
+    val frontTemplate get() = TR.cardTemplatesFrontTemplate().toSentenceCase(R.string.sentence_front_template)
+
+    context(_: Context)
+    val backTemplate get() = TR.cardTemplatesBackTemplate().toSentenceCase(R.string.sentence_back_template)
 }
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
@@ -148,6 +148,18 @@ object SentenceCase {
 
     context(_: Context)
     val deleteDeck get() = TR.decksDeleteDeck().toSentenceCase(R.string.sentence_delete_deck)
+
+    context(_: Context)
+    val logIn get() = TR.syncLogInButton().toSentenceCase(R.string.sentence_log_in)
+
+    context(_: Fragment)
+    val logIn get() = TR.syncLogInButton().toSentenceCase(R.string.sentence_log_in)
+
+    context(_: Context)
+    val logOut get() = TR.syncLogOutButton().toSentenceCase(R.string.sentence_log_out)
+
+    context(_: Fragment)
+    val logOut get() = TR.syncLogOutButton().toSentenceCase(R.string.sentence_log_out)
 }
 
 /**

--- a/AnkiDroid/src/main/res/layout/fragment_my_account.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_my_account.xml
@@ -2,6 +2,7 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -98,7 +99,7 @@
                     android:layout_height="wrap_content"
                     android:minWidth="200dp"
                     android:layout_gravity="center"
-                    android:text="@string/log_in"
+                    tools:text="Log in"
                     android:enabled="false"
                     android:layout_margin="@dimen/content_vertical_padding"/>
 

--- a/AnkiDroid/src/main/res/layout/fragment_my_account_logged_in.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_my_account_logged_in.xml
@@ -67,7 +67,7 @@
                     android:layout_height="wrap_content"
                     android:minWidth="200dp"
                     android:layout_gravity="center"
-                    android:text="@string/log_out"
+                    tools:text="Log out"
                     android:layout_margin="@dimen/content_vertical_padding"
                     />
 

--- a/AnkiDroid/src/main/res/menu-xlarge/deck_picker.xml
+++ b/AnkiDroid/src/main/res/menu-xlarge/deck_picker.xml
@@ -22,7 +22,7 @@
     <item
         android:id="@+id/action_deck_delete"
         android:icon="@drawable/ic_delete_white"
-        android:title="@string/contextmenu_deckpicker_delete_deck"
+        tools:title="Delete deck"
         app:showAsAction="always"/>
     <item
         android:id="@+id/action_undo"

--- a/AnkiDroid/src/main/res/menu/card_template_editor_navigation_bar_menu.xml
+++ b/AnkiDroid/src/main/res/menu/card_template_editor_navigation_bar_menu.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <item
         android:id="@+id/front_edit"
         android:icon="@drawable/ic_card_question"
@@ -11,5 +12,5 @@
     <item
         android:id="@+id/styling_edit"
         android:icon="@drawable/ic_css"
-        android:title="@string/card_template_editor_styling" />
+        tools:title="Styling" />
 </menu>

--- a/AnkiDroid/src/main/res/menu/study_options_fragment.xml
+++ b/AnkiDroid/src/main/res/menu/study_options_fragment.xml
@@ -1,5 +1,6 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:ankidroid="http://schemas.android.com/apk/res-auto">
+    xmlns:ankidroid="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
     <item
         android:id="@+id/action_schedule_reminders"
         android:title="@string/schedule_reminders_do_not_translate"
@@ -8,7 +9,7 @@
         ankidroid:showAsAction="always"/>
     <item
         android:id="@+id/action_rebuild"
-        android:title="@string/rebuild_cram_label"
+        tools:title="Rebuild"
         android:visibility = "gone"
         android:icon="@drawable/ic_refresh_white"
         ankidroid:showAsAction="ifRoom"/>
@@ -20,7 +21,7 @@
         ankidroid:showAsAction="ifRoom"/>
     <item
         android:id="@+id/action_custom_study"
-        android:title="@string/custom_study"
+        tools:title="Custom study"
         android:icon="@drawable/ic_build_white"
         ankidroid:showAsAction="ifRoom"/>
     <!-- the title for the following option will be set dynamically -->
@@ -31,6 +32,6 @@
         ankidroid:showAsAction="always"/>
     <item
         android:id="@+id/action_unbury"
-        android:title="@string/unbury"
+        tools:title="Unbury"
         android:visibility = "gone"/>
 </menu>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -132,9 +132,6 @@
 
     <!-- Card template editor -->
     <string name="title_activity_template_editor">Card types</string>
-    <string name="card_template_editor_front">Front template</string>
-    <string name="card_template_editor_back">Back template</string>
-    <string name="card_template_editor_styling" maxLength="28">Styling</string>
     <string name="card_template_editor_menu_card_browser_appearance" maxLength="28">Card Browser Appearance</string>
     <string name="card_template_editor_deck_override" maxLength="28">Deck override</string>
     <string name="card_template_editor_insert_field" maxLength="28">Insert field</string>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -73,7 +73,6 @@
     <!-- flashcard_portrait.xml -->
     <string name="undo_action_whiteboard_last_stroke" comment="One of the display patterns of 'Undo' item on the action menu in the Study Screen. It is shown as the title of the item when the whiteboard (handwriting) feature is enabled and visible and has any strokes (handwritten lines)" maxLength="28">Undo stroke</string>
     <string name="move_all_to_deck">Move all to deck</string>
-    <string name="unbury" maxLength="28">Unbury</string>
     <string name="rename_deck" maxLength="28">Rename deck</string>
     <string name="create_shortcut">Create shortcut</string>
     <string name="browse_cards">Browse cards</string>
@@ -109,7 +108,6 @@
     of the permissions/app info screen will differ between devices. -->
     <string name="startup_no_storage_permission">Please grant AnkiDroid the ‘Storage’ permission to continue</string>
     <string name="rebuild_filtered_deck">Rebuilding filtered deck…</string>
-    <string name="rebuild_cram_label" maxLength="28">Rebuild</string>
     <string name="empty_cram_label" maxLength="28">Empty</string>
     <string name="create_subdeck">Create subdeck</string>
     <string name="empty_filtered_deck">Emptying filtered deck…</string>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -187,7 +187,6 @@
     <string name="menu__deck_options" maxLength="28">Deck options</string>
     <string name="menu__study_options" comment="Menu item that opens options for a Filtered deck (aka Cram deck, aka Custom study)">Study options</string>
     <string name="select_tts" maxLength="28">Set TTS language</string>
-    <string name="custom_study" maxLength="28">Custom study</string>
     <string name="dyn_deck_desc">This is a special deck for studying outside of the normal schedule. Cards will be automatically returned to their original decks after you review them. Deleting this deck from the deck list will return all remaining cards to their original deck.</string>
     <string name="tag_editor_add_feedback">Touch “%2$s” to confirm adding “%1$s”</string>
     <string name="tag_editor_add_feedback_existing">Existing tag “%1$s” selected</string>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -19,7 +19,6 @@
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 --><resources xmlns:tools="http://schemas.android.com/tools">
     <string name="check_db_warning">This may take a long time. Proceed?</string>
-    <string name="contextmenu_deckpicker_delete_deck" maxLength="28">Delete deck</string>
     <string name="delete_deck_title">Delete deck?</string>
     <plurals name="delete_deck_message">
         <item quantity="one">Delete all cards in %1$s? It contains %2$d card</item>

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -33,12 +33,10 @@
     <!-- MyAccount.kt -->
     <string name="username">Email address</string>
     <string name="password">Password</string>
-    <string name="log_in">Log in</string>
     <string name="sign_up_description">Don’t have an AnkiWeb account? It’s free!</string>
     <string name="sign_up_not_affiliated">Note: AnkiWeb is not affiliated with AnkiDroid</string>
     <string name="sign_up">Sign up</string>
     <string name="logged_as">Logged in as</string>
-    <string name="log_out">Log out</string>
     <string name="reset_password">Reset password</string>
     <string name="lost_mail_instructions">Forgot Email?</string>
     <string name="sign_in">Signing in</string>

--- a/AnkiDroid/src/main/res/values/sentence-case.xml
+++ b/AnkiDroid/src/main/res/values/sentence-case.xml
@@ -66,4 +66,6 @@ undoActionUndone()
     <string name="sentence_rename_deck">Rename deck</string>
     <string name="sentence_deck_options">Deck options</string>
     <string name="sentence_delete_deck">Delete deck</string>
+    <string name="sentence_log_in">Log in</string>
+    <string name="sentence_log_out">Log out</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/sentence-case.xml
+++ b/AnkiDroid/src/main/res/values/sentence-case.xml
@@ -61,4 +61,6 @@ undoActionUndone()
     <string name="sentence_restore_to_default">Restore to default</string>
     <string name="sentence_check_db">Check database</string>
     <string name="sentence_check_media">Check media</string>
+    <string name="sentence_front_template">Front template</string>
+    <string name="sentence_back_template">Back template</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/sentence-case.xml
+++ b/AnkiDroid/src/main/res/values/sentence-case.xml
@@ -63,4 +63,7 @@ undoActionUndone()
     <string name="sentence_check_media">Check media</string>
     <string name="sentence_front_template">Front template</string>
     <string name="sentence_back_template">Back template</string>
+    <string name="sentence_rename_deck">Rename deck</string>
+    <string name="sentence_deck_options">Deck options</string>
+    <string name="sentence_delete_deck">Delete deck</string>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
@@ -275,7 +275,6 @@ class TranslationTest : RobolectricTest() {
                 // TR.actionsPreview()
                 // TR.cardTemplatesPreviewBox()
                 "Question", // R.string.card_side_question | TR.browsingQuestion()
-                "Rebuild", // R.string.rebuild_cram_label | TR.actionsRebuild()
                 "Record audio", // R.string.multimedia_editor_popup_audio | TR.editingRecordAudio()
                 "Redo", // R.string.redo | TR.undoRedo()
                 "Rename", // R.string.rename | TR.actionsRename()
@@ -311,7 +310,6 @@ class TranslationTest : RobolectricTest() {
                 // TR.browsingSidebarTags()
                 "Theme", // R.string.app_theme | TR.preferencesTheme()
                 "Timebox time limit", // R.string.time_limit | TR.preferencesTimeboxTimeLimit()
-                "Unbury", // R.string.unbury | TR.studyingUnbury()
                 "Undo", // R.string.undo | TR.undoUndo()
             )
 
@@ -357,11 +355,7 @@ class TranslationTest : RobolectricTest() {
                 // TR.aboutCopyDebugInfo()
                 // TR.errorsCopyDebugInfoButton()
                 "Create deck", // R.string.new_deck | TR.decksCreateDeck()
-                "Custom study", // R.string.custom_study
-                // TR.actionsCustomStudy()
-                // TR.schedulingCustomStudy()
                 "Deck options", // R.string.menu__deck_options | TR.deckConfigTitle()
-                "Delete deck", // R.string.contextmenu_deckpicker_delete_deck | TR.decksDeleteDeck()
                 "Delete note", // R.string.menu_delete_note | TR.studyingDeleteNote()
                 "Empty cards", // R.string.empty_cards
                 // TR.actionsEmptyCards()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
@@ -302,7 +302,6 @@ class TranslationTest : RobolectricTest() {
                 "Show remaining card count", // R.string.show_progress_summ | TR.preferencesShowRemainingCardCount()
                 "Statistics", // R.string.statistics | TR.statisticsTitle()
                 "Study", // R.string.studyoptions_start | TR.decksStudy()
-                "Styling", // R.string.card_template_editor_styling | TR.cardTemplatesTemplateStyling()
                 "Suspend", // R.string.menu_suspend | TR.studyingSuspend()
                 "Sync", // R.string.button_sync, R.string.pref_cat_sync
                 // TR.qtMiscSync()
@@ -347,7 +346,6 @@ class TranslationTest : RobolectricTest() {
                 "Answer buttons", // R.string.answer_buttons | TR.statisticsAnswerButtonsTitle()
                 "Answer good", // R.string.answer_good | TR.deckConfigAnswerGood()
                 "Answer hard", // R.string.answer_hard | TR.deckConfigAnswerHard()
-                "Back template", // R.string.card_template_editor_back | TR.cardTemplatesBackTemplate()
                 "Blank", // R.string.reviewer_tts_cloze_spoken_replacement | TR.cardTemplatesBlank()
                 "Browser appearance", // R.string.card_template_browser_appearance_title | TR.browsingBrowserAppearance()
                 "Browser options", // R.string.browser_options_dialog_heading | TR.browsingBrowserOptions()
@@ -370,7 +368,6 @@ class TranslationTest : RobolectricTest() {
                 // TR.emptyCardsWindowTitle()
                 "Flag card", // R.string.menu_flag_card | TR.studyingFlagCard()
                 "Follow system", // R.string.theme_follow_system | TR.preferencesThemeFollowSystem()
-                "Front template", // R.string.card_template_editor_front | TR.cardTemplatesFrontTemplate()
                 "Log in", // R.string.log_in | TR.syncLogInButton()
                 "Log out", // R.string.log_out | TR.syncLogOutButton()
                 "Manage note types", // R.string.model_browser_label

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
@@ -362,8 +362,6 @@ class TranslationTest : RobolectricTest() {
                 // TR.emptyCardsWindowTitle()
                 "Flag card", // R.string.menu_flag_card | TR.studyingFlagCard()
                 "Follow system", // R.string.theme_follow_system | TR.preferencesThemeFollowSystem()
-                "Log in", // R.string.log_in | TR.syncLogInButton()
-                "Log out", // R.string.log_out | TR.syncLogOutButton()
                 "Manage note types", // R.string.model_browser_label
                 // TR.browsingManageNoteTypes()
                 // TR.qtMiscManageNoteTypes()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
@@ -25,10 +25,12 @@ import androidx.fragment.app.testing.FragmentScenario.Companion.launch
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.IntroductionActivity
 import com.ichi2.anki.R
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.preferences.sharedPrefs
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.testutils.BackupManagerTestUtilities.setupSpaceForBackup
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert
@@ -109,12 +111,15 @@ class DeckPickerContextMenuTest {
             fragment.assertOptionPresent(R.string.menu__deck_options)
             fragment.assertOptionPresent(R.string.export_deck)
             fragment.assertOptionPresent(R.string.create_shortcut)
-            fragment.assertOptionPresent(R.string.contextmenu_deckpicker_delete_deck)
+            fragment.assertOptionPresent(with(fragment.requireContext()) { TR.sentenceCase.deleteDeck })
         }
     }
 
     private fun DeckPickerContextMenu.assertOptionPresent(optionStringRes: Int) {
-        val optionTitle = getString(optionStringRes)
+        assertOptionPresent(getString(optionStringRes))
+    }
+
+    private fun DeckPickerContextMenu.assertOptionPresent(optionTitle: String) {
         assertTrue(
             foundOptions().contains(optionTitle),
             "'$optionTitle' should be present",
@@ -129,7 +134,7 @@ class DeckPickerContextMenuTest {
             MatcherAssert.assertThat(
                 "'Delete deck' should be last item in the menu",
                 fragment.foundOptions().last(),
-                equalTo(fragment.getString(R.string.contextmenu_deckpicker_delete_deck)),
+                equalTo(with(fragment.requireContext()) { TR.sentenceCase.deleteDeck }),
             )
         }
     }
@@ -142,7 +147,7 @@ class DeckPickerContextMenuTest {
                 "'Empty' should be present when deck is dynamic",
             )
             assertTrue(
-                fragment.foundOptions().contains(fragment.getString(R.string.rebuild_cram_label)),
+                fragment.foundOptions().contains(TR.actionsRebuild()),
                 "'Rebuild' should be present when deck is dynamic",
             )
         }
@@ -162,7 +167,7 @@ class DeckPickerContextMenuTest {
     fun `Shows option to unbury if deck has buried cards`() {
         launch(withArguments(hasBuriedCards = true)).onFragment { fragment ->
             assertTrue(
-                fragment.foundOptions().contains(fragment.getString(R.string.unbury)),
+                fragment.foundOptions().contains(TR.studyingUnbury()),
                 "'Unbury' should be present when deck has buried cards",
             )
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
@@ -68,6 +68,8 @@ class SentenceCaseTest : RobolectricTest() {
                 assertThat(TR.sentenceCase.customStudy, equalTo("Custom study"))
                 assertThat(TR.sentenceCase.deckOptions, equalTo("Deck options"))
                 assertThat(TR.sentenceCase.deleteDeck, equalTo("Delete deck"))
+                assertThat(TR.sentenceCase.logIn, equalTo("Log in"))
+                assertThat(TR.sentenceCase.logOut, equalTo("Log out"))
 
                 assertThat("syncMediaLogTitle", TR.syncMediaLogTitle(), equalTo("Media Sync Log"))
                 assertThat(TR.sentenceCase.mediaSyncLog, equalTo("Media sync log"))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
@@ -62,6 +62,8 @@ class SentenceCaseTest : RobolectricTest() {
                 assertThat(TR.sentenceCase.checkDatabase, equalTo("Check database"))
                 assertThat(TR.sentenceCase.checkMediaTitle, equalTo("Check media"))
                 assertThat(TR.sentenceCase.checkMediaAction, equalTo("Check media"))
+                assertThat(TR.sentenceCase.frontTemplate, equalTo("Front template"))
+                assertThat(TR.sentenceCase.backTemplate, equalTo("Back template"))
 
                 assertThat("syncMediaLogTitle", TR.syncMediaLogTitle(), equalTo("Media Sync Log"))
                 assertThat(TR.sentenceCase.mediaSyncLog, equalTo("Media sync log"))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
@@ -64,6 +64,10 @@ class SentenceCaseTest : RobolectricTest() {
                 assertThat(TR.sentenceCase.checkMediaAction, equalTo("Check media"))
                 assertThat(TR.sentenceCase.frontTemplate, equalTo("Front template"))
                 assertThat(TR.sentenceCase.backTemplate, equalTo("Back template"))
+                assertThat(TR.sentenceCase.renameDeck, equalTo("Rename deck"))
+                assertThat(TR.sentenceCase.customStudy, equalTo("Custom study"))
+                assertThat(TR.sentenceCase.deckOptions, equalTo("Deck options"))
+                assertThat(TR.sentenceCase.deleteDeck, equalTo("Delete deck"))
 
                 assertThat("syncMediaLogTitle", TR.syncMediaLogTitle(), equalTo("Media Sync Log"))
                 assertThat(TR.sentenceCase.mediaSyncLog, equalTo("Media sync log"))


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - 95% of this, with re-prompting to add `with(context)` for brevity

## Purpose / Description
Someone lovely came into the Discord asking about doing translations, and in return I wanted to make translators lives a little easier

## How Has This Been Tested?
* API 37 phone emulator
  * Opened Deck Picker
  * Opened Study Options & tested menu
  *   * Login/logout 

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)