### PR TITLE
security: Pin GitHub Actions by SHA

### DIFF
--- a/.github/workflows/assignees.yml
+++ b/.github/workflows/assignees.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,7 +62,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -72,7 +72,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -86,7 +86,7 @@ jobs:
     # AnkiDroid requires JDK21+ to build, current runners default to 17
     - name: Configure JDK
       if: matrix.language == 'java-kotlin'
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: "temurin"
         java-version: "21"  # also change jitpack.yml
@@ -106,6 +106,6 @@ jobs:
         ./gradlew --stop
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/compare_apk_size.yml
+++ b/.github/workflows/compare_apk_size.yml
@@ -30,7 +30,7 @@ jobs:
       KEYALIAS: nrkeystorealias
     steps:
       - name: Configure JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: "temurin"
           java-version: "21"
@@ -43,13 +43,13 @@ jobs:
         shell: bash
 
       - name: Checkout PR
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           ref: 'refs/pull/${{ github.event.inputs.prNumber }}/head'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         timeout-minutes: 5
         with:
           # Use open source provider: https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#basic-caching
@@ -58,7 +58,7 @@ jobs:
 
       - name: Assemble PR APK
         # This makes sure we fetch gradle network resources with a retry
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 10
           retry_wait_seconds: 60
@@ -75,7 +75,7 @@ jobs:
 
       - name: Assemble Baseline APK
         # This makes sure we fetch gradle network resources with a retry
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 10
           retry_wait_seconds: 60
@@ -86,7 +86,7 @@ jobs:
         run: echo OLDSIZE=`ls -lrt AnkiDroid/build/outputs/apk/play/release/AnkiDroid-play-arm64-v8a-release.apk | awk '{print $5}'` >> $GITHUB_ENV
 
       - name: Post comment
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             var inputs = ${{ toJSON(inputs) }}

--- a/.github/workflows/conflict.yaml
+++ b/.github/workflows/conflict.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Check for conflicts and label conflict
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             // Helper function for retrying GitHub API calls

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/github-script@v9
+    - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           let removeLabelsList = [
@@ -78,7 +78,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const I18N_FILES = [
@@ -205,7 +205,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const creator = context.payload.sender.login
@@ -238,7 +238,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             await github.rest.issues.addLabels({

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,18 +22,18 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Configure JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: "temurin"
           java-version: "21"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         timeout-minutes: 5
         with:
           # Use open source provider: https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#basic-caching
@@ -45,7 +45,7 @@ jobs:
 
       - name: Warm Gradle Cache
         # This makes sure we fetch gradle network resources with a retry
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 10
           retry_wait_seconds: 60
@@ -67,7 +67,7 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
@@ -77,7 +77,7 @@ jobs:
         # npm install --location=global prettier
         # prettier --check AnkiDroid/**/*.js
       - name: Prettify AnkiDroid javascript code
-        uses: creyD/prettier_action@v4.6
+        uses: creyD/prettier_action@8c18391fdc98ed0d884c6345f03975edac71b8f0 # v4.6
         with:
           prettier_options: --check AnkiDroid/**/*.js
           dry: True

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-    - uses: actions/github-script@v9
+    - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           await github.rest.issues.update({

--- a/.github/workflows/opencollective_notices.yml
+++ b/.github/workflows/opencollective_notices.yml
@@ -20,7 +20,7 @@ jobs:
             pull-requests: write
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/github-script@v9
+            - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
               with:
                   script: |
                       // First get the month we are working on and prepare our PR query range

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,16 +27,16 @@ jobs:
     timeout-minutes: 120
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         name: Gradle Cache
         with:
           path: ~/.gradle/caches
           key: gradle-${{ hashFiles('**/*.gradle*') }}-v1
 
       - name: Configure JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: "temurin"
           java-version: "21"
@@ -55,7 +55,7 @@ jobs:
           git remote set-url origin git@github.com:$GITHUB_REPOSITORY
         shell: bash
 
-      - uses: webfactory/ssh-agent@v0.10.0
+      - uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v10
+    - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Hello 👋, this issue has been opened for more than 3 months with no activity on it. If the issue is still here, please keep in mind that we need community support and help to fix it! Just comment something like _still searching for solutions_ and if you found one, please open a pull request! You have 7 days until this gets closed automatically'

--- a/.github/workflows/sync_translations.yml
+++ b/.github/workflows/sync_translations.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 50
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.MACHINE_ACCOUNT_PAT }}
           ref: 'main'
@@ -45,7 +45,7 @@ jobs:
 
       - name: Calculate seconds passed
         id: calc_time
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const lastRun = new Date(process.env.LATEST_RUN);
@@ -58,7 +58,7 @@ jobs:
         if: steps.calc_time.outputs.time_left > 0
         run: sleep ${{ steps.calc_time.outputs.time_left }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
       
@@ -109,7 +109,7 @@ jobs:
 
       - name: Create PR for strings changes if needed
         if: ${{ steps.tr_check.outputs.HAS_CHANGES }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.MACHINE_ACCOUNT_PAT }}
           script: |

--- a/.github/workflows/sync_translations.yml
+++ b/.github/workflows/sync_translations.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Calculate seconds passed
         id: calc_time
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const lastRun = new Date(process.env.LATEST_RUN);

--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -33,7 +33,7 @@ jobs:
       matrix: ${{ steps.build-matrix.outputs.result }}
     steps:
       - id: build-matrix
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             // by default, we will run one iteration
@@ -97,7 +97,7 @@ jobs:
       matrix: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: insightsengineering/disk-space-reclaimer@v1
+        uses: insightsengineering/disk-space-reclaimer@dae9fabcb8febe09f6585471948acf9dc9a57489 # v1.1.2
         with:
           tools-cache: false
           android: false
@@ -107,7 +107,7 @@ jobs:
           swap-storage: false
           docker-images: false
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 50
 
@@ -118,13 +118,13 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Configure JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: "temurin"
           java-version: "21"  # also change jitpack.yml
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         timeout-minutes: 5
         with:
           # Use open source provider: https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#basic-caching
@@ -138,7 +138,7 @@ jobs:
         # Repo limit is 10GB; branch caches are independent; branches may read default branch cache.
         # We don't want branches to evict main branch snapshot, so save on main, read-only all else
       - name: AVD cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: avd-cache
         with:
           path: |
@@ -150,7 +150,7 @@ jobs:
 
       - name: Warm Gradle Cache
         # This makes sure we fetch gradle network resources with a retry
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 15
           retry_wait_seconds: 60
@@ -161,7 +161,7 @@ jobs:
         # Only generate a snapshot for saving if we are on main branch with a cache miss
         # Comment the if out to generate snapshots on branch for performance testing
         if: "${{ github.event.inputs.clearCaches != '' || (steps.avd-cache.outputs.cache-hit != 'true' && github.ref == 'refs/heads/main') }}"
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
         with:
           api-level: ${{ matrix.api-level }}
           force-avd-creation: false
@@ -185,7 +185,7 @@ jobs:
         if: "${{ github.event.inputs.clearCaches != '' || (steps.avd-cache.outputs.cache-hit != 'true' && github.ref == 'refs/heads/main') }}"
         env:
           FIRST_BOOT_DELAY: ${{ matrix.first-boot-delay }}
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
         with:
           api-level: ${{ matrix.api-level }}
           force-avd-creation: false
@@ -205,7 +205,7 @@ jobs:
             echo "First boot warmup completed."
 
       - name: Run Emulator Tests
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
         timeout-minutes: 30
         with:
           api-level: ${{ matrix.api-level }}
@@ -224,27 +224,27 @@ jobs:
             ./gradlew uninstallAll jacocoAndroidTestReport --daemon
 
       - name: Upload Test Report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: ${{ matrix.api-level }}-${{ matrix.arch }}-${{matrix.target}}-${{matrix.first-boot-delay}}-${{matrix.iteration}}-jacocoAndroidTestReport
           path: ~/work/Anki-Android/Anki-Android/AnkiDroid/build/reports/jacoco/
 
       - name: Upload Emulator Log
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: ${{ matrix.api-level }}-${{ matrix.arch }}-${{matrix.target}}-${{matrix.first-boot-delay}}-${{matrix.iteration}}-adb_logs
           path: adb-log.txt
 
       - name: Upload Emulator Screen Record
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: ${{ matrix.api-level }}-${{ matrix.arch }}-${{matrix.target}}-${{matrix.first-boot-delay}}-${{matrix.iteration}}-adb_video
           path: video.webm
 
-      - uses: codecov/codecov-action@v6
+      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           verbose: true
           fail_ci_if_error: ${{ github.repository == 'ankidroid/Anki-Android' }} # optional (default = false)

--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -48,7 +48,7 @@ jobs:
       matrix: ${{ steps.build-matrix.outputs.result }}
     steps:
       - id: build-matrix
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             // by default, we will include all 3 platforms we test on
@@ -121,25 +121,25 @@ jobs:
     #  CODACY_TOKEN: ${{ secrets.CODACY_TOKEN }}
     steps:
       - name: Configure Windows Pagefile
-        uses: al-cheb/configure-pagefile-action@v1.5
+        uses: al-cheb/configure-pagefile-action@9b6da52fb72a3c6147c1aad2df22d8d905681adc # v1.5
         if: contains(matrix.os, 'windows')
         with:
           minimum-size: 8GB
           maximum-size: 12GB
           disk-root: "C:"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 50
 
       - name: Configure JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: "temurin"
           java-version: "21"  # also change jitpack.yml
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         timeout-minutes: 10
         with:
           # Use open source provider: https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#basic-caching
@@ -150,7 +150,7 @@ jobs:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       - name: Gradle Dependency Download
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 10
           retry_wait_seconds: 60
@@ -175,7 +175,7 @@ jobs:
         # cancelled() handles test timeouts
         # remove when test timeouts cause a failure()
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: logcat-${{ matrix.name }}-${{ matrix.iteration }}
           # look for the `<system-out>` element in the XML files in `test-results`
@@ -193,7 +193,7 @@ jobs:
         if: contains(matrix.os, 'windows')
         run: ./gradlew --stop
 
-      - uses: codecov/codecov-action@v6
+      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           verbose: true
           fail_ci_if_error: ${{ github.repository == 'ankidroid/Anki-Android' }} # optional (default = false)


### PR DESCRIPTION
> [!WARNING]
> This stops Dependabot Alerts from working

> [!NOTE]
> Assisted-by: Claude Opus 4.7 
> only shell script. Updates applied by hand due to the security critical nature of the change

## Purpose / Description


Pinned SHAs defend against action repo compromises

The downside is readability, lack of implicit security updates, and losing Dependabot alerts

`dependencies:` is upcoming, which will improve this feature

https://github.blog/news-insights/product-news/whats-coming-to-our-github-actions-2026-security-roadmap/

The syntax which dependabot understands is:

`- uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5`

## Fixes
* Fixes #21038

## Approach

Sources used:

* https://github.com/actions/cache/releases/tag/v5.0.5
* https://github.com/actions/checkout/releases/tag/v6.0.2
* https://github.com/actions/github-script/releases/tag/v9.0.0
* https://github.com/actions/setup-java/releases/tag/v5.2.0
* https://github.com/actions/setup-node/releases/tag/v6.4.0
* https://github.com/actions/stale/releases/tag/v10.2.0
* https://github.com/actions/upload-artifact/releases/tag/v7.0.1
* https://github.com/al-cheb/configure-pagefile-action/releases/tag/v1.5
* https://github.com/codecov/codecov-action/releases/tag/v6.0.0
* https://github.com/creyD/prettier_action/releases/tag/v4.6
* https://github.com/github/codeql-action/releases/tag/v4.35.4
* https://github.com/gradle/actions/releases/tag/v6.1.0
* https://github.com/insightsengineering/disk-space-reclaimer/releases/tag/v1.1.2
* https://github.com/nick-fields/retry/releases/tag/v4.0.0
* https://github.com/ReactiveCircus/android-emulator-runner/releases/tag/v2.37.0
* https://github.com/webfactory/ssh-agent/releases/tag/v0.10.0

For each source, replace the associated action with the exact version tag, and the SHA of the tag


## How Has This Been Tested?

The list of SHAs were be obtained with the below:

```
sha() {
  s=$(GH_PAGER='' gh api "repos/$1/commits/$2" --jq .sha)
  printf '%-40s %s\n' "$1" "$s"
}

sha actions/cache v5
sha actions/checkout v6
sha actions/github-script v9
sha actions/setup-java v5
sha actions/setup-node v6
sha actions/stale v10
sha actions/upload-artifact v7
sha al-cheb/configure-pagefile-action v1.5
sha codecov/codecov-action v6
sha creyD/prettier_action v4.6
sha github/codeql-action v4.35.4
sha gradle/actions v6
sha insightsengineering/disk-space-reclaimer v1
sha nick-fields/retry v4
sha reactivecircus/android-emulator-runner v2
sha webfactory/ssh-agent v0.10.0
```

```
actions/cache                            27d5ce7f107fe9357f9df03efb73ab90386fccae
actions/checkout                         de0fac2e4500dabe0009e67214ff5f5447ce83dd
actions/github-script                    3a2844b7e9c422d3c10d287c895573f7108da1b3
actions/setup-java                       be666c2fcd27ec809703dec50e508c2fdc7f6654
actions/setup-node                       48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
actions/stale                            b5d41d4e1d5dceea10e7104786b73624c18a190f
actions/upload-artifact                  043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
al-cheb/configure-pagefile-action        9b6da52fb72a3c6147c1aad2df22d8d905681adc
codecov/codecov-action                   57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
creyD/prettier_action                    8c18391fdc98ed0d884c6345f03975edac71b8f0
github/codeql-action                     68bde559dea0fdcac2102bfdf6230c5f70eb485e
gradle/actions                           50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
insightsengineering/disk-space-reclaimer dae9fabcb8febe09f6585471948acf9dc9a57489
nick-fields/retry                        ad984534de44a9489a53aefd81eb77f87c70dc60
reactivecircus/android-emulator-runner   e89f39f1abbbd05b1113a29cf4db69e7540cae5a
webfactory/ssh-agent                     e83874834305fe9a4a2997156cb26c5de65a8555
```

## Learning

https://github.blog/changelog/2022-10-31-dependabot-now-updates-comments-in-github-actions-workflows-referencing-action-versions/

> `- uses: actions/checkout@01aecc # v2.1.0`

-- https://redirect.github.com/dependabot/dependabot-core/pull/5951

https://github.blog/news-insights/product-news/whats-coming-to-our-github-actions-2026-security-roadmap/

https://docs.github.com/en/actions/reference/security/secure-use#monitoring-the-actions-in-your-workflows - dependabot alerts issue

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)