### PR TITLE
fix: menu items drag

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserColumnSelectionAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserColumnSelectionAdapter.kt
@@ -28,7 +28,7 @@ import com.ichi2.anki.browser.BrowserColumnSelectionRecyclerItem.UsageItem
 import com.ichi2.anki.browser.ColumnUsage.AVAILABLE
 import com.ichi2.anki.databinding.ItemBrowserColumnsEntryBinding
 import com.ichi2.anki.databinding.ItemBrowserColumnsHeadingBinding
-import java.util.Collections
+import com.ichi2.anki.utils.ext.swapPositions
 
 class BrowserColumnSelectionAdapter(
     val items: MutableList<BrowserColumnSelectionRecyclerItem>,
@@ -202,7 +202,7 @@ open class BrowserColumnSelectionTouchHelperCallback(
         // `Available` should always be the first element, so don't allow moving above it
         if (toPosition == 0) return false
 
-        Collections.swap(items, fromPosition, toPosition)
+        items.swapPositions(fromPosition, toPosition)
         recyclerView.adapter?.notifyItemMoved(fromPosition, toPosition)
         return true
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ReviewerMenuSettingsAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ReviewerMenuSettingsAdapter.kt
@@ -37,7 +37,7 @@ import com.ichi2.anki.databinding.ItemReviewerMenuDisplayTypeBinding
  * @see ReviewerMenuSettingsRecyclerItem
  */
 class ReviewerMenuSettingsAdapter(
-    private val items: List<ReviewerMenuSettingsRecyclerItem>,
+    private val items: MutableList<ReviewerMenuSettingsRecyclerItem>,
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     override fun onCreateViewHolder(
         parent: ViewGroup,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ReviewerMenuSettingsAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ReviewerMenuSettingsAdapter.kt
@@ -22,6 +22,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.R
 import com.ichi2.anki.databinding.ItemReviewerMenuBinding
 import com.ichi2.anki.databinding.ItemReviewerMenuDisplayTypeBinding
+import java.util.Objects
 
 /**
  * Provides bindings from menu items and display types (headings) to [RecyclerView] views
@@ -39,6 +40,10 @@ import com.ichi2.anki.databinding.ItemReviewerMenuDisplayTypeBinding
 class ReviewerMenuSettingsAdapter(
     private val items: MutableList<ReviewerMenuSettingsRecyclerItem>,
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+    init {
+        setHasStableIds(true)
+    }
+
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int,
@@ -71,6 +76,11 @@ class ReviewerMenuSettingsAdapter(
     override fun getItemCount(): Int = items.size
 
     override fun getItemViewType(position: Int): Int = items[position].viewType
+
+    override fun getItemId(position: Int): Long {
+        val item = items[position]
+        return Objects.hash(item.viewType, item).toLong()
+    }
 
     private var onDragHandleTouchedListener: ((RecyclerView.ViewHolder) -> Unit)? = null
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ReviewerMenuSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ReviewerMenuSettingsFragment.kt
@@ -59,7 +59,7 @@ class ReviewerMenuSettingsFragment :
             listOf(ReviewerMenuSettingsRecyclerItem.DisplayType(displayType)) +
                 menuItems.getValue(displayType).map { ReviewerMenuSettingsRecyclerItem.Action(it) }
 
-        val recyclerViewItems = MenuDisplayType.entries.flatMap { section(it) }
+        val recyclerViewItems = MenuDisplayType.entries.flatMap { section(it) }.toMutableList()
 
         val callback = ReviewerMenuSettingsTouchHelperCallback(recyclerViewItems)
         callback.setOnClearViewListener(this)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ReviewerMenuSettingsTouchHelperCallback.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ReviewerMenuSettingsTouchHelperCallback.kt
@@ -17,7 +17,7 @@ package com.ichi2.anki.preferences.reviewer
 
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView
-import java.util.Collections
+import com.ichi2.anki.utils.ext.swapPositions
 
 /**
  * A [ItemTouchHelper.Callback] for the [ReviewerMenuSettingsAdapter].
@@ -29,7 +29,7 @@ import java.util.Collections
  * (see [clearView]).
  */
 class ReviewerMenuSettingsTouchHelperCallback(
-    private val items: List<ReviewerMenuSettingsRecyclerItem>,
+    private val items: MutableList<ReviewerMenuSettingsRecyclerItem>,
 ) : ItemTouchHelper.Callback() {
     private val movementFlags = makeMovementFlags(ItemTouchHelper.UP or ItemTouchHelper.DOWN, 0)
 
@@ -54,7 +54,7 @@ class ReviewerMenuSettingsTouchHelperCallback(
         // `Always show` should always be the first element, so don't allow moving above it
         if (toPosition == 0) return false
 
-        Collections.swap(items, fromPosition, toPosition)
+        items.swapPositions(fromPosition, toPosition)
         recyclerView.adapter?.notifyItemMoved(fromPosition, toPosition)
         return true
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/MutableList.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/MutableList.kt
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 Brayan Oliveira <brayandso.dev@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+package com.ichi2.anki.utils.ext
+
+import java.util.Collections
+
+/**
+ * Moves an item within a MutableList by swapping adjacent elements. This is particularly
+ * optimized for [androidx.recyclerview.widget.ItemTouchHelper] drag-and-drop operations.
+ */
+fun <T> MutableList<T>.swapPositions(
+    fromPosition: Int,
+    toPosition: Int,
+) {
+    if (fromPosition < toPosition) {
+        for (i in fromPosition until toPosition) {
+            Collections.swap(this, i, i + 1)
+        }
+    } else {
+        for (i in fromPosition downTo toPosition + 1) {
+            Collections.swap(this, i, i - 1)
+        }
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

> [!NOTE]
> Assisted-by: Gemini 3.1 Pro - diagnostics

## Fixes

* Fixes #21041

## How Has This Been Tested?

Emulator 37

Dragged elements quickly on the reviewer menu settings. No visual bugs


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->