### PR TITLE
test: card side selection screenshot test

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CardSideSelectionDialogScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CardSideSelectionDialogScreenshotTest.kt
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 Brayan Oliveira <brayandso.dev@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+package com.ichi2.anki.dialogs
+
+import androidx.fragment.app.FragmentActivity
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.ScreenshotTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric.buildActivity
+
+@RunWith(AndroidJUnit4::class)
+class CardSideSelectionDialogScreenshotTest : ScreenshotTest() {
+    @Test
+    fun testCardSideSelectionDialogAppearance() {
+        val activity = buildActivity(FragmentActivity::class.java).setup().get()
+        CardSideSelectionDialog.displayInstance(activity) {}
+        captureScreen("dialog")
+    }
+}


### PR DESCRIPTION
## Purpose / Description

I wanted to try out making a scrreenshot test for dialogs. Still not sure if there is a cleaner or more perfomant approach

## How Has This Been Tested?

./gradlew :AnkiDroid:recordRoborazziPlayDebug -Pscreenshot --tests "com.ichi2.anki.dialogs.CardSideSelectionDialogScreenshotTest"

<img width="3318" height="2483" alt="dialog_compare" src="https://github.com/user-attachments/assets/cab23ecf-788c-47d8-8db6-c261f218295b" />

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->