### PR TITLE
fix(SetDueDateDialog) : TransactionTooLargeException

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -777,7 +777,7 @@ open class Reviewer :
     private fun showDueDateDialog() =
         launchCatchingTask {
             Timber.i("showing due date dialog")
-            val dialog = SetDueDateDialog.newInstance(listOf(currentCardId!!))
+            val dialog = SetDueDateDialog.newInstance(externalCacheDir ?: cacheDir, listOf(currentCardId!!))
             showDialogFragment(dialog)
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -1530,7 +1530,7 @@ class CardBrowserFragment :
                 activityViewModel.selectedRows.size,
                 allCardIds.size,
             )
-            showDialogFragment(SetDueDateDialog.newInstance(allCardIds))
+            showDialogFragment(SetDueDateDialog.newInstance(this@CardBrowserFragment, allCardIds))
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
@@ -17,6 +17,7 @@
 package com.ichi2.anki.scheduling
 
 import android.app.Dialog
+import android.content.DialogInterface
 import android.content.res.Configuration
 import android.os.Bundle
 import android.text.InputFilter
@@ -45,6 +46,8 @@ import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.asyncCatching
+import com.ichi2.anki.browser.IdsFile
+import com.ichi2.anki.browser.removeSafely
 import com.ichi2.anki.common.utils.android.showThemedToast
 import com.ichi2.anki.databinding.DialogSetDueDateBinding
 import com.ichi2.anki.databinding.FragmentSetDueDateRangeBinding
@@ -59,6 +62,7 @@ import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.doOnImeHidden
 import com.ichi2.anki.utils.ext.requireBoolean
+import com.ichi2.anki.utils.ext.requireParcelable
 import com.ichi2.anki.utils.openUrl
 import com.ichi2.anki.withProgress
 import com.ichi2.utils.AndroidUiUtils
@@ -70,8 +74,12 @@ import com.ichi2.utils.title
 import com.ichi2.utils.titleWithHelpIcon
 import dev.androidbroadcast.vbpd.viewBinding
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import java.io.File
+import java.io.IOException
 import kotlin.math.min
 
 /**
@@ -96,14 +104,25 @@ class SetDueDateDialog : DialogFragment() {
     // used to determine if a rotation has taken place
     private var initialRotation: Int = 0
 
-    val cardIds: LongArray
-        get() = requireNotNull(requireArguments().getLongArray(ARG_CARD_IDS)) { ARG_CARD_IDS }
+    val cardIds: List<Long>
+        get() = requireArguments().requireParcelable<IdsFile>(ARG_IDS_FILE).getIds()
 
     val fsrsEnabled: Boolean
         get() = requireArguments().requireBoolean(ARG_FSRS)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val cardIds =
+            try {
+                this.cardIds
+            } catch (e: IOException) {
+                // the file may be missing, or truncated if the write was interrupted
+                Timber.w(e, "Failed to read cardIds")
+                showThemedToast(requireContext(), R.string.something_wrong, false)
+                dismiss()
+                return
+            }
+
         viewModel.init(cardIds, fsrsEnabled)
         Timber.d("Set due date dialog: %d card(s)", cardIds.size)
         this.initialRotation = getScreenRotation()
@@ -117,6 +136,23 @@ class SetDueDateDialog : DialogFragment() {
                 }
                 dismiss()
             }
+        }
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+
+        // DialogFragment also calls this from onDestroyView, so without this check a rotation
+        // would delete the file which the recreated dialog still needs
+        if (activity?.isChangingConfigurations == true) {
+            Timber.d("not removing IdsFile: dialog is being recreated")
+            return
+        }
+
+        if (arguments?.containsKey(ARG_IDS_FILE) == true) {
+            requireArguments()
+                .requireParcelable<IdsFile>(ARG_IDS_FILE)
+                .removeSafely("SetDueDateDialog")
         }
     }
 
@@ -239,26 +275,39 @@ class SetDueDateDialog : DialogFragment() {
     private fun launchUpdateDueDate(showError: Boolean = true) = requireAnkiActivity().updateDueDate(viewModel, showError)
 
     companion object {
-        const val ARG_CARD_IDS = "ARGS_CARD_IDS"
+        const val ARG_IDS_FILE = "ARGS_IDS_FILE"
         const val ARG_FSRS = "ARGS_FSRS"
         const val MAX_WIDTH_DP = 450f
 
         private const val RESULT_SUBMIT_DUE_DATE = "SubmitDueDate"
 
         @CheckResult
-        suspend fun newInstance(cardIds: List<CardId>) =
-            SetDueDateDialog().apply {
+        suspend fun newInstance(
+            cacheDir: File,
+            cardIds: List<CardId>,
+        ): SetDueDateDialog {
+            val fsrsEnabled = getFSRSStatus() ?: false.also { Timber.w("FSRS Status error") }
+            // getFSRSStatus swallows cancellation, so check for it explicitly: the dialog would
+            // fail to show and leave behind a file which only onDismiss removes
+            currentCoroutineContext().ensureActive()
+            return SetDueDateDialog().apply {
                 arguments =
                     Bundle().apply {
-                        putLongArray(ARG_CARD_IDS, cardIds.toLongArray())
-                        putBoolean(
-                            ARG_FSRS,
-                            getFSRSStatus()
-                                ?: false.also { Timber.w("FSRS Status error") },
-                        )
+                        putParcelable(ARG_IDS_FILE, IdsFile(cacheDir, cardIds, "set-due-date"))
+                        putBoolean(ARG_FSRS, fsrsEnabled)
                     }
                 Timber.i("Showing 'set due date' dialog for %d cards", cardIds.size)
             }
+        }
+
+        @CheckResult
+        suspend fun newInstance(
+            fragment: Fragment,
+            cardIds: List<CardId>,
+        ): SetDueDateDialog {
+            val context = fragment.requireContext()
+            return newInstance(context.externalCacheDir ?: context.cacheDir, cardIds)
+        }
     }
 
     class DueDateStateAdapter(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateViewModel.kt
@@ -133,16 +133,16 @@ class SetDueDateViewModel : ViewModel() {
     val currentInterval = MutableStateFlow<ReviewIntervalDays?>(null)
 
     fun init(
-        cardIds: LongArray,
+        cardIds: List<CardId>,
         fsrsEnabled: Boolean,
     ) {
-        this.cardIds = cardIds.toList()
+        this.cardIds = cardIds
         this.fsrsEnabled = fsrsEnabled
 
         initCurrentInterval(cardIds)
     }
 
-    private fun initCurrentInterval(cardIds: LongArray) {
+    private fun initCurrentInterval(cardIds: List<CardId>) {
         // Current interval cannot be shown if multiple cards are selected
         if (cardCount > 1) {
             return

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -599,7 +599,7 @@ class ReviewerFragment :
         }
 
         viewModel.setDueDateFlow.collectIn(lifecycleScope) { cardId ->
-            val dialogFragment = SetDueDateDialog.newInstance(listOf(cardId))
+            val dialogFragment = SetDueDateDialog.newInstance(this, listOf(cardId))
             showDialogFragment(dialogFragment)
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/scheduling/SetDueDateDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/scheduling/SetDueDateDialogTest.kt
@@ -2,6 +2,7 @@
 
 package com.ichi2.anki.scheduling
 
+import android.os.Bundle
 import android.widget.CheckBox
 import android.widget.EditText
 import android.widget.TextView
@@ -15,14 +16,24 @@ import com.google.android.material.textfield.TextInputLayout
 import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.RobolectricTest.Companion.advanceRobolectricLooper
+import com.ichi2.anki.browser.IdsFile
 import com.ichi2.anki.common.annotations.NeedsTest
+import com.ichi2.anki.libanki.CardId
 import com.ichi2.anki.libanki.sched.SetDueDateDays
 import com.ichi2.anki.scheduling.SetDueDateViewModel.Tab
+import com.ichi2.anki.utils.ext.requireParcelable
 import com.ichi2.utils.positiveButton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.advanceUntilIdle
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.File
+import kotlin.coroutines.coroutineContext
 
 @NeedsTest("set interval to same value visibility with FSRS")
 @RunWith(AndroidJUnit4::class)
@@ -127,12 +138,85 @@ class SetDueDateDialogTest : RobolectricTest() {
             assertThat(dateRangeEnd.text.toString(), equalTo("12345"))
         }
 
+    @Test
+    fun `card ids are readable after recreation`() =
+        runTest {
+            val cardIds = List(2) { addBasicNote().firstCard().id }
+            launchFragment<SetDueDateDialog>(
+                themeResId = R.style.Base_Theme_Light,
+                fragmentArgs = setDueDateArgs(cardIds),
+            ).use { scenario ->
+                advanceRobolectricLooper()
+                scenario.recreate()
+                advanceRobolectricLooper()
+                scenario.onFragment { fragment ->
+                    assertThat(fragment.cardIds, equalTo(cardIds))
+                }
+            }
+        }
+
+    @Test
+    fun `ids file is removed after the dialog is dismissed`() =
+        runTest {
+            val cardIds = List(2) { addBasicNote().firstCard().id }
+            val args = setDueDateArgs(cardIds)
+            val idsFile = args.requireParcelable<IdsFile>(SetDueDateDialog.ARG_IDS_FILE)
+
+            launchFragment<SetDueDateDialog>(
+                themeResId = R.style.Base_Theme_Light,
+                fragmentArgs = args,
+            ).use { scenario ->
+                advanceRobolectricLooper()
+                assertThat("kept while the dialog is open", idsFile.exists(), equalTo(true))
+                scenario.onFragment { it.dismiss() }
+                advanceRobolectricLooper()
+            }
+
+            assertThat("removed once dismissed", idsFile.exists(), equalTo(false))
+        }
+
+    @Test
+    fun `unreadable ids file does not crash`() =
+        runTest {
+            val cardIds = List(2) { addBasicNote().firstCard().id }
+            val args = setDueDateArgs(cardIds)
+            args.requireParcelable<IdsFile>(SetDueDateDialog.ARG_IDS_FILE).writeBytes(ByteArray(0))
+
+            launchFragment<SetDueDateDialog>(
+                themeResId = R.style.Base_Theme_Light,
+                fragmentArgs = args,
+            ).use {
+                advanceRobolectricLooper()
+            }
+        }
+
+    @Test
+    fun `cancelled caller leaves no ids file behind`() =
+        runTest {
+            val cardIds = List(2) { addBasicNote().firstCard().id }
+            val cacheDir = File(targetContext.cacheDir, "set-due-date-cancelled").also { it.mkdirs() }
+
+            CoroutineScope(coroutineContext + Job())
+                .async {
+                    coroutineContext.cancel()
+                    SetDueDateDialog.newInstance(cacheDir, cardIds)
+                }
+            advanceUntilIdle()
+
+            assertThat(cacheDir.listFiles()?.size, equalTo(0))
+        }
+
+    private suspend fun setDueDateArgs(cardIds: List<CardId>): Bundle =
+        SetDueDateDialog
+            .newInstance(targetContext.externalCacheDir ?: targetContext.cacheDir, cardIds)
+            .requireArguments()
+
     private fun testDialog(
         cardCount: Int = 1,
         action: SetDueDateDialog.() -> Unit,
     ) = runTest {
         val cardIds = List(cardCount) { addBasicNote().firstCard().id }
-        val dialog = SetDueDateDialog.newInstance(cardIds)
+        val dialog = SetDueDateDialog.newInstance(targetContext.externalCacheDir ?: targetContext.cacheDir, cardIds)
         launchFragment(
             themeResId = R.style.Base_Theme_Light,
             fragmentArgs = dialog.arguments,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/scheduling/SetDueDateViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/scheduling/SetDueDateViewModelTest.kt
@@ -172,7 +172,7 @@ class SetDueDateViewModelTest : JvmTest() {
         testBody: suspend SetDueDateViewModel.() -> Unit,
     ) = runTest {
         val viewModel = SetDueDateViewModel()
-        viewModel.init(cardIds.toLongArray(), fsrsEnabled = fsrsEnabled)
+        viewModel.init(cardIds, fsrsEnabled = fsrsEnabled)
         testBody(viewModel)
     }
 }


### PR DESCRIPTION
## Purpose / Description
_Set Due Date Dialog crashed when >60k browsed cards are selected and the user puts the app in the background._

## Fixes
* Fixes #20509 

## Approach
_Imitated the approach used in `FindAndReplaceDialogFragment.kt` and [Export Dialog](https://github.com/ankidroid/Anki-Android/pull/20984) to deal with this issue by using the class `IdsFile` rather than using `Bundle`, which was overflowing when the capacity exceeded, thereby causing the crash._

Modified `newInstance` API in unit tests to make it consistent with the approach used in this PR.

## How Has This Been Tested?

Tested on my phone (Android 14, Xiaomi / HyperOS) using a debug build. 

> I reproduced the issue. It
> 
> * directed me to the **main screen**: when I waited for some time (maybe 10 seconds or so)
> * showed **error/crash**: when I re-opened instantly

Both these observations have been tested. Video attached as evidence.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

https://github.com/user-attachments/assets/d4c3e49e-62f5-40f2-93f6-058713535b55



<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->