### PR TITLE
Refactor menu logic in ViewModel

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -72,6 +72,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import anki.collection.OpChanges
+import anki.decks.deckId
 import anki.sync.SyncStatusResponse
 import com.google.android.material.progressindicator.LinearProgressIndicator
 import com.google.android.material.snackbar.BaseTransientBottomBar
@@ -436,25 +437,18 @@ open class DeckPicker :
         }
     }
 
-    private fun showDeckPickerContextMenu(deckId: DeckId) =
-        launchCatchingTask {
-            viewModel.selectDeck(deckId).join()
-            val menu = DeckPickerContextMenu.newInstance(deckId)
-            CardBrowser.clearLastDeckId()
-            showDialogFragment(menu)
-        }
+    private suspend fun showDeckPickerContextMenu(deckId: DeckId) {
+        val menu = DeckPickerContextMenu.newInstance(deckId)
+        CardBrowser.clearLastDeckId()
+        showDialogFragment(menu)
+    }
 
-    private fun showDeckPickerRightClickContextMenu(
-        deckId: DeckId,
-        x: Float,
-        y: Float,
-    ) = launchCatchingTask {
-        viewModel.selectDeck(deckId).join()
+    private suspend fun showDeckPickerRightClickContextMenu(request: DeckPickerViewModel.RightClickMenuRequest) {
         DeckPickerMenuContentProvider.show(
             deckPicker = this@DeckPicker,
-            deckId = deckId,
-            x = x,
-            y = y,
+            deckId = request.deckId,
+            x = request.x,
+            y = request.y,
         )
     }
 
@@ -520,9 +514,9 @@ open class DeckPicker :
                     viewModel.toggleDeckExpand(deckId)
                     dismissAllDialogFragments()
                 },
-                onDeckContextRequested = ::showDeckPickerContextMenu,
+                onDeckContextRequested = { deckId -> viewModel.requestContextMenu(deckId) },
                 onDeckRightClick = { deckId, x, y ->
-                    showDeckPickerRightClickContextMenu(deckId, x, y)
+                    viewModel.requestRightClickContextMenu(deckId, x, y)
                     Timber.d("Right Click on deck recorded!! %d, %f %f", deckId, x, y)
                 },
             )
@@ -795,6 +789,8 @@ open class DeckPicker :
         viewModel.flowOfResizingDividerVisible.launchCollectionInLifecycleScope(::onResizingDividerVisibilityChanged)
         viewModel.flowOfDecksReloaded.launchCollectionInLifecycleScope(::onDecksReloaded)
         viewModel.flowOfStartupResponse.filterNotNull().launchCollectionInLifecycleScope(::onStartupResponse)
+        viewModel.flowOfShowContextMenu.launchCollectionInLifecycleScope(::showDeckPickerContextMenu)
+        viewModel.flowOfShowRightClickContextMenu.launchCollectionInLifecycleScope(::showDeckPickerRightClickContextMenu)
     }
 
     private val onReceiveContentListener =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -304,6 +304,31 @@ class DeckPickerViewModel :
         flowOfDestination.emit(NoteEditorLauncher.AddNote(deckId))
     }
 
+    val flowOfShowContextMenu = MutableSharedFlow<DeckId>(extraBufferCapacity = 1)
+
+    data class RightClickMenuRequest(
+        val deckId: DeckId,
+        val x: Float,
+        val y: Float,
+    )
+
+    val flowOfShowRightClickContextMenu = MutableSharedFlow<RightClickMenuRequest>(extraBufferCapacity = 1)
+
+    fun requestContextMenu(deckId: DeckId) =
+        viewModelScope.launch {
+            selectDeck(deckId).join()
+            flowOfShowContextMenu.emit(deckId)
+        }
+
+    fun requestRightClickContextMenu(
+        deckId: DeckId,
+        x: Float,
+        y: Float,
+    ) = viewModelScope.launch {
+        selectDeck(deckId).join()
+        flowOfShowRightClickContextMenu.emit(RightClickMenuRequest(deckId, x, y))
+    }
+
     /**
      * Opens the Manage Note Types screen.
      */

--- a/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerViewModelTest.kt
@@ -208,4 +208,35 @@ class DeckPickerViewModelTest : RobolectricTest() {
             }
         }
     }
+
+    @Test
+    fun `request context menu - flow`() {
+        runTest {
+            val deckId = addDeck("Deck A")
+
+            viewModel.flowOfShowContextMenu.test {
+                viewModel.requestContextMenu(deckId).join()
+
+                assertEquals(deckId, awaitItem())
+            }
+        }
+    }
+
+    @Test
+    fun `request right click context menu - flow`() {
+        runTest {
+            val deckId = addDeck("Deck B")
+            val x = 10f
+            val y = 20f
+
+            viewModel.flowOfShowRightClickContextMenu.test {
+                viewModel.requestRightClickContextMenu(deckId, x, y).join()
+
+                val item = awaitItem()
+                assertEquals(deckId, item.deckId)
+                assertEquals(x, item.x)
+                assertEquals(y, item.y)
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Purpose / Description
I fixed a crash occurring when a deck context menu is requested during a background task but the activity state is saved before the task completes 

## Fixes
* Fixes #20715 

## Approach
I created `SharedFlows` in `DeckPickerViewModel` to handle menu requests. I've updated `DeckPicker` to observe these flows using `launchCollectionInLifecycleScope` to ensures the dialogs are only triggered when the activity is in a valid lifecycle state, automatically preventing state loss crashes.
## How Has This Been Tested?

I write unit tests to verify that both standard and right-click menu flows emit the correct `DeckId` and coordinate data after the background selection task finishes

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->