### PR TITLE
refactor: renaming, viewbinding, and relationship streamlining for ScheduleReminders + AddEditReminderDialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -50,7 +50,7 @@ import com.ichi2.anki.libanki.Decks
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.reviewreminders.ReviewReminderScope
-import com.ichi2.anki.reviewreminders.ScheduleReminders
+import com.ichi2.anki.reviewreminders.ScheduleRemindersFragment
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.ext.showDialogFragment
@@ -218,7 +218,7 @@ class StudyOptionsFragment :
             R.id.action_schedule_reminders -> {
                 Timber.i("StudyOptionsFragment:: schedule reminders button pressed")
                 val intent =
-                    ScheduleReminders.getIntent(
+                    ScheduleRemindersFragment.getIntent(
                         requireContext(),
                         ReviewReminderScope.DeckSpecific(col!!.decks.current().id),
                     )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
@@ -30,7 +30,7 @@ import com.ichi2.anki.compat.CompatHelper
 import com.ichi2.anki.preferences.profiles.SwitchProfilesFragment
 import com.ichi2.anki.preferences.reviewer.ReviewerMenuSettingsFragment
 import com.ichi2.anki.reviewreminders.ReviewReminderScope
-import com.ichi2.anki.reviewreminders.ScheduleReminders
+import com.ichi2.anki.reviewreminders.ScheduleRemindersFragment
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.preferences.HeaderPreference
@@ -61,7 +61,7 @@ class HeaderFragment : SettingsFragment() {
         requirePreference<HeaderPreference>(R.string.pref_review_reminders_screen_key)
             .setOnPreferenceClickListener {
                 Timber.i("HeaderFragment:: edit review reminders button pressed")
-                val intent = ScheduleReminders.getIntent(requireContext(), ReviewReminderScope.Global)
+                val intent = ScheduleRemindersFragment.getIntent(requireContext(), ReviewReminderScope.Global)
                 startActivity(intent)
                 true
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -45,7 +45,7 @@ import com.ichi2.anki.SingleFragmentActivity
 import com.ichi2.anki.common.annotations.LegacyNotifications
 import com.ichi2.anki.preferences.HeaderFragment.Companion.getHeaderKeyForFragment
 import com.ichi2.anki.reviewreminders.ReviewReminderScope
-import com.ichi2.anki.reviewreminders.ScheduleReminders
+import com.ichi2.anki.reviewreminders.ScheduleRemindersFragment
 import com.ichi2.anki.utils.ext.sharedPrefs
 import com.ichi2.anki.utils.isWindowCompact
 import com.ichi2.themes.Themes
@@ -123,7 +123,7 @@ class PreferencesFragment :
     override fun onSearchResultClicked(result: SearchPreferenceResult) {
         if (result.key == getString(R.string.pref_review_reminders_screen_key)) {
             Timber.i("Preferences:: edit review reminders button pressed")
-            val intent = ScheduleReminders.getIntent(requireContext(), ReviewReminderScope.Global)
+            val intent = ScheduleRemindersFragment.getIntent(requireContext(), ReviewReminderScope.Global)
             startActivity(intent)
             return
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
@@ -71,7 +71,7 @@ class AddEditReminderDialog : DialogFragment() {
     @Parcelize
     sealed class DialogMode : Parcelable {
         /**
-         * Adding a new review reminder. Requires the editing scope of [ScheduleReminders] as an argument so that the dialog can
+         * Adding a new review reminder. Requires the editing scope of [ScheduleRemindersFragment] as an argument so that the dialog can
          * pick a default deck to add to (or, if the scope is global, so that the dialog can
          * show that the review reminder will default to being a global reminder).
          */
@@ -140,13 +140,13 @@ class AddEditReminderDialog : DialogFragment() {
         setUpCardThresholdInput()
         setUpOnlyNotifyIfNoReviewsCheckbox()
 
-        // For getting the result of the deck selection sub-dialog from ScheduleReminders
-        // See ScheduleReminders.onDeckSelected for more information
-        setFragmentResultListener(ScheduleReminders.DECK_SELECTION_RESULT_REQUEST_KEY) { _, bundle ->
+        // For getting the result of the deck selection sub-dialog from ScheduleRemindersFragment
+        // See ScheduleRemindersFragment.onDeckSelected for more information
+        setFragmentResultListener(ScheduleRemindersFragment.DECK_SELECTION_RESULT_REQUEST_KEY) { _, bundle ->
             val selectedDeck =
                 BundleCompat.getParcelable(
                     bundle,
-                    ScheduleReminders.DECK_SELECTION_RESULT_REQUEST_KEY,
+                    ScheduleRemindersFragment.DECK_SELECTION_RESULT_REQUEST_KEY,
                     SelectableDeck::class.java,
                 )
             Timber.d("Received result from deck selection sub-dialog: %s", selectedDeck)
@@ -330,9 +330,9 @@ class AddEditReminderDialog : DialogFragment() {
         val reminderToBeReturned = viewModel.outputStateAsReminder()
         Timber.d("Reminder to be returned: %s", reminderToBeReturned)
         setFragmentResult(
-            ScheduleReminders.ADD_EDIT_DIALOG_RESULT_REQUEST_KEY,
+            ScheduleRemindersFragment.ADD_EDIT_DIALOG_RESULT_REQUEST_KEY,
             Bundle().apply {
-                putParcelable(ScheduleReminders.ADD_EDIT_DIALOG_RESULT_REQUEST_KEY, reminderToBeReturned)
+                putParcelable(ScheduleRemindersFragment.ADD_EDIT_DIALOG_RESULT_REQUEST_KEY, reminderToBeReturned)
             },
         )
 
@@ -356,9 +356,9 @@ class AddEditReminderDialog : DialogFragment() {
         )
         confirmationDialog.setConfirm {
             setFragmentResult(
-                ScheduleReminders.ADD_EDIT_DIALOG_RESULT_REQUEST_KEY,
+                ScheduleRemindersFragment.ADD_EDIT_DIALOG_RESULT_REQUEST_KEY,
                 Bundle().apply {
-                    putParcelable(ScheduleReminders.ADD_EDIT_DIALOG_RESULT_REQUEST_KEY, null)
+                    putParcelable(ScheduleRemindersFragment.ADD_EDIT_DIALOG_RESULT_REQUEST_KEY, null)
                 },
             )
             dismiss()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
@@ -27,7 +27,6 @@ import androidx.core.view.isVisible
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.setFragmentResult
-import androidx.fragment.app.setFragmentResultListener
 import androidx.fragment.app.viewModels
 import com.google.android.material.timepicker.MaterialTimePicker
 import com.google.android.material.timepicker.TimeFormat
@@ -36,6 +35,7 @@ import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
 import com.ichi2.anki.databinding.DialogAddEditReminderBinding
 import com.ichi2.anki.dialogs.ConfirmationDialog
+import com.ichi2.anki.dialogs.registerDeckSelectedHandler
 import com.ichi2.anki.isDefaultDeckEmpty
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.Consts
@@ -124,6 +124,8 @@ class AddEditReminderDialog : DialogFragment() {
             negativeButton?.setOnClickListener { onDelete() } // delete button does not exist in Add mode, hence null check
         }
 
+        registerDeckSelectedHandler(action = ::onDeckSelected)
+
         Timber.d("Setting up fields")
         setUpToolbar()
         setUpTimeButton()
@@ -131,26 +133,6 @@ class AddEditReminderDialog : DialogFragment() {
         setUpAdvancedDropdown()
         setUpCardThresholdInput()
         setUpOnlyNotifyIfNoReviewsCheckbox()
-
-        // For getting the result of the deck selection sub-dialog from ScheduleRemindersFragment
-        // See ScheduleRemindersFragment.onDeckSelected for more information
-        setFragmentResultListener(ScheduleRemindersFragment.DECK_SELECTION_RESULT_REQUEST_KEY) { _, bundle ->
-            val selectedDeck =
-                BundleCompat.getParcelable(
-                    bundle,
-                    ScheduleRemindersFragment.DECK_SELECTION_RESULT_REQUEST_KEY,
-                    SelectableDeck::class.java,
-                )
-            Timber.d("Received result from deck selection sub-dialog: %s", selectedDeck)
-            val selectedDeckId: DeckId =
-                when (selectedDeck) {
-                    is SelectableDeck.Deck -> selectedDeck.deckId
-                    is SelectableDeck.AllDecks -> ALL_DECKS_ID
-                    else -> Consts.DEFAULT_DECK_ID
-                }
-            viewModel.setDeckSelected(selectedDeckId)
-            binding.addEditReminderDeckName.text = selectedDeck?.getDisplayName(requireContext())
-        }
 
         dialog.window?.let { resizeWhenSoftInputShown(it) }
         return dialog
@@ -344,6 +326,18 @@ class AddEditReminderDialog : DialogFragment() {
         }
 
         showDialogFragment(confirmationDialog)
+    }
+
+    private fun onDeckSelected(deck: SelectableDeck?) {
+        Timber.d("Deck selected in deck spinner: %s", deck)
+        val selectedDeckId: DeckId =
+            when (deck) {
+                is SelectableDeck.Deck -> deck.deckId
+                is SelectableDeck.AllDecks -> ALL_DECKS_ID
+                null -> return
+            }
+        viewModel.setDeckSelected(selectedDeckId)
+        binding.addEditReminderDeckName.text = deck.getDisplayName(requireContext())
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
@@ -21,13 +21,7 @@ import android.content.res.Configuration
 import android.os.Bundle
 import android.os.Parcelable
 import android.text.format.DateFormat
-import android.view.View
-import android.widget.EditText
-import android.widget.ImageView
-import android.widget.LinearLayout
-import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.widget.Toolbar
 import androidx.core.os.BundleCompat
 import androidx.core.view.isVisible
 import androidx.core.widget.doOnTextChanged
@@ -35,14 +29,12 @@ import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.setFragmentResultListener
 import androidx.fragment.app.viewModels
-import com.google.android.material.button.MaterialButton
-import com.google.android.material.checkbox.MaterialCheckBox
-import com.google.android.material.textfield.TextInputLayout
 import com.google.android.material.timepicker.MaterialTimePicker
 import com.google.android.material.timepicker.TimeFormat
 import com.ichi2.anki.ALL_DECKS_ID
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
+import com.ichi2.anki.databinding.DialogAddEditReminderBinding
 import com.ichi2.anki.dialogs.ConfirmationDialog
 import com.ichi2.anki.isDefaultDeckEmpty
 import com.ichi2.anki.launchCatchingTask
@@ -90,7 +82,7 @@ class AddEditReminderDialog : DialogFragment() {
 
     private val viewModel: AddEditReminderDialogViewModel by viewModels()
 
-    private lateinit var contentView: View
+    private lateinit var binding: DialogAddEditReminderBinding
 
     /**
      * The mode of this dialog, retrieved from arguments and set by [getInstance].
@@ -106,12 +98,12 @@ class AddEditReminderDialog : DialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         super.onCreateDialog(savedInstanceState)
-        contentView = layoutInflater.inflate(R.layout.dialog_add_edit_reminder, null)
+        binding = DialogAddEditReminderBinding.inflate(layoutInflater)
         Timber.d("dialog mode: %s", dialogMode.toString())
 
         val dialogBuilder =
             AlertDialog.Builder(requireActivity()).apply {
-                customView(contentView)
+                customView(binding.root)
                 positiveButton(R.string.dialog_ok)
                 neutralButton(R.string.dialog_cancel)
 
@@ -157,8 +149,7 @@ class AddEditReminderDialog : DialogFragment() {
                     else -> Consts.DEFAULT_DECK_ID
                 }
             viewModel.setDeckSelected(selectedDeckId)
-            this.dialog?.findViewById<TextView>(R.id.add_edit_reminder_deck_name)?.text =
-                selectedDeck?.getDisplayName(requireContext())
+            binding.addEditReminderDeckName.text = selectedDeck?.getDisplayName(requireContext())
         }
 
         dialog.window?.let { resizeWhenSoftInputShown(it) }
@@ -166,8 +157,7 @@ class AddEditReminderDialog : DialogFragment() {
     }
 
     private fun setUpToolbar() {
-        val toolbar = contentView.findViewById<Toolbar>(R.id.add_edit_reminder_toolbar)
-        toolbar.title =
+        binding.addEditReminderToolbar.title =
             getString(
                 when (dialogMode) {
                     is DialogMode.Add -> R.string.add_review_reminder
@@ -177,25 +167,23 @@ class AddEditReminderDialog : DialogFragment() {
     }
 
     private fun setUpTimeButton() {
-        val timeButton = contentView.findViewById<MaterialButton>(R.id.add_edit_reminder_time_button)
-        timeButton.setOnClickListener {
+        binding.addEditReminderTimeButton.setOnClickListener {
             Timber.i("Time button clicked")
             val time = viewModel.time.value ?: ReviewReminderTime.getCurrentTime()
             showTimePickerDialog(time.hour, time.minute)
         }
         viewModel.time.observe(this) { time ->
-            timeButton.text = time.toFormattedString(requireContext())
+            binding.addEditReminderTimeButton.text = time.toFormattedString(requireContext())
         }
     }
 
     private fun setInitialDeckSelection() {
-        val deckName = contentView.findViewById<TextView>(R.id.add_edit_reminder_deck_name)
-        deckName.setOnClickListener { startDeckSelection(all = true, filtered = true) }
+        binding.addEditReminderDeckName.setOnClickListener { startDeckSelection(all = true, filtered = true) }
         launchCatchingTask {
             Timber.d("Setting up deck name view")
             val (selectedDeckId, selectedDeckName) = getValidDeckSelection()
             Timber.d("Initial selection of deck %s(id=%d)", selectedDeckName, selectedDeckId)
-            deckName.text = selectedDeckName
+            binding.addEditReminderDeckName.text = selectedDeckName
             viewModel.setDeckSelected(selectedDeckId)
         }
     }
@@ -231,34 +219,28 @@ class AddEditReminderDialog : DialogFragment() {
     }
 
     private fun setUpAdvancedDropdown() {
-        val advancedDropdown = contentView.findViewById<LinearLayout>(R.id.add_edit_reminder_advanced_dropdown)
-        val advancedDropdownIcon = contentView.findViewById<ImageView>(R.id.add_edit_reminder_advanced_dropdown_icon)
-        val advancedContent = contentView.findViewById<LinearLayout>(R.id.add_edit_reminder_advanced_content)
-
-        advancedDropdown.setOnClickListener {
+        binding.addEditReminderAdvancedDropdown.setOnClickListener {
             viewModel.toggleAdvancedSettingsOpen()
         }
         viewModel.advancedSettingsOpen.observe(this) { advancedSettingsOpen ->
             when (advancedSettingsOpen) {
                 true -> {
-                    advancedContent.isVisible = true
-                    advancedDropdownIcon.setBackgroundResource(DROPDOWN_EXPANDED_CHEVRON)
+                    binding.addEditReminderAdvancedContent.isVisible = true
+                    binding.addEditReminderAdvancedDropdownIcon.setBackgroundResource(DROPDOWN_EXPANDED_CHEVRON)
                 }
                 false -> {
-                    advancedContent.isVisible = false
-                    advancedDropdownIcon.setBackgroundResource(DROPDOWN_COLLAPSED_CHEVRON)
+                    binding.addEditReminderAdvancedContent.isVisible = false
+                    binding.addEditReminderAdvancedDropdownIcon.setBackgroundResource(DROPDOWN_COLLAPSED_CHEVRON)
                 }
             }
         }
     }
 
     private fun setUpCardThresholdInput() {
-        val cardThresholdInputWrapper = contentView.findViewById<TextInputLayout>(R.id.add_edit_reminder_card_threshold_input_wrapper)
-        val cardThresholdInput = contentView.findViewById<EditText>(R.id.add_edit_reminder_card_threshold_input)
-        cardThresholdInput.setText(viewModel.cardTriggerThreshold.value.toString())
-        cardThresholdInput.doOnTextChanged { text, _, _, _ ->
+        binding.addEditReminderCardThresholdInput.setText(viewModel.cardTriggerThreshold.value.toString())
+        binding.addEditReminderCardThresholdInput.doOnTextChanged { text, _, _, _ ->
             val value: Int? = text.toString().toIntOrNull()
-            cardThresholdInputWrapper.error =
+            binding.addEditReminderCardThresholdInputWrapper.error =
                 when {
                     (value == null) -> "Please enter a whole number of cards"
                     (value < 0) -> "The threshold must be at least 0"
@@ -269,16 +251,14 @@ class AddEditReminderDialog : DialogFragment() {
     }
 
     private fun setUpOnlyNotifyIfNoReviewsCheckbox() {
-        val contentSection = contentView.findViewById<LinearLayout>(R.id.add_edit_reminder_only_notify_if_no_reviews_section)
-        val checkbox = contentView.findViewById<MaterialCheckBox>(R.id.add_edit_reminder_only_notify_if_no_reviews_checkbox)
-        contentSection.setOnClickListener {
+        binding.addEditReminderOnlyNotifyIfNoReviewsSection.setOnClickListener {
             viewModel.toggleOnlyNotifyIfNoReviews()
         }
-        checkbox.setOnClickListener {
+        binding.addEditReminderOnlyNotifyIfNoReviewsCheckbox.setOnClickListener {
             viewModel.toggleOnlyNotifyIfNoReviews()
         }
         viewModel.onlyNotifyIfNoReviews.observe(this) { onlyNotifyIfNoReviews ->
-            checkbox.isChecked = onlyNotifyIfNoReviews
+            binding.addEditReminderOnlyNotifyIfNoReviewsCheckbox.isChecked = onlyNotifyIfNoReviews
         }
     }
 
@@ -321,9 +301,8 @@ class AddEditReminderDialog : DialogFragment() {
     private fun onSubmit() {
         Timber.i("Submitted dialog")
         // Do nothing if numerical fields are invalid
-        val cardThresholdInputWrapper = contentView.findViewById<TextInputLayout>(R.id.add_edit_reminder_card_threshold_input_wrapper)
-        cardThresholdInputWrapper.error?.let {
-            contentView.showSnackbar(R.string.something_wrong)
+        binding.addEditReminderCardThresholdInputWrapper.error?.let {
+            binding.root.showSnackbar(R.string.something_wrong)
             return
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
@@ -22,7 +22,6 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.text.format.DateFormat
 import androidx.appcompat.app.AlertDialog
-import androidx.core.os.BundleCompat
 import androidx.core.view.isVisible
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.DialogFragment
@@ -93,7 +92,7 @@ class AddEditReminderDialog : DialogFragment() {
      */
     private val dialogMode: DialogMode by lazy {
         requireNotNull(
-            BundleCompat.getParcelable(requireArguments(), ARGS_DIALOG_MODE, DialogMode::class.java),
+            requireArguments().getParcelableCompat<DialogMode>(ARGS_DIALOG_MODE),
         ) {
             "Dialog mode cannot be null"
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
@@ -26,7 +26,9 @@ import androidx.core.os.BundleCompat
 import androidx.core.view.isVisible
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.setFragmentResult
+import androidx.fragment.app.setFragmentResultListener
 import androidx.fragment.app.viewModels
 import com.google.android.material.timepicker.MaterialTimePicker
 import com.google.android.material.timepicker.TimeFormat
@@ -45,6 +47,7 @@ import com.ichi2.anki.reviewreminders.AddEditReminderDialog.Companion.getInstanc
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.startDeckSelection
+import com.ichi2.anki.utils.ext.getParcelableCompat
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.utils.DisplayUtils.resizeWhenSoftInputShown
 import com.ichi2.utils.Permissions
@@ -90,7 +93,7 @@ class AddEditReminderDialog : DialogFragment() {
      */
     private val dialogMode: DialogMode by lazy {
         requireNotNull(
-            BundleCompat.getParcelable(requireArguments(), DIALOG_MODE_ARGUMENTS_KEY, DialogMode::class.java),
+            BundleCompat.getParcelable(requireArguments(), ARGS_DIALOG_MODE, DialogMode::class.java),
         ) {
             "Dialog mode cannot be null"
         }
@@ -291,9 +294,10 @@ class AddEditReminderDialog : DialogFragment() {
         val reminderToBeReturned = viewModel.outputStateAsReminder()
         Timber.d("Reminder to be returned: %s", reminderToBeReturned)
         setFragmentResult(
-            ScheduleRemindersFragment.ADD_EDIT_DIALOG_RESULT_REQUEST_KEY,
+            REQUEST_ADD_EDIT_REMINDER,
             Bundle().apply {
-                putParcelable(ScheduleRemindersFragment.ADD_EDIT_DIALOG_RESULT_REQUEST_KEY, reminderToBeReturned)
+                putParcelable(KEY_REMINDER_MODE, dialogMode)
+                putParcelable(KEY_REMINDER_RESULT, reminderToBeReturned)
             },
         )
 
@@ -317,9 +321,11 @@ class AddEditReminderDialog : DialogFragment() {
         )
         confirmationDialog.setConfirm {
             setFragmentResult(
-                ScheduleRemindersFragment.ADD_EDIT_DIALOG_RESULT_REQUEST_KEY,
+                REQUEST_ADD_EDIT_REMINDER,
                 Bundle().apply {
-                    putParcelable(ScheduleRemindersFragment.ADD_EDIT_DIALOG_RESULT_REQUEST_KEY, null)
+                    // dialogMode should always be DialogMode.Edit in this case since the delete button only exists in Edit mode
+                    putParcelable(KEY_REMINDER_MODE, dialogMode)
+                    putParcelable(KEY_REMINDER_RESULT, null)
                 },
             )
             dismiss()
@@ -357,12 +363,47 @@ class AddEditReminderDialog : DialogFragment() {
          *
          * @see DialogMode
          */
-        const val DIALOG_MODE_ARGUMENTS_KEY = "dialog_mode"
+        const val ARGS_DIALOG_MODE = "args_dialog_mode"
+
+        /**
+         * Fragment result key for receiving the result of a recently closed [AddEditReminderDialog].
+         */
+        private const val REQUEST_ADD_EDIT_REMINDER = "request_add_edit"
+
+        /**
+         * Fragment result bundle key for the [DialogMode] of a recently closed [AddEditReminderDialog].
+         */
+        private const val KEY_REMINDER_MODE = "key_reminder_mode"
+
+        /**
+         * Fragment result bundle key for the [ReviewReminder] result of a recently closed [AddEditReminderDialog].
+         */
+        private const val KEY_REMINDER_RESULT = "key_reminder_result"
 
         /**
          * Unique fragment tag for the Material TimePicker shown for setting the time of a review reminder.
          */
         private const val TIME_PICKER_TAG = "REMINDER_TIME_PICKER_DIALOG"
+
+        /**
+         * Register a fragment result listener to listen for results from a recently closed [AddEditReminderDialog].
+         * If the reminder has been deleted, the [ReviewReminder] argument to the callback will be null.
+         *
+         * @param action The callback to be executed when a result is received
+         */
+        fun Fragment.registerAddEditReminderHandler(
+            action: (newOrModifiedReminder: ReviewReminder?, modeOfFinishedDialog: DialogMode) -> Unit,
+        ) {
+            setFragmentResultListener(REQUEST_ADD_EDIT_REMINDER) { _, bundle ->
+                Timber.i("Received fragment result from add/edit dialog")
+                val modeOfFinishedDialog =
+                    bundle.getParcelableCompat<DialogMode>(
+                        KEY_REMINDER_MODE,
+                    ) ?: return@setFragmentResultListener
+                val newOrModifiedReminder = bundle.getParcelableCompat<ReviewReminder>(KEY_REMINDER_RESULT)
+                action(newOrModifiedReminder, modeOfFinishedDialog)
+            }
+        }
 
         /**
          * Creates a new instance of this dialog with the given dialog mode.
@@ -371,7 +412,7 @@ class AddEditReminderDialog : DialogFragment() {
             AddEditReminderDialog().apply {
                 arguments =
                     Bundle().apply {
-                        putParcelable(DIALOG_MODE_ARGUMENTS_KEY, dialogMode)
+                        putParcelable(ARGS_DIALOG_MODE, dialogMode)
                     }
             }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialogViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialogViewModel.kt
@@ -39,7 +39,7 @@ class AddEditReminderDialogViewModel(
      */
     private val dialogMode =
         requireNotNull(
-            savedStateHandle.get<AddEditReminderDialog.DialogMode>(AddEditReminderDialog.DIALOG_MODE_ARGUMENTS_KEY),
+            savedStateHandle.get<AddEditReminderDialog.DialogMode>(AddEditReminderDialog.ARGS_DIALOG_MODE),
         ) { "dialogMode is required" }
 
     private val _time =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
@@ -155,7 +155,7 @@ class ReminderTroubleshootingFragment : Fragment(R.layout.fragment_reminder_trou
  * Shared factory for [ReminderTroubleshootingViewModel].
  *
  * Lives outside the ViewModel itself to keep the ViewModel free of `Context`. Both
- * [ScheduleReminders] and [ReminderTroubleshootingFragment] use this with
+ * [ScheduleRemindersFragment] and [ReminderTroubleshootingFragment] use this with
  * `by activityViewModels { … }` so they observe a single VM + repository instance.
  */
 internal fun reminderTroubleshootingViewModelFactory(context: Context): ViewModelProvider.Factory {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminder.kt
@@ -111,11 +111,11 @@ value class ReviewReminderCardTriggerThreshold(
 
 /**
  * An indicator of whether a review reminders feature is associated with every deck in the user's
- * collection or if it is associated with a single deck. For example, the [ScheduleReminders] fragment
+ * collection or if it is associated with a single deck. For example, the [ScheduleRemindersFragment] fragment
  * can be triggered in either global or deck-specific editing mode. A [ReviewReminder] can be associated
  * with either all decks or a specific deck.
  *
- * This class is marked with @Parcelize so that it can be passed into [ScheduleReminders.getIntent].
+ * This class is marked with @Parcelize so that it can be passed into [ScheduleRemindersFragment.getIntent].
  * This class is marked with @Serializable so that it can be a field of [ReviewReminder]s, which are stored as JSON strings.
  */
 @Serializable

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersDestination.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersDestination.kt
@@ -25,7 +25,7 @@ class ScheduleRemindersDestination(
     private val did: DeckId,
 ) : Destination {
     override fun toIntent(context: Context): Intent =
-        ScheduleReminders.getIntent(
+        ScheduleRemindersFragment.getIntent(
             context,
             ReviewReminderScope.DeckSpecific(did),
         )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
@@ -30,7 +30,6 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.commit
-import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.setFragmentResultListener
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
@@ -43,11 +42,8 @@ import com.ichi2.anki.R
 import com.ichi2.anki.SingleFragmentActivity
 import com.ichi2.anki.canUserAccessDeck
 import com.ichi2.anki.databinding.FragmentScheduleRemindersBinding
-import com.ichi2.anki.dialogs.DeckSelectionDialog
-import com.ichi2.anki.dialogs.registerDeckSelectedHandler
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.DeckId
-import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.services.AlarmManagerService
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
@@ -185,7 +181,6 @@ class ScheduleRemindersFragment :
         // Retrieve reminders based on the editing scope
         launchCatchingTask { loadDatabaseRemindersIntoUI() }
 
-        registerDeckSelectedHandler(action = ::onDeckSelected)
         // If the user creates or edits a review reminder, the dialog for doing so opens
         // Once their changes are complete, the dialog closes and this fragment is reloaded
         // Hence, we check for any fragment results here and update the database accordingly
@@ -453,22 +448,6 @@ class ScheduleRemindersFragment :
     }
 
     /**
-     * [AddEditReminderDialog] requires to catch changes from [DeckSelectionDialog]. However,
-     * [AddEditReminderDialog] is removed from the fragment stack when the [DeckSelectionDialog]
-     * appears, so we set [ScheduleRemindersFragment] as the receiver and forward data to
-     * [AddEditReminderDialog] when a deck is selected.
-     */
-    private fun onDeckSelected(deck: SelectableDeck?) {
-        Timber.d("Deck selected in deck spinner: %s", deck)
-        setFragmentResult(
-            DECK_SELECTION_RESULT_REQUEST_KEY,
-            Bundle().apply {
-                putParcelable(DECK_SELECTION_RESULT_REQUEST_KEY, deck)
-            },
-        )
-    }
-
-    /**
      * Trigger a RecyclerView UI update for this fragment.
      * If there are no reminders to display, show the "No Reminders" placeholder icon and text.
      */
@@ -505,13 +484,6 @@ class ScheduleRemindersFragment :
          * Public so [AddEditReminderDialog] can access it, too.
          */
         const val ADD_EDIT_DIALOG_RESULT_REQUEST_KEY = "add_edit_reminder_dialog_result_request_key"
-
-        /**
-         * Fragment result key for sending [AddEditReminderDialog] the result of the deck spinner selection event.
-         * Public so [AddEditReminderDialog] can access it, too.
-         * @see onDeckSelected
-         */
-        const val DECK_SELECTION_RESULT_REQUEST_KEY = "reminder_deck_selection_result_request_key"
 
         /**
          * Wrapper for database access in this fragment.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
@@ -24,7 +24,6 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.os.BundleCompat
 import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
@@ -48,6 +47,7 @@ import com.ichi2.anki.services.AlarmManagerService
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.utils.ext.getParcelableCompat
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.withProgress
 import dev.androidbroadcast.vbpd.viewBinding
@@ -65,11 +65,8 @@ class ScheduleRemindersFragment :
      * @see ReviewReminderScope
      */
     private val scheduleRemindersScope: ReviewReminderScope by lazy {
-        BundleCompat.getParcelable(
-            requireArguments(),
-            ARGS_SCOPE,
-            ReviewReminderScope::class.java,
-        ) ?: ReviewReminderScope.Global
+        requireArguments().getParcelableCompat<ReviewReminderScope>(ARGS_SCOPE)
+            ?: ReviewReminderScope.Global
     }
 
     private val binding by viewBinding(FragmentScheduleRemindersBinding::bind)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
@@ -61,7 +61,7 @@ import timber.log.Timber
 /**
  * Fragment for creating, viewing, editing, and deleting review reminders.
  */
-class ScheduleReminders :
+class ScheduleRemindersFragment :
     Fragment(R.layout.fragment_schedule_reminders),
     BaseSnackbarBuilderProvider {
     /**
@@ -455,7 +455,7 @@ class ScheduleReminders :
     /**
      * [AddEditReminderDialog] requires to catch changes from [DeckSelectionDialog]. However,
      * [AddEditReminderDialog] is removed from the fragment stack when the [DeckSelectionDialog]
-     * appears, so we set [ScheduleReminders] as the receiver and forward data to
+     * appears, so we set [ScheduleRemindersFragment] as the receiver and forward data to
      * [AddEditReminderDialog] when a deck is selected.
      */
     private fun onDeckSelected(deck: SelectableDeck?) {
@@ -469,7 +469,7 @@ class ScheduleReminders :
     }
 
     /**
-     * Trigger a RecyclerView UI update for ScheduleReminders.
+     * Trigger a RecyclerView UI update for this fragment.
      * If there are no reminders to display, show the "No Reminders" placeholder icon and text.
      */
     private fun triggerUIUpdate() {
@@ -524,9 +524,9 @@ class ScheduleReminders :
             }
 
         /**
-         * Creates an intent to start the ScheduleReminders fragment.
+         * Creates an intent to launch this fragment in a [SingleFragmentActivity].
          * @param context
-         * @param scope The editing scope of the ScheduleReminders fragment.
+         * @param scope The editing scope of this fragment.
          * @return The new intent.
          */
         fun getIntent(
@@ -536,12 +536,12 @@ class ScheduleReminders :
             SingleFragmentActivity
                 .getIntent(
                     context,
-                    ScheduleReminders::class,
+                    ScheduleRemindersFragment::class,
                     Bundle().apply {
                         putParcelable(EXTRAS_SCOPE_KEY, scope)
                     },
                 ).apply {
-                    Timber.i("launching ScheduleReminders for %s scope", scope)
+                    Timber.i("launching ScheduleRemindersFragment for %s scope", scope)
                 }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
@@ -30,7 +30,6 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.commit
-import androidx.fragment.app.setFragmentResultListener
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -44,6 +43,7 @@ import com.ichi2.anki.canUserAccessDeck
 import com.ichi2.anki.databinding.FragmentScheduleRemindersBinding
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.DeckId
+import com.ichi2.anki.reviewreminders.AddEditReminderDialog.Companion.registerAddEditReminderHandler
 import com.ichi2.anki.services.AlarmManagerService
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
@@ -67,7 +67,7 @@ class ScheduleRemindersFragment :
     private val scheduleRemindersScope: ReviewReminderScope by lazy {
         BundleCompat.getParcelable(
             requireArguments(),
-            EXTRAS_SCOPE_KEY,
+            ARGS_SCOPE,
             ReviewReminderScope::class.java,
         ) ?: ReviewReminderScope.Global
     }
@@ -183,21 +183,9 @@ class ScheduleRemindersFragment :
 
         // If the user creates or edits a review reminder, the dialog for doing so opens
         // Once their changes are complete, the dialog closes and this fragment is reloaded
-        // Hence, we check for any fragment results here and update the database accordingly
-        setFragmentResultListener(ADD_EDIT_DIALOG_RESULT_REQUEST_KEY) { _, bundle ->
-            val modeOfFinishedDialog =
-                BundleCompat.getParcelable(
-                    requireArguments(),
-                    ACTIVE_DIALOG_MODE_ARGUMENTS_KEY,
-                    AddEditReminderDialog.DialogMode::class.java,
-                ) ?: return@setFragmentResultListener
-            val newOrModifiedReminder =
-                BundleCompat.getParcelable(
-                    bundle,
-                    ADD_EDIT_DIALOG_RESULT_REQUEST_KEY,
-                    ReviewReminder::class.java,
-                )
-            Timber.d("Dialog result received with recent dialog mode: %s", modeOfFinishedDialog)
+        // Hence, we check for any fragment results and update the database accordingly
+        registerAddEditReminderHandler { newOrModifiedReminder, modeOfFinishedDialog ->
+            Timber.i("Received result from add/edit dialog: mode=%s reminder=%s", modeOfFinishedDialog, newOrModifiedReminder)
             handleAddEditDialogResult(newOrModifiedReminder, modeOfFinishedDialog)
         }
     }
@@ -429,8 +417,6 @@ class ScheduleRemindersFragment :
         Timber.d("Adding new review reminder")
         val dialogMode = AddEditReminderDialog.DialogMode.Add(scheduleRemindersScope)
         val dialog = AddEditReminderDialog.getInstance(dialogMode)
-        // Save the dialog mode so that we refer back to it once the dialog closes
-        requireArguments().putParcelable(ACTIVE_DIALOG_MODE_ARGUMENTS_KEY, dialogMode)
         showDialogFragment(dialog)
     }
 
@@ -442,8 +428,6 @@ class ScheduleRemindersFragment :
         Timber.d("Editing review reminder: %s", reminder.id)
         val dialogMode = AddEditReminderDialog.DialogMode.Edit(reminder)
         val dialog = AddEditReminderDialog.getInstance(dialogMode)
-        // Save the dialog mode so that we refer back to it once the dialog closes
-        requireArguments().putParcelable(ACTIVE_DIALOG_MODE_ARGUMENTS_KEY, dialogMode)
         showDialogFragment(dialog)
     }
 
@@ -470,20 +454,7 @@ class ScheduleRemindersFragment :
         /**
          * Arguments key for passing the [ReviewReminderScope] to open this fragment with.
          */
-        private const val EXTRAS_SCOPE_KEY = "scope"
-
-        /**
-         * Arguments key for storing the current or latest [AddEditReminderDialog] instance.
-         * We save this so we can pass [onDeckSelected] onward to the dialog
-         * and so we can determine what reminder has been recently edited.
-         */
-        private const val ACTIVE_DIALOG_MODE_ARGUMENTS_KEY = "active_dialog_mode"
-
-        /**
-         * Fragment result key for receiving the result of [AddEditReminderDialog].
-         * Public so [AddEditReminderDialog] can access it, too.
-         */
-        const val ADD_EDIT_DIALOG_RESULT_REQUEST_KEY = "add_edit_reminder_dialog_result_request_key"
+        private const val ARGS_SCOPE = "scope"
 
         /**
          * Wrapper for database access in this fragment.
@@ -510,7 +481,7 @@ class ScheduleRemindersFragment :
                     context,
                     ScheduleRemindersFragment::class,
                     Bundle().apply {
-                        putParcelable(EXTRAS_SCOPE_KEY, scope)
+                        putParcelable(ARGS_SCOPE, scope)
                     },
                 ).apply {
                     Timber.i("launching ScheduleRemindersFragment for %s scope", scope)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/AlarmManagerService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/AlarmManagerService.kt
@@ -24,7 +24,6 @@ import android.content.Intent
 import androidx.annotation.VisibleForTesting
 import androidx.core.app.PendingIntentCompat
 import androidx.core.content.getSystemService
-import androidx.core.os.BundleCompat
 import com.ichi2.anki.R
 import com.ichi2.anki.android.AnkiBroadcastReceiver
 import com.ichi2.anki.common.time.TimeManager
@@ -37,6 +36,7 @@ import com.ichi2.anki.services.AlarmManagerService.Companion.getIntent
 import com.ichi2.anki.services.AlarmManagerService.Companion.scheduleAllEnabledReviewReminderNotifications
 import com.ichi2.anki.services.AlarmManagerService.Companion.unscheduleReviewReminderNotifications
 import com.ichi2.anki.showThemedToast
+import com.ichi2.anki.utils.ext.getParcelableCompat
 import timber.log.Timber
 import java.util.Calendar
 import kotlin.time.Duration
@@ -361,11 +361,7 @@ class AlarmManagerService : AnkiBroadcastReceiver() {
         // Get the request type
         val extras = intent.extras ?: return
         val reviewReminder =
-            BundleCompat.getParcelable(
-                extras,
-                EXTRA_REVIEW_REMINDER,
-                ReviewReminder::class.java,
-            ) ?: return
+            extras.getParcelableCompat<ReviewReminder>(EXTRA_REVIEW_REMINDER) ?: return
         // Dismiss the snoozed notification when the snooze button is clicked
         val manager = context.getSystemService<NotificationManager>()
         manager?.cancel(NotificationService.REVIEW_REMINDER_NOTIFICATION_TAG, reviewReminder.id.value)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
@@ -24,7 +24,6 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.app.NotificationCompat
 import androidx.core.app.PendingIntentCompat
 import androidx.core.content.getSystemService
-import androidx.core.os.BundleCompat
 import com.ichi2.anki.Channel
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.DeckPicker
@@ -46,6 +45,7 @@ import com.ichi2.anki.services.NotificationService.Companion.addAction
 import com.ichi2.anki.services.NotificationService.Companion.getIntent
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.utils.ext.allDecksCounts
+import com.ichi2.anki.utils.ext.getParcelableCompat
 import com.ichi2.anki.utils.remainingTime
 import com.ichi2.widget.WidgetStatus
 import net.ankiweb.rsdroid.BackendException
@@ -460,11 +460,7 @@ class NotificationService : AnkiBroadcastReceiver() {
             val extras = intent.extras ?: return
             val reviewReminder =
                 try {
-                    BundleCompat.getParcelable(
-                        extras,
-                        EXTRA_REVIEW_REMINDER,
-                        ReviewReminder::class.java,
-                    ) ?: return
+                    extras.getParcelableCompat<ReviewReminder>(EXTRA_REVIEW_REMINDER) ?: return
                 } catch (e: BadParcelableException) {
                     // #20782: If the extra's review reminder has an invalid schema, attempt a full re-schedule of all
                     // review reminder notifications, as that will retrieve reminders from Shared Preferences

--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -326,9 +326,9 @@ open class PrefsRepository(
      * when in reality notification permissions have not been requested for the device. This is most prominently
      * an issue for the review reminders feature, so to ensure the user is able to receive review reminder notifications after
      * a data restore / migration, a Snackbar noting that notification permissions are missing will be shown
-     * on the [com.ichi2.anki.reviewreminders.ScheduleReminders] fragment if notification permissions are not granted.
+     * on the [com.ichi2.anki.reviewreminders.ScheduleRemindersFragment] fragment if notification permissions are not granted.
      *
-     * @see com.ichi2.anki.reviewreminders.ScheduleReminders.checkForNotificationPermissions
+     * @see com.ichi2.anki.reviewreminders.ScheduleRemindersFragment.checkForNotificationPermissions
      */
     var notificationsPermissionRequested by booleanPref(R.string.notifications_permission_requested_key, false)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsBottomSheet.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsBottomSheet.kt
@@ -22,7 +22,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
@@ -32,6 +31,7 @@ import com.ichi2.anki.PermissionSet
 import com.ichi2.anki.R
 import com.ichi2.anki.databinding.FragmentPermissionsBottomSheetBinding
 import com.ichi2.anki.utils.ext.behavior
+import com.ichi2.anki.utils.ext.getParcelableCompat
 import dev.androidbroadcast.vbpd.viewBinding
 
 /**
@@ -69,7 +69,7 @@ class PermissionsBottomSheet : BottomSheetDialogFragment() {
         }
 
         val permissionSet =
-            requireNotNull(BundleCompat.getParcelable(requireArguments(), PERMISSION_SET_ARGUMENT_KEY, PermissionSet::class.java)) {
+            requireNotNull(requireArguments().getParcelableCompat<PermissionSet>(PERMISSION_SET_ARGUMENT_KEY)) {
                 "Permission set cannot be null"
             }
         val permissionsFragment =

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/AlarmManagerServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/AlarmManagerServiceTest.kt
@@ -36,6 +36,7 @@ import com.ichi2.anki.reviewreminders.ReviewReminderScope
 import com.ichi2.anki.reviewreminders.ReviewReminderTime
 import com.ichi2.anki.reviewreminders.ReviewRemindersDatabase
 import com.ichi2.anki.services.NotificationService.Companion.EXTRA_REVIEW_REMINDER
+import com.ichi2.anki.utils.ext.getParcelableCompat
 import com.ichi2.testutils.ext.storeReminders
 import io.mockk.every
 import io.mockk.mockk
@@ -221,11 +222,7 @@ class AlarmManagerServiceTest : RobolectricTest() {
         val actuallyFired =
             capturedIntents
                 .map { intent ->
-                    BundleCompat.getParcelable(
-                        intent.extras!!,
-                        EXTRA_REVIEW_REMINDER,
-                        ReviewReminder::class.java,
-                    )!!
+                    intent.extras!!.getParcelableCompat<ReviewReminder>(EXTRA_REVIEW_REMINDER)!!
                 }.toSet()
         val actuallyFiredIds = actuallyFired.map { it.id }.toSet()
         val notFired = testCases.map { it.reminder }.filterNot { it.id in actuallyFiredIds }.toSet()


### PR DESCRIPTION
## Purpose / Description
- Renames `ScheduleReminders` to `ScheduleRemindersFragment`.
- Refactors `AddEditReminderDialog` to use viewbinding.
- Cleans up some deck selection listener junk that is now unnecessary thanks to `lukstbit`'s change at https://github.com/ankidroid/Anki-Android/pull/20889
- Previously, the mode the AddEditReminderDialog was opened in was stored via an argument. This 1) causes issues with my future refactor of the fragment UI and 2) is bad design. We now pass the mode to the dialog and have it pass it back along with the reminder. The bundle argument keys are also standardized, and we no longer reuse the fragment result key as the ReviewReminder bundle key.

## Fixes
* Precursor to the larger fragment refactor and UI cleanup I'm working on for the review reminders system: making sure the UI looks good on mobile, tablet, edge-to-edge, no matter where it's opened from, adhering to the styling of the Settings pages, etc. etc... it's taking a while long than I would like, so let's get the bits I'm 100% confident in merged first.

## How Has This Been Tested?
- Physical Lenovo M11 Tablet, API 35
- Physical Samsung S23, API 34
- Launching, opening screen from all sources, CRUD'ing reminders all works

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->