### PR TITLE
test: deck picker screenshot test

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -268,7 +268,8 @@ open class DeckPicker :
     private lateinit var deckListAdapter: DeckAdapter
     private lateinit var pullToSyncWrapper: SwipeRefreshLayout
 
-    private lateinit var floatingActionMenu: DeckPickerFloatingActionMenu
+    @VisibleForTesting
+    lateinit var floatingActionMenu: DeckPickerFloatingActionMenu
 
     var activeSnackBar: Snackbar? = null
     private val activeSnackbarCallback =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
@@ -22,6 +22,7 @@ import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
 import android.widget.LinearLayout
+import androidx.annotation.VisibleForTesting
 import com.google.android.material.color.MaterialColors
 import com.ichi2.anki.databinding.ActivityHomescreenBinding
 import com.ichi2.anki.databinding.IncludeFloatingAddButtonBinding
@@ -59,7 +60,8 @@ class DeckPickerFloatingActionMenu(
     val isFragmented: Boolean
         get() = studyOptionsFrame != null
 
-    private fun showFloatingActionMenu() {
+    @VisibleForTesting
+    fun showFloatingActionMenu() {
         toggleListener?.onBeginToggle(isOpening = true)
         deckPicker.activeSnackBar?.dismiss()
         linearLayout.alpha = 0.5f

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AllActivitiesScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AllActivitiesScreenshotTest.kt
@@ -7,7 +7,6 @@ import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.core.content.edit
 import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -17,7 +16,6 @@ import com.ichi2.anki.account.AccountActivity
 import com.ichi2.anki.instantnoteeditor.InstantNoteEditorActivity
 import com.ichi2.anki.multimedia.MultimediaActivity
 import com.ichi2.anki.preferences.PreferencesActivity
-import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.previewer.CardViewerActivity
 import com.ichi2.anki.utils.ConfigAwareSingleFragmentActivity
 import com.ichi2.testutils.ActivityList
@@ -66,13 +64,6 @@ class AllActivitiesScreenshotTest : ScreenshotTest() {
         notYetHandled(CardTemplateEditor::class.java.simpleName, "Needs a real note type in the collection")
 
         super.setUp()
-
-        // Setup for DeckPicker
-        ensureCollectionLoadIsSynchronous()
-        setIntroductionSlidesShown(true)
-        BackupManagerTestUtilities.setupSpaceForBackup(targetContext)
-        // suppress the periodic 'backup your collection' prompt so the screenshot is just the activity
-        targetContext.sharedPrefs().edit { putBoolean("backupPromptDisabled", true) }
     }
 
     @After
@@ -116,7 +107,9 @@ class AllActivitiesScreenshotTest : ScreenshotTest() {
     class ActivityLauncherProvider : TestParameterValuesProvider() {
         override fun provideValues(context: Context?): List<ActivityConfig> {
             val handled =
-                listOf(
+                setOf(
+                    // DeckPickerScreenshotTest
+                    DeckPicker::class.java,
                     // StudyScreenScreenshotTest, PreviewerScreenshotTest and TemplatePreviewerScreenshotTest
                     CardViewerActivity::class.java,
                     // PreferencesScreenshotTest

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerScreenshotTest.kt
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 Brayan Oliveira <brayandso.dev@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+package com.ichi2.anki
+
+import androidx.core.content.edit
+import com.ichi2.anki.preferences.sharedPrefs
+import com.ichi2.testutils.BackupManagerTestUtilities
+import org.junit.Before
+import org.junit.Test
+
+class DeckPickerScreenshotTest : ScreenshotTest() {
+    @Before
+    override fun setUp() {
+        super.setUp()
+        ensureCollectionLoadIsSynchronous()
+        setIntroductionSlidesShown(true)
+        BackupManagerTestUtilities.setupSpaceForBackup(targetContext)
+        // suppress the periodic 'backup your collection' prompt so the screenshot is just the activity
+        targetContext.sharedPrefs().edit { putBoolean("backupPromptDisabled", true) }
+    }
+
+    @Test
+    fun baseState_and_fabExpanded() {
+        val intent = DeckPicker.getIntent(targetContext)
+        val activity = startActivityNormallyOpenCollectionWithIntent(DeckPicker::class.java, intent)
+        captureScreen("baseState")
+
+        activity.floatingActionMenu.showFloatingActionMenu()
+        captureScreen("fabExpanded")
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CardSideSelectionDialogScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CardSideSelectionDialogScreenshotTest.kt
@@ -9,7 +9,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric.buildActivity
 
-@RunWith(AndroidJUnit4::class)
 class CardSideSelectionDialogScreenshotTest : ScreenshotTest() {
     @Test
     fun testCardSideSelectionDialogAppearance() {


### PR DESCRIPTION
## Purpose / Description

I wanted a test to check the FAB buttons when expanded

Blocked by #21059 -> remove from AllActivitiesScreenshotTest

## How Has This Been Tested?

./gradlew :AnkiDroid:recordRoborazziPlayDebug -Pscreenshot --tests "com.ichi2.anki.DeckPickerScreenshotTest"

<details>

<img width="1078" height="2399" alt="baseState" src="https://github.com/user-attachments/assets/3522fb68-929b-46be-9a79-6233d620cf90" />

<img width="1078" height="2399" alt="fabExpanded" src="https://github.com/user-attachments/assets/d323dd3e-db4c-49c2-b231-8ac9a8d6f878" />

</details>


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->