### PR TITLE
docs: make `SPDX-FileCopyrightText` optional

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/AllActivitiesScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AllActivitiesScreenshotTest.kt
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2026 David Allison <davidallisongithub@gmail.com>
 // SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.ichi2.anki
 
 import android.app.Activity

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CoroutineHelpersTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CoroutineHelpersTest.kt
@@ -1,4 +1,3 @@
-// SPDX-FileCopyrightText: 2026 David Allison <davidallisongithub@gmail.com>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 package com.ichi2.anki

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,26 @@ git push origin HEAD
 
 See also: [Wiki - Git - One time setup guide](https://github.com/ankidroid/Anki-Android/wiki/Development-Guide/#initial-setup-one-time)
 
+### License/copyright headers
+
+Files you create MUST either:
+1. Start with a [SPDX License ID](https://spdx.dev/learn/handling-license-info/): `// SPDX-License-Identifier: GPL-3.0-or-later`
+   - Recommended for most files
+   - Use `LGPL-3.0-or-later` for the API
+2. Start with a [long-form license](https://softwarefreedom.org/resources/2007/gpl-non-gpl-collaboration.html#x1-40002.2) including copyright.  
+   - If the license is non-GPL
+   - Pre-2026 mono-licensed GPL files may use this form, it is not recommended for new mono-licensed GPL files.
+3. Follow the [`REUSE.toml` spec](https://reuse.software/spec-3.2/#reusetoml)
+   - For new files where the above is not possible/desired (images etc...).
+
+#### Copyright headers
+
+Copyright headers are **optional** and must come after the license identifier line. 
+You own the copyright of your contributions, regardless of the copyright header.
+
+See [docs/contributing/copyright-headers.md](docs/contributing/copyright-headers.md) for how to 
+ apply a copyright header. 
+
 ## Before submitting a Pull Request (PR)
 
 > [!WARNING]

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,8 @@
+version = 1
+
+# make FileCopyrightText optional on all .kt files
+# see docs/contributing/copyright-headers.md
+[[annotations]]
+path = "**.kt"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "Contributors to the AnkiDroid project"

--- a/anki-common/build.gradle.kts
+++ b/anki-common/build.gradle.kts
@@ -1,4 +1,3 @@
-// SPDX-FileCopyrightText: 2026 David Allison <davidallisongithub@gmail.com>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import com.android.build.api.dsl.LibraryExtension

--- a/anki-common/src/main/AndroidManifest.xml
+++ b/anki-common/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- SPDX-FileCopyrightText: 2026 David Allison <davidallisongithub@gmail.com> -->
 <!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 <manifest>
 

--- a/docs/contributing/copyright-headers.md
+++ b/docs/contributing/copyright-headers.md
@@ -1,0 +1,38 @@
+# Copyright headers
+
+AnkiDroid uses git history as the authoritative record of authorship. 
+You own the copyright of your contributions, regardless of the copyright header. 
+Copyright headers are optional
+
+Please contact the maintainers, or raise an issue if you have any questions/concerns.
+
+## Applying a copyright header
+
+You may add a copyright header to work which you have created or nontrivially modified. 
+Your name may be a pseudonym, and the email is optional.
+
+The copyright line should be added at the end of the header and it is recommended to be formatted as follows:
+
+```diff
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2023 Existing Contributor <email@example.com>
+// SPDX-FileCopyrightText: 2026 New Contributor Name <email@example.com>
+
+package com.ichi2.anki
+```
+
+Alternate formats are listed: https://reuse.software/faq/#copyright-symbol 
+
+You may request this header be added to your work retroactively (ideally via a pull request).
+
+## Collective copyright
+
+The project adds a collective copyright line to `.kt` files for license-compliance tooling:
+
+`SPDX-FileCopyrightText: Contributors to the AnkiDroid project`
+
+This is informational only and does not affect your copyright. See [REUSE.toml](../../REUSE.toml) for the implementation.
+
+## Removing copyright headers
+
+Existing copyright notices must be preserved **as-is** and **must not** be removed.  The only exception is when this copyright header is your own.

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
@@ -22,7 +22,6 @@ import com.android.tools.lint.client.api.Vendor
 import com.android.tools.lint.detector.api.CURRENT_API
 import com.android.tools.lint.detector.api.Issue
 import com.ichi2.anki.lint.rules.AvoidAlertDialogUsage
-import com.ichi2.anki.lint.rules.CopyrightHeaderExists
 import com.ichi2.anki.lint.rules.DirectCalendarInstanceUsage
 import com.ichi2.anki.lint.rules.DirectDateInstantiation
 import com.ichi2.anki.lint.rules.DirectGregorianInstantiation
@@ -36,6 +35,7 @@ import com.ichi2.anki.lint.rules.HardcodedPreferenceKey
 import com.ichi2.anki.lint.rules.InvalidStringFormatDetector
 import com.ichi2.anki.lint.rules.JUnitNullAssertionDetector
 import com.ichi2.anki.lint.rules.LayoutPrefixDetector
+import com.ichi2.anki.lint.rules.LicenseHeaderExists
 import com.ichi2.anki.lint.rules.LocaleRootDetector
 import com.ichi2.anki.lint.rules.NonPositionalFormatSubstitutions
 import com.ichi2.anki.lint.rules.OpenInputStreamSafeDetector
@@ -51,7 +51,6 @@ class IssueRegistry : IssueRegistry() {
             // Keep this list lexicographically ordered.
             return listOf(
                 LayoutPrefixDetector.ISSUE,
-                CopyrightHeaderExists.ISSUE,
                 DirectCalendarInstanceUsage.ISSUE,
                 DirectDateInstantiation.ISSUE,
                 DirectGregorianInstantiation.ISSUE,
@@ -62,6 +61,7 @@ class IssueRegistry : IssueRegistry() {
                 DuplicateCrowdInStrings.ISSUE,
                 HardcodedPreferenceKey.ISSUE,
                 JUnitNullAssertionDetector.ISSUE,
+                LicenseHeaderExists.ISSUE,
                 LocaleRootDetector.ISSUE,
                 PrintStackTraceUsage.ISSUE,
                 NonPositionalFormatSubstitutions.ISSUE,

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/LicenseHeaderExists.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/LicenseHeaderExists.kt
@@ -21,6 +21,7 @@ import com.android.tools.lint.detector.api.Context
 import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.Implementation
 import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.LintFix
 import com.android.tools.lint.detector.api.Location
 import com.android.tools.lint.detector.api.Scope
 import com.android.tools.lint.detector.api.SourceCodeScanner
@@ -40,7 +41,7 @@ import java.util.regex.Pattern
  * @see .EXPLANATION
  */
 @Beta
-class CopyrightHeaderExists :
+class LicenseHeaderExists :
     Detector(),
     SourceCodeScanner {
     companion object {
@@ -71,17 +72,18 @@ class CopyrightHeaderExists :
         const val ID = "MissingCopyrightHeader"
 
         @VisibleForTesting
-        const val DESCRIPTION = "All files in AnkiDroid must contain a GPLv3-compatible copyright header"
+        const val DESCRIPTION = "All files in AnkiDroid must contain a GPLv3-compatible license identifier"
         private const val EXPLANATION =
             "All files in AnkiDroid must start with a " +
-                "GPLv3-compatible copyright header: \n" +
+                "GPLv3-compatible license identifier: \n" +
                 "```" +
-                $$"// SPDX-FileCopyrightText: $today.year Your Name <email@example.com> // name + email optional\n" +
-                "// SPDX-License-Identifier: GPL-3.0-or-later" +
+                $$"// SPDX-License-Identifier: GPL-3.0-or-later" +
                 "```\n" +
                 "The copyright header can be set in " +
                 "`Settings - Editor - Copyright - Copyright Profiles - Add Profile - AnkiDroid`" +
-                "or search in Settings for 'Copyright'. " +
+                "or search in Settings for 'Copyright'. \n" +
+                "You may optionally add your copyright to the file. " +
+                "See https://github.com/ankidroid/Anki-Android/blob/main/docs/contributing/copyright-headers.md.\n" +
                 "A long-form header may also be used: " +
                 "https://github.com/ankidroid/Anki-Android/issues/8211#issuecomment-825269673\n\n" +
                 "If the file is under a GPL-Compatible License " +
@@ -89,7 +91,7 @@ class CopyrightHeaderExists :
                 "then this warning may be suppressed either by adding a GPL header alongside the license " +
                 "(https://softwarefreedom.org/resources/2007/gpl-non-gpl-collaboration.html#x1-40002.2) or by " +
                 "adding \"//noinspection MissingCopyrightHeader <reason>\" as the first line of the file."
-        private val implementation = Implementation(CopyrightHeaderExists::class.java, EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES))
+        private val implementation = Implementation(LicenseHeaderExists::class.java, EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES))
         val ISSUE: Issue =
             Issue.create(
                 ID,
@@ -128,6 +130,25 @@ class CopyrightHeaderExists :
         // If there is no line break, highlight the contents
         val endOffset = if (end == 0) contents.length else end
         val location: Location = Location.create(context.file, contents.subSequence(0, endOffset), 0, endOffset)
-        context.report(ISSUE, location, DESCRIPTION)
+        context.report(ISSUE, location, DESCRIPTION, createFix(context, location))
+    }
+
+    /**
+     * Builds a [LintFix] that prepends `// SPDX-License-Identifier` to the file
+     */
+    private fun createFix(
+        context: Context,
+        location: Location,
+    ): LintFix {
+        val license = if (context.project.name == "api") "LGPL" else "GPL"
+        return LintFix
+            .create()
+            .name("Add SPDX-License-Identifier: $license-3.0-or-later")
+            .replace()
+            .range(location)
+            .beginning()
+            .with("// SPDX-License-Identifier: $license-3.0-or-later\n\n")
+            .autoFix()
+            .build()
     }
 }

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/LicenseHeaderExistsTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/LicenseHeaderExistsTest.kt
@@ -15,6 +15,7 @@
  */
 package com.ichi2.anki.lint.rules
 
+import com.android.tools.lint.checks.infrastructure.ProjectDescription
 import com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile.create
 import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
 import com.google.common.annotations.Beta
@@ -22,12 +23,12 @@ import org.intellij.lang.annotations.Language
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-/** Test for [CopyrightHeaderExists] */
+/** Test for [LicenseHeaderExists] */
 @Suppress("UnstableApiUsage")
 @Beta
-class CopyrightHeaderExistsTest {
+class LicenseHeaderExistsTest {
     @Language("JAVA")
-    private val copyrightHeader = """/*
+    private val fileWithLicense = """/*
  *  This program is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free Software
  *  Foundation; either version 3 of the License, or (at your option) any later
@@ -42,34 +43,34 @@ class CopyrightHeaderExistsTest {
  */"""
 
     @Language("JAVA")
-    private val spdxCopyrightHeader =
-        """// SPDX-FileCopyrightText: 2025 David Allison <david@example.com>
-// SPDX-License-Identifier: GPL-3.0-or-later"""
+    private val spdxGplHeader =
+        "// SPDX-License-Identifier: GPL-3.0-or-later"
 
     @Language("JAVA")
-    private val spdxLgplCopyrightHeader =
-        """// SPDX-FileCopyrightText: 2025 David Allison <david@example.com>
-// SPDX-License-Identifier: LGPL-3.0-or-later"""
+    private val spdxLgplHeader =
+        "// SPDX-License-Identifier: LGPL-3.0-or-later"
 
     // invalid
     @Language("JAVA")
     private val spdxOldGplHeader =
-        """// SPDX-FileCopyrightText: 2025 David Allison <david@example.com>
-// SPDX-License-Identifier: GPL-3.0"""
+        "// SPDX-License-Identifier: GPL-3.0"
 
     @Language("JAVA")
     private val spdxGplOnlyHeader =
-        """// SPDX-FileCopyrightText: 2025 David Allison <david@example.com>
-// SPDX-License-Identifier: GPL-3.0-only"""
+        "// SPDX-License-Identifier: GPL-3.0-only"
 
     // invalid
     @Language("JAVA")
     private val spdxLgplOnlyHeader =
-        """// SPDX-FileCopyrightText: 2025 David Allison <ddavid@example.com>
-// SPDX-License-Identifier: LGPL-3.0"""
+        "// SPDX-License-Identifier: LGPL-3.0"
 
     @Language("JAVA")
-    private val noCopyrightHeader =
+    private val spdxGplAndCopyrightHeader =
+        """// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025 David Allison <david@example.com>"""
+
+    @Language("JAVA")
+    private val noHeader =
         """
         
         package com.ichi2.upgrade;
@@ -86,31 +87,41 @@ class CopyrightHeaderExistsTest {
         """.trimIndent()
 
     @Test
-    fun fileWithCopyrightHeaderPasses() {
+    fun fileWithLicensePasses() {
         lint()
             .allowMissingSdk()
-            .files(create(copyrightHeader))
-            .issues(CopyrightHeaderExists.ISSUE)
+            .files(create(fileWithLicense))
+            .issues(LicenseHeaderExists.ISSUE)
             .run()
             .expectClean()
     }
 
     @Test
-    fun fileWithSpdxCopyrightHeaderPasses() {
+    fun fileWithSpdxLicenseHeaderPasses() {
         lint()
             .allowMissingSdk()
-            .files(create(spdxCopyrightHeader))
-            .issues(CopyrightHeaderExists.ISSUE)
+            .files(create(spdxGplHeader))
+            .issues(LicenseHeaderExists.ISSUE)
             .run()
             .expectClean()
     }
 
     @Test
-    fun fileWithSpdxLgplCopyrightHeaderPasses() {
+    fun fileWithSpdxLgplLicenseHeaderPasses() {
         lint()
             .allowMissingSdk()
-            .files(create(spdxLgplCopyrightHeader))
-            .issues(CopyrightHeaderExists.ISSUE)
+            .files(create(spdxLgplHeader))
+            .issues(LicenseHeaderExists.ISSUE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun fileWithGplAndCopyrightHeaderPasses() {
+        lint()
+            .allowMissingSdk()
+            .files(create(spdxGplAndCopyrightHeader))
+            .issues(LicenseHeaderExists.ISSUE)
             .run()
             .expectClean()
     }
@@ -121,7 +132,7 @@ class CopyrightHeaderExistsTest {
             .allowMissingSdk()
             .allowCompilationErrors()
             .files(create(spdxOldGplHeader))
-            .issues(CopyrightHeaderExists.ISSUE)
+            .issues(LicenseHeaderExists.ISSUE)
             .run()
             .expectErrorCount(1)
     }
@@ -132,7 +143,7 @@ class CopyrightHeaderExistsTest {
             .allowMissingSdk()
             .allowCompilationErrors()
             .files(create(spdxGplOnlyHeader))
-            .issues(CopyrightHeaderExists.ISSUE)
+            .issues(LicenseHeaderExists.ISSUE)
             .run()
             .expectErrorCount(1)
     }
@@ -143,23 +154,59 @@ class CopyrightHeaderExistsTest {
             .allowMissingSdk()
             .allowCompilationErrors()
             .files(create(spdxLgplOnlyHeader))
-            .issues(CopyrightHeaderExists.ISSUE)
+            .issues(LicenseHeaderExists.ISSUE)
             .run()
             .expectErrorCount(1)
     }
 
     @Test
-    fun fileWithNoCopyrightHeaderFails() {
+    fun fileWithNoLicenseHeaderFails() {
         lint()
             .allowMissingSdk()
             .allowCompilationErrors() // import failures
-            .files(create(noCopyrightHeader))
-            .issues(CopyrightHeaderExists.ISSUE)
+            .files(create(noHeader))
+            .issues(LicenseHeaderExists.ISSUE)
             .run()
             .expectErrorCount(1)
             .check({ output: String ->
-                assertTrue(output.contains(CopyrightHeaderExists.ID))
-                assertTrue(output.contains(CopyrightHeaderExists.DESCRIPTION))
+                assertTrue(output.contains(LicenseHeaderExists.ID))
+                assertTrue(output.contains(LicenseHeaderExists.DESCRIPTION))
             })
+    }
+
+    @Test
+    fun autofixPrependsSpdxIdentifier() {
+        lint()
+            .allowMissingSdk()
+            .allowCompilationErrors()
+            .files(create(noHeader))
+            .issues(LicenseHeaderExists.ISSUE)
+            .run()
+            .expectFixDiffs(
+                """
+                Autofix for src/com/ichi2/upgrade/Upgrade.java line 1: Add SPDX-License-Identifier: GPL-3.0-or-later:
+                @@ -1 +1
+                + // SPDX-License-Identifier: GPL-3.0-or-later
+                +
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    fun autofixInApiModuleUsesLgpl() {
+        lint()
+            .allowMissingSdk()
+            .allowCompilationErrors()
+            .projects(ProjectDescription(create(noHeader)).name("api"))
+            .issues(LicenseHeaderExists.ISSUE)
+            .run()
+            .expectFixDiffs(
+                """
+                Autofix for src/com/ichi2/upgrade/Upgrade.java line 1: Add SPDX-License-Identifier: LGPL-3.0-or-later:
+                @@ -1 +1
+                + // SPDX-License-Identifier: LGPL-3.0-or-later
+                +
+                """.trimIndent(),
+            )
     }
 }


### PR DESCRIPTION
Live links:

* https://github.com/david-allison/Anki-Android/blob/spdx-copyright/CONTRIBUTING.md#licensecopyright-headers
* https://github.com/david-allison/Anki-Android/blob/spdx-copyright/docs/contributing/copyright-headers.md


## Purpose / Description
According to the Berne Convention, copyright is automatic, and the license header is informative only.

Our (minimal) license header now matches the style of the Linux Kernel:

```
// SPDX-License-Identifier: GPL-3.0-or-later
```

This saves reviewer time, tokens, and allows an automated `LintFix` to be applied

## Fixes
* Fixes #21013

## Approach
This adds a REUSE.toml file to silence the lint on .kt files, and an update to the docs and lint.

Due to the brevity of the fix, a `LintFix` is now offered on the in-IDE lint warning

## How Has This Been Tested?

<img width="850" height="389" alt="Screenshot 2026-05-17 at 01 08 50" src="https://github.com/user-attachments/assets/1cca31c5-4844-4d7b-ae3f-e81a725888c0" />

`reuse lint` was a little more happy

## Learning (optional, can help others)

The Linux Foundation's general rationale for making the copyright side of the header optional:

- Copyright notices are not mandatory in order for the contributor to retain ownership of their copyright.
- Copyright notices are rarely kept up to date as a file evolves, resulting in inaccurate statements.
- Trying to keep notices up to date, or to correct notices that have become inaccurate, increases the burden on developers without tangible benefit.
- Developers and maintainers often do not want to have to worry about e.g. whether a minor contribution (such as a typo fix) means that a new copyright notice should be added.
- The specific individual or legal entity that owns the copyright might not be known to the contributor; it could be you, your employer, or some other entity.

Note that the GPL states that per-file copyright is the safest option:

> To do so, attach the following notices to the program.  It is safest
> to attach them to the start of each source file to most effectively
> state the exclusion of warranty

https://docs.kernel.org/process/license-rules.html#license-identifier-syntax https://www.linuxfoundation.org/blog/blog/copyright-notices-in-open-source-software-projects


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)