### PR TITLE
fix(lint): register new modules for lint, and auto-register all in CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,13 +11,13 @@ following scripts before submitting a PR.
 
 Alternately, you may run the actions on your fork of `Anki-Android`.
 
-| **Job**                                                                                                    | **Command**                                                                                                           | **Comments**                                              |
-|------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------|
-| [Lint (Kotlin)](https://github.com/ankidroid/Anki-Android/blob/main/.github/workflows/lint.yml)            | `./gradlew lintPlayDebug :api:lintDebug :libanki:lintDebug ktLintCheck lintVitalFullRelease lint-rules:test --daemon` | Android lint rules, formatting and tests for lint rules   |
-| [Lint (JavaScript)](https://github.com/ankidroid/Anki-Android/blob/main/.github/workflows/lint.yml)        | See script                                                                                                            | Prettier, lint & code formatting                          |
-| [Unit Tests](https://github.com/ankidroid/Anki-Android/blob/main/.github/workflows/tests_unit.yml)         | `./gradlew jacocoUnitTestReport --daemon`                                                                             | Unit tests for the Android Project                        |
-| [Emulator Tests](https://github.com/ankidroid/Anki-Android/blob/main/.github/workflows/tests_emulator.yml) | `TEST_RELEASE_BUILD=true ./gradlew jacocoAndroidTestReport --daemon`                                                  | Emulator tests for the Android Project                    |
-| [CodeQL](https://github.com/ankidroid/Anki-Android/blob/main/.github/workflows/codeql.yml)                 | N/A                                                                                                                   | GitHub-only check.<br/>[Docs](https://codeql.github.com/) |
+| **Job**                                                                                                    | **Command**                                                                   | **Comments**                                              |
+|------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|-----------------------------------------------------------|
+| [Lint (Kotlin)](https://github.com/ankidroid/Anki-Android/blob/main/.github/workflows/lint.yml)            | `./gradlew lintAll ktLintCheck lintVitalFullRelease lint-rules:test --daemon` | Android lint rules, formatting and tests for lint rules   |
+| [Lint (JavaScript)](https://github.com/ankidroid/Anki-Android/blob/main/.github/workflows/lint.yml)        | See script                                                                    | Prettier, lint & code formatting                          |
+| [Unit Tests](https://github.com/ankidroid/Anki-Android/blob/main/.github/workflows/tests_unit.yml)         | `./gradlew jacocoUnitTestReport --daemon`                                     | Unit tests for the Android Project                        |
+| [Emulator Tests](https://github.com/ankidroid/Anki-Android/blob/main/.github/workflows/tests_emulator.yml) | `TEST_RELEASE_BUILD=true ./gradlew jacocoAndroidTestReport --daemon`          | Emulator tests for the Android Project                    |
+| [CodeQL](https://github.com/ankidroid/Anki-Android/blob/main/.github/workflows/codeql.yml)                 | N/A                                                                           | GitHub-only check.<br/>[Docs](https://codeql.github.com/) |
 
 ## Other Workflows
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,13 +11,13 @@ following scripts before submitting a PR.
 
 Alternately, you may run the actions on your fork of `Anki-Android`.
 
-| **Job**                                                                                                    | **Command**                                                                   | **Comments**                                              |
-|------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|-----------------------------------------------------------|
-| [Lint (Kotlin)](https://github.com/ankidroid/Anki-Android/blob/main/.github/workflows/lint.yml)            | `./gradlew lintAll ktLintCheck lintVitalFullRelease lint-rules:test --daemon` | Android lint rules, formatting and tests for lint rules   |
-| [Lint (JavaScript)](https://github.com/ankidroid/Anki-Android/blob/main/.github/workflows/lint.yml)        | See script                                                                    | Prettier, lint & code formatting                          |
-| [Unit Tests](https://github.com/ankidroid/Anki-Android/blob/main/.github/workflows/tests_unit.yml)         | `./gradlew jacocoUnitTestReport --daemon`                                     | Unit tests for the Android Project                        |
-| [Emulator Tests](https://github.com/ankidroid/Anki-Android/blob/main/.github/workflows/tests_emulator.yml) | `TEST_RELEASE_BUILD=true ./gradlew jacocoAndroidTestReport --daemon`          | Emulator tests for the Android Project                    |
-| [CodeQL](https://github.com/ankidroid/Anki-Android/blob/main/.github/workflows/codeql.yml)                 | N/A                                                                           | GitHub-only check.<br/>[Docs](https://codeql.github.com/) |
+| **Job**                                                                                                    | **Command**                                                          | **Comments**                                              |
+|------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------|-----------------------------------------------------------|
+| [Lint (Kotlin)](https://github.com/ankidroid/Anki-Android/blob/main/.github/workflows/lint.yml)            | `./gradlew lintAll ktLintCheck lint-rules:test --daemon`             | Android lint rules, formatting and tests for lint rules   |
+| [Lint (JavaScript)](https://github.com/ankidroid/Anki-Android/blob/main/.github/workflows/lint.yml)        | See script                                                           | Prettier, lint & code formatting                          |
+| [Unit Tests](https://github.com/ankidroid/Anki-Android/blob/main/.github/workflows/tests_unit.yml)         | `./gradlew jacocoUnitTestReport --daemon`                            | Unit tests for the Android Project                        |
+| [Emulator Tests](https://github.com/ankidroid/Anki-Android/blob/main/.github/workflows/tests_emulator.yml) | `TEST_RELEASE_BUILD=true ./gradlew jacocoAndroidTestReport --daemon` | Emulator tests for the Android Project                    |
+| [CodeQL](https://github.com/ankidroid/Anki-Android/blob/main/.github/workflows/codeql.yml)                 | N/A                                                                  | GitHub-only check.<br/>[Docs](https://codeql.github.com/) |
 
 ## Other Workflows
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,13 +50,12 @@ jobs:
           timeout_minutes: 10
           retry_wait_seconds: 60
           max_attempts: 3
-          command: ./gradlew :AnkiDroid:compilePlayDebugJavaWithJavac compileLint lint-rules:compileTestJava --daemon
+          command: ./gradlew :AnkiDroid:compileFullDebugJavaWithJavac compileLint lint-rules:compileTestJava --daemon
 
       - name: Run Lint Debug
-        # "lintAll" opts in all modules in 1 flavor to lint, pinning :AnkiDroid to lintPlayDebug
-        # "lintVitalFullRelease": if `main` resources are only used in `androidTest` (#15741)
+        # "lintAll" opts in all modules in 1 flavor to lint, pinning :AnkiDroid to lintFullDebug
         # update workflows/README.md when modifying this line
-        run: ./gradlew lintAll ktLintCheck lintVitalFullRelease lint-rules:test --daemon
+        run: ./gradlew lintAll ktLintCheck lint-rules:test --daemon
 
   # update workflows/README.md when modifying commands
   lintJavascript:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,13 +53,10 @@ jobs:
           command: ./gradlew :AnkiDroid:compilePlayDebugJavaWithJavac compileLint lint-rules:compileTestJava --daemon
 
       - name: Run Lint Debug
-        # "lint" is run under the 'Amazon' flavor, so slow in CI
-        # "lintPlayRelease" doesn't test androidTest
-        # "lintPlayDebug" doesn't test the API
+        # "lintAll" opts in all modules in 1 flavor to lint, pinning :AnkiDroid to lintPlayDebug
         # "lintVitalFullRelease": if `main` resources are only used in `androidTest` (#15741)
-
         # update workflows/README.md when modifying this line
-        run: ./gradlew lintPlayDebug :api:lintDebug :libanki:lintDebug ktLintCheck lintVitalFullRelease lint-rules:test --daemon
+        run: ./gradlew lintAll ktLintCheck lintVitalFullRelease lint-rules:test --daemon
 
   # update workflows/README.md when modifying commands
   lintJavascript:

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -59,8 +59,6 @@ dependencies {
     testImplementation(libs.junit.platform.launcher)
     testImplementation(libs.robolectric)
     testImplementation(libs.kotlin.test)
-
-    lintChecks(project(":lint-rules"))
 }
 
 afterEvaluate {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,11 +135,13 @@ subprojects {
     }
 }
 
-// Opt all modules in to lint (with :AnkiDroid pinned to one flavor: 'Play')
+// Opt all modules in to lint (with :AnkiDroid pinned to one flavor: 'Full')
 val lintAll = tasks.register("lintAll") {
     group = "verification"
     description = "Runs lint on every module."
-    dependsOn(":AnkiDroid:lintPlayDebug") // specify 'Play' explicitly so other flavors don't run
+    // specify 'Full' explicitly so other flavors don't run
+    // 'full' has no Manifest changes, so catches more unused references (#15741)
+    dependsOn(":AnkiDroid:lintFullDebug")
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,6 +135,22 @@ subprojects {
     }
 }
 
+// Opt all modules in to lint (with :AnkiDroid pinned to one flavor: 'Play')
+val lintAll = tasks.register("lintAll") {
+    group = "verification"
+    description = "Runs lint on every module."
+    dependsOn(":AnkiDroid:lintPlayDebug") // specify 'Play' explicitly so other flavors don't run
+}
+
+subprojects {
+    if (path == ":AnkiDroid") return@subprojects // pinned above to avoid other flavors
+    afterEvaluate {
+        // 'lintDebug' applies to all Android modules; 'lint' for all JVM modules
+        (tasks.findByName("lintDebug") ?: tasks.findByName("lint"))
+            ?.let { lintAll.configure { dependsOn(it) } }
+    }
+}
+
 val jvmVersion = Jvm.current().javaVersion?.majorVersion.parseIntOrDefault(defaultValue = 0)
 val minSdk: String = libs.versions.minSdk.get()
 val jvmVersionLowerBound = 21

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,9 @@ subprojects {
 
     afterEvaluate {
         plugins.withType<com.android.build.gradle.BasePlugin> {
-            val androidExtension = extensions.getByName("android") as CommonExtension
+            // com.android.lint [BasePlugin] has no `android` extension
+            // as it can be applied to java-library
+            val androidExtension = extensions.findByName("android") as? CommonExtension ?: return@withType
             androidExtension.testOptions.unitTests {
                 isIncludeAndroidResources = true
             }

--- a/buildSrc/src/main/kotlin/ankidroid.android.api.gradle.kts
+++ b/buildSrc/src/main/kotlin/ankidroid.android.api.gradle.kts
@@ -53,3 +53,7 @@ extensions.configure<KotlinAndroidProjectExtension> {
 
 // Shared project-wide lint configuration.
 apply(from = "${rootDir}/lint.gradle")
+
+dependencies {
+    "lintChecks"(project(":lint-rules"))
+}

--- a/buildSrc/src/main/kotlin/ankidroid.android.library.gradle.kts
+++ b/buildSrc/src/main/kotlin/ankidroid.android.library.gradle.kts
@@ -44,6 +44,14 @@ extensions.configure<LibraryExtension> {
 // Shared project-wide lint configuration.
 apply(from = "${rootDir}/lint.gradle")
 
+// `:vbpd` is vendored third-party code; not subject to our lint rules.
+if (path != ":vbpd") {
+    dependencies {
+        // PERF: some rules do not need to be applied... but the full run was 3s
+        "lintChecks"(project(":lint-rules"))
+    }
+}
+
 // Apply jacoco so module unit tests produce .exec files that
 // AnkiDroid's jacocoUnitTestReport aggregates across modules.
 apply(from = "${rootDir}/jacocoSupport.gradle")

--- a/buildSrc/src/main/kotlin/ankidroid.jvm.library.gradle.kts
+++ b/buildSrc/src/main/kotlin/ankidroid.jvm.library.gradle.kts
@@ -34,3 +34,11 @@ tasks.withType(KotlinCompile::class).configureEach {
         jvmTarget = JvmTarget.JVM_17
     }
 }
+
+// Skip self-application for `:lint-rules`, which provides the checks.
+if (path != ":lint-rules") {
+    pluginManager.apply("com.android.lint")
+    dependencies {
+        "lintChecks"(project(":lint-rules"))
+    }
+}

--- a/common/src/main/java/com/ichi2/anki/common/time/MockTime.kt
+++ b/common/src/main/java/com/ichi2/anki/common/time/MockTime.kt
@@ -90,6 +90,7 @@ open class MockTime(
          * @param milliseconds, from 0 to 999
          * @return the time stamp of this instant in GMT calendar
          */
+        @Suppress("DirectGregorianInstantiation") // MockTime is the test-controlled time source the rule points at
         fun timeStamp(
             year: Int,
             month: Int,

--- a/libanki/build.gradle.kts
+++ b/libanki/build.gradle.kts
@@ -62,8 +62,4 @@ dependencies {
     testFixturesImplementation(libs.kotlinx.coroutines.core)
     testFixturesImplementation(libs.kotlinx.coroutines.test)
     testFixturesImplementation(libs.androidx.sqlite.framework)
-
-    // project lint checks
-    // PERF: some rules do not need to be applied... but the full run was 3s
-    lintChecks(project(":lint-rules"))
 }

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectToastMakeTextUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectToastMakeTextUsage.kt
@@ -17,7 +17,7 @@ import org.jetbrains.uast.UCallExpression
 
 /**
  * This custom Lint rules will raise an error if a developer uses the {android.widget.Toast#makeText(...)} method instead
- * of using the top level method {com.ichi2.anki.showThemedToast(...)} provided by the UIUtils file.
+ * of using the top level method {com.ichi2.anki.common.utils.android.showThemedToast(...)} provided by the Toast file.
  */
 class DirectToastMakeTextUsage :
     Detector(),
@@ -54,7 +54,7 @@ class DirectToastMakeTextUsage :
         super.visitMethodCall(context, node, method)
         val evaluator = context.evaluator
         val foundClasses = context.uastFile!!.classes
-        if (!LintUtils.isAnAllowedClass(foundClasses, "UIUtilsKt") && evaluator.isMemberInClass(method, "android.widget.Toast")) {
+        if (!LintUtils.isAnAllowedClass(foundClasses, "ToastKt") && evaluator.isMemberInClass(method, "android.widget.Toast")) {
             context.report(
                 ISSUE,
                 node,

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectToastMakeTextUsageTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectToastMakeTextUsageTest.kt
@@ -38,17 +38,17 @@ public class TestJavaClass {
 """
 
     @Language("JAVA")
-    private val javaFileWithUIUtils = """                            
-package com.ichi2.anki.lint.rules;                             
-                                                               
-import android.widget.Toast;                                   
-                                                               
-public class UIUtilsKt {
-                                                               
-    public static void main(String[] args) {                   
-        Toast.makeText();                                      
-    }                                                          
-}                                                              
+    private val javaFileWithToastWrapper = """
+package com.ichi2.anki.lint.rules;
+
+import android.widget.Toast;
+
+public class ToastKt {
+
+    public static void main(String[] args) {
+        Toast.makeText();
+    }
+}
 """
 
     @Test
@@ -67,11 +67,11 @@ public class UIUtilsKt {
     }
 
     @Test
-    fun allowsUsageForUIUtils() {
+    fun allowsUsageForToastWrapper() {
         lint()
             .allowMissingSdk()
             .allowCompilationErrors()
-            .files(create(stubToast), create(javaFileWithUIUtils))
+            .files(create(stubToast), create(javaFileWithToastWrapper))
             .issues(DirectToastMakeTextUsage.ISSUE)
             .run()
             .expectClean()


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - most of the code

## Purpose / Description
A number of modules weren't using `lint-rules`, fix them. Some are excluded, see commit 1 for details

## Fixes
* Fixes #21063
* Fixes #21159

## Approach
* Move to a convention plugin, so this is applied automatically
* Update CI so new modules do not manually need to be registered there
* Optimize the CI script

## How Has This Been Tested?
`./gradlew lintAll ktLintCheck lint-rules:test --daemon`

## Learning (optional, can help others)
I was surprised it was so easy to apply lint-rules to a `java-library`

But there's no in-IDE support it seems for those files... only CI

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)