### PR TITLE
fix(test): avoid diff on collection path pref

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesScreenshotTest.kt
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 package com.ichi2.anki.preferences
 
+import androidx.preference.Preference
 import androidx.test.core.app.ActivityScenario
+import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.R
 import com.ichi2.anki.ScreenshotTest
 import com.ichi2.anki.settings.Prefs
 import org.junit.Test
@@ -22,7 +25,16 @@ class PreferencesScreenshotTest : ScreenshotTest() {
                 .launch<PreferencesActivity>(
                     PreferencesActivity.getIntent(targetContext, fragmentClass),
                 ).use { scenario ->
-                    scenario.onActivity {
+                    scenario.onActivity { activity ->
+                        val mainFragment = activity!!.fragment as PreferencesFragment
+                        val settingsFragment = mainFragment.childFragmentManager.findFragmentById(R.id.settings_container)
+                        // Robolectric generates a different temporary path every time,
+                        // so avoid creating an unnecessary diff in the collection path pref summary
+                        (settingsFragment as? AdvancedSettingsFragment)?.apply {
+                            requirePreference<Preference>(CollectionHelper.PREF_COLLECTION_PATH).summaryProvider = {
+                                "/storage/emulated/0/AnkiDroid"
+                            }
+                        }
                         captureScreen(fragmentClass.simpleName!!)
                     }
                 }


### PR DESCRIPTION
Robolectric generates a different temporary path every time, so avoid creating an unnecessary diff in the collection path pref summary

## How Has This Been Tested?

<details>

```
./gradlew :AnkiDroid:recordRoborazziPlayDebug -Pscreenshot --tests "com.ichi2.anki.preferences.PreferencesScreenshotTest"
```

<img width="1078" height="2399" alt="AdvancedSettingsFragment" src="https://github.com/user-attachments/assets/471b8935-0cf5-4e30-aaeb-d3574ff7180c" />

</details>

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->