### PR TITLE
fix(sync): conflict dialog display

### DIFF
--- a/AnkiDroid/src/main/res/layout/dialog_alert_dialog_title_with_help.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_alert_dialog_title_with_help.xml
@@ -27,12 +27,11 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:textAppearance="?attr/textAppearanceHeadlineSmall"
+        android:textColor="?attr/colorOnSurface"
         android:layout_marginStart="12dp"
         app:layout_goneMarginStart="0dp"
         app:layout_constraintStart_toEndOf="@id/title_icon"
         app:layout_constraintEnd_toStartOf="@id/help_icon"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
         tools:text="Reset Card Progress" />
 
     <ImageView


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - diagnostics

## Purpose / Description
8e6004332ab6bef3d648b2a1b0c9588ca20a0991 broke this dialog on some OneUI
 devices (SM-N960U1 - Samsung Galaxy Note 9). Only the title was showing

## Fixes
* Fixes #21050

## Approach
Fix forward

## How Has This Been Tested?

This fix was confirmed to work by the author of the above commit, and works on an API 29 emulator

⚠️ I was unable to reproduce the original issue - likely device-specific. I have not confirmed on the affected device that this is fixed, only that it remains unbroken

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->