### PR TITLE
Hide other DeckPicker FAB menu items when opening SearchView

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
@@ -327,6 +327,8 @@ class DeckPickerFloatingActionMenu(
 
     fun hideFloatingActionButton() {
         if (binding.fabMain.isShown) {
+            // close the menu if it's open so the other menu items are hidden as well
+            closeFloatingActionMenu(false)
             Timber.i("DeckPicker:: hideFloatingActionButton()")
             binding.fabMain.visibility = View.GONE
         }


### PR DESCRIPTION
## Purpose / Description

Fixes a small bug I noticed while looking at #21066:

In DeckPicker, when the toolbar SearchView is opened we hide the  FAB, but if the FAB is already open and the other menu items are visible these will not be hidden .

Before with the bug/After the fix:

<img width="540" height="1200" alt="Screenshot_20260517_204130" src="https://github.com/user-attachments/assets/3692779c-6c86-41c7-ac9c-14161579c8d1" />
<img width="540" height="1200" alt="Screenshot_20260517_204508" src="https://github.com/user-attachments/assets/f6abd7eb-e573-45f0-b16a-2865e3c24ef3" />


## How Has This Been Tested?

Tried to open search with different FAB configurations.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
