### PR TITLE
test: reduce date and version noise in `AboutFragment` test

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
@@ -21,6 +21,7 @@ import android.os.Bundle
 import android.text.format.DateFormat
 import android.text.method.LinkMovementMethod
 import android.view.View
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.core.text.parseAsHtml
 import androidx.fragment.app.Fragment
@@ -48,7 +49,8 @@ import java.util.Locale
 import net.ankiweb.rsdroid.BuildConfig as BackendBuildConfig
 
 class AboutFragment : Fragment(R.layout.fragment_about) {
-    private val binding by viewBinding(FragmentAboutBinding::bind)
+    @VisibleForTesting
+    val binding by viewBinding(FragmentAboutBinding::bind)
 
     override fun onViewCreated(
         view: View,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesScreenshotTest.kt
@@ -35,6 +35,10 @@ class PreferencesScreenshotTest : ScreenshotTest() {
                                 "/storage/emulated/0/AnkiDroid"
                             }
                         }
+                        (settingsFragment as? AboutFragment)?.apply {
+                            binding.buildDate.text = "May 18, 2026"
+                            binding.version.text = "2.24.0-screenshot"
+                        }
                         captureScreen(fragmentClass.simpleName!!)
                     }
                 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

The date in `AboutFragment` changes when a commit is done on a new day, which generates noise on its screenshot test. Same for new versions

https://github.com/ankidroid/Anki-Android/pull/21075#issuecomment-4475843588

> [!NOTE]
> The version of Anki's backend and FSRS may generate diffs as well, but upgrading them is a rare event, so I kept the diff as an extra "confirmation" after doing the upgrades

## How Has This Been Tested?

./gradlew :AnkiDroid:recordRoborazziPlayDebug -Pscreenshot --tests "com.ichi2.anki.preferences.*"

<details>

<img width="1078" height="2399" alt="AboutFragment" src="https://github.com/user-attachments/assets/050fb1b5-5d1b-41e6-8c64-2e85f395bb76" />

</details>

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->