### PR TITLE
feat: move and rename "Safe display" pref 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -87,7 +87,7 @@ import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.receiver.SdCardReceiver
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
-import com.ichi2.anki.utils.AnimationUtils
+import com.ichi2.anki.utils.AnimUtils
 import com.ichi2.anki.utils.ext.requireString
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.workarounds.AppLoadedFromBackupWorkaround.showedActivityFailedScreen
@@ -299,7 +299,7 @@ open class AnkiActivity(
      *
      * @see .animationEnabled
      */
-    fun animationDisabled(): Boolean = !AnimationUtils.areAnimationsEnabled(this)
+    fun animationDisabled(): Boolean = !AnimUtils.areAnimationsEnabled(this)
 
     /**
      * Whether animations should be displayed

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -87,6 +87,7 @@ import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.receiver.SdCardReceiver
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.utils.AnimationUtils
 import com.ichi2.anki.utils.ext.requireString
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.workarounds.AppLoadedFromBackupWorkaround.showedActivityFailedScreen
@@ -298,10 +299,7 @@ open class AnkiActivity(
      *
      * @see .animationEnabled
      */
-    fun animationDisabled(): Boolean {
-        val preferences = this.sharedPrefs()
-        return preferences.getBoolean("safeDisplay", false)
-    }
+    fun animationDisabled(): Boolean = !AnimationUtils.areAnimationsEnabled(this)
 
     /**
      * Whether animations should be displayed

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
@@ -27,7 +27,6 @@ import com.google.android.material.color.MaterialColors
 import com.ichi2.anki.databinding.ActivityHomescreenBinding
 import com.ichi2.anki.databinding.IncludeFloatingAddButtonBinding
 import com.ichi2.anki.ui.DoubleTapListener
-import com.ichi2.anki.utils.AnimationUtils.areSystemAnimationsEnabled
 import timber.log.Timber
 
 class DeckPickerFloatingActionMenu(
@@ -73,12 +72,7 @@ class DeckPickerFloatingActionMenu(
             binding.addDeckButton.visibility = View.VISIBLE
             binding.addFilteredDeckButton.visibility = View.VISIBLE
             binding.fabBGLayout.visibility = View.VISIBLE
-            if (areSystemAnimationsEnabled(context)) {
-                binding.fabMain.backgroundTintList = ColorStateList.valueOf(fabPressedColor)
-            } else {
-                // Changes the background color of FAB
-                binding.fabMain.backgroundTintList = ColorStateList.valueOf(fabNormalColor)
-            }
+            binding.fabMain.backgroundTintList = ColorStateList.valueOf(fabPressedColor)
             binding.fabMain.setIconResource(addNoteIcon)
             binding.fabMain.extend()
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AccessibilitySettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AccessibilitySettingsFragment.kt
@@ -16,8 +16,10 @@
 package com.ichi2.anki.preferences
 
 import androidx.preference.Preference
+import androidx.preference.SwitchPreferenceCompat
 import com.ichi2.anki.R
 import com.ichi2.anki.settings.Prefs
+import com.ichi2.anki.utils.AnimationUtils
 
 /**
  * Fragment with preferences related to notifications
@@ -41,6 +43,12 @@ class AccessibilitySettingsFragment : SettingsFragment() {
             val keyString = getString(key)
             findPreference<Preference>(keyString)?.isVisible = false
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        requirePreference<SwitchPreferenceCompat>(R.string.safe_display_key).isEnabled =
+            AnimationUtils.areSystemAnimationsEnabled(requireContext())
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AccessibilitySettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AccessibilitySettingsFragment.kt
@@ -19,7 +19,7 @@ import androidx.preference.Preference
 import androidx.preference.SwitchPreferenceCompat
 import com.ichi2.anki.R
 import com.ichi2.anki.settings.Prefs
-import com.ichi2.anki.utils.AnimationUtils
+import com.ichi2.anki.utils.AnimUtils
 
 /**
  * Fragment with preferences related to notifications
@@ -48,7 +48,7 @@ class AccessibilitySettingsFragment : SettingsFragment() {
     override fun onResume() {
         super.onResume()
         requirePreference<SwitchPreferenceCompat>(R.string.safe_display_key).isEnabled =
-            AnimationUtils.areSystemAnimationsEnabled(requireContext())
+            AnimUtils.areSystemAnimationsEnabled(requireContext())
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -46,7 +46,7 @@ import com.ichi2.anki.common.annotations.LegacyNotifications
 import com.ichi2.anki.preferences.HeaderFragment.Companion.getHeaderKeyForFragment
 import com.ichi2.anki.reviewreminders.ReviewReminderScope
 import com.ichi2.anki.reviewreminders.ScheduleRemindersFragment
-import com.ichi2.anki.utils.AnimationUtils
+import com.ichi2.anki.utils.AnimUtils
 import com.ichi2.anki.utils.isWindowCompact
 import com.ichi2.themes.Themes
 import com.ichi2.utils.FragmentFactoryUtils
@@ -209,7 +209,7 @@ class PreferencesFragment :
     }
 
     private fun setFadeTransition(fragmentTransaction: FragmentTransaction) {
-        if (AnimationUtils.areAnimationsEnabled(requireContext())) {
+        if (AnimUtils.areAnimationsEnabled(requireContext())) {
             fragmentTransaction.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -46,7 +46,7 @@ import com.ichi2.anki.common.annotations.LegacyNotifications
 import com.ichi2.anki.preferences.HeaderFragment.Companion.getHeaderKeyForFragment
 import com.ichi2.anki.reviewreminders.ReviewReminderScope
 import com.ichi2.anki.reviewreminders.ScheduleRemindersFragment
-import com.ichi2.anki.utils.ext.sharedPrefs
+import com.ichi2.anki.utils.AnimationUtils
 import com.ichi2.anki.utils.isWindowCompact
 import com.ichi2.themes.Themes
 import com.ichi2.utils.FragmentFactoryUtils
@@ -209,7 +209,7 @@ class PreferencesFragment :
     }
 
     private fun setFadeTransition(fragmentTransaction: FragmentTransaction) {
-        if (!sharedPrefs().getBoolean("safeDisplay", false)) {
+        if (AnimationUtils.areAnimationsEnabled(requireContext())) {
             fragmentTransaction.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -381,6 +381,7 @@ open class PrefsRepository(
 
     val answerButtonsSize: Int by intPref(R.string.answer_button_size_preference, 100)
     val cardZoom: Int by intPref(R.string.card_zoom_preference, 100)
+    val removeAppAnimations by booleanPref(R.string.safe_display_key, defaultValue = false)
 
     // **************************************** Advanced **************************************** //
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/AnimUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/AnimUtils.kt
@@ -22,7 +22,7 @@ import com.ichi2.anki.settings.PrefsRepository
 /**
  * Utility class for animation-related helper functions
  */
-object AnimationUtils {
+object AnimUtils {
     /**
      * @return whether the animations are enabled by the system settings,
      * i.e. the 'Remove animations' setting is disabled.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/AnimationUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/AnimationUtils.kt
@@ -22,41 +22,14 @@ import android.provider.Settings
  * Utility class for animation-related helper functions
  */
 object AnimationUtils {
-    /**
-     * Checks if system animations are enabled by verifying all animation scale settings.
-     *
-     * This function returns false if any of the mentioned system animations are disabled (0f),
-     * which addresses safe display mode and accessibility concerns.
-     *
-     * ANIMATION_DURATION_SCALE - controls app switching animation speed.
-     * TRANSITION_ANIMATION_SCALE - controls app window opening and closing animation speed
-     * WINDOW_ANIMATION_SCALE - controls pop-up window opening and closing animation speed
-     *
-     * @param context The context used to access system settings
-     * @return true if all animation scales are non-zero, false otherwise
-     */
     fun areSystemAnimationsEnabled(context: Context): Boolean =
         try {
-            val animDuration =
-                Settings.Global.getFloat(
-                    context.contentResolver,
-                    Settings.Global.ANIMATOR_DURATION_SCALE,
-                    1f,
-                )
-            val animTransition =
-                Settings.Global.getFloat(
-                    context.contentResolver,
-                    Settings.Global.TRANSITION_ANIMATION_SCALE,
-                    1f,
-                )
-            val animWindow =
-                Settings.Global.getFloat(
-                    context.contentResolver,
-                    Settings.Global.WINDOW_ANIMATION_SCALE,
-                    1f,
-                )
-            animDuration != 0f && animTransition != 0f && animWindow != 0f
-        } catch (e: Exception) {
+            Settings.Global.getFloat(
+                context.contentResolver,
+                Settings.Global.ANIMATOR_DURATION_SCALE,
+                1f,
+            ) > 0f
+        } catch (_: Exception) {
             true // Default to animations enabled if unable to read settings
         }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/AnimationUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/AnimationUtils.kt
@@ -17,11 +17,18 @@ package com.ichi2.anki.utils
 
 import android.content.Context
 import android.provider.Settings
+import com.ichi2.anki.settings.PrefsRepository
 
 /**
  * Utility class for animation-related helper functions
  */
 object AnimationUtils {
+    /**
+     * @return whether the animations are enabled by the system settings,
+     * i.e. the 'Remove animations' setting is disabled.
+     * On most cases, using [AnimationUtils.areAnimationsEnabled] is preferred
+     * because it considers the app's own 'Remove animations' setting
+     */
     fun areSystemAnimationsEnabled(context: Context): Boolean =
         try {
             Settings.Global.getFloat(
@@ -32,4 +39,10 @@ object AnimationUtils {
         } catch (_: Exception) {
             true // Default to animations enabled if unable to read settings
         }
+
+    /**
+     * @return whether animations are enabled on the system and app settings
+     */
+    fun areAnimationsEnabled(context: Context): Boolean =
+        areSystemAnimationsEnabled(context) && !PrefsRepository(context).removeAppAnimations
 }

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -135,8 +135,6 @@
     <string name="select_locale_title">Select language</string>
     <string name="software_render" maxLength="41">Disable card hardware render</string>
     <string name="software_render_summ">Hardware render is faster but may have problems, specifically on Android 8/8.1. If you cannot see parts of the card review user interface, try this setting.</string>
-    <string name="safe_display" maxLength="41">Safe display mode</string>
-    <string name="safe_display_summ">Disable all animations and use safer method for drawing cards. E-ink devices may require this.</string>
     <string name="disable_extended_text_ui" maxLength="41">Disable Single-Field Edit Mode</string>
     <!--See: multimedia_editor_popup_cloze. We can't use format strings as this is auto-generated-->
     <string name="disable_extended_text_ui_summ">Allows \'Cloze Deletion\' context menu when in landscape mode.</string>
@@ -150,6 +148,8 @@
     <string name="show_estimates_summ">Show next review time on answer buttons</string>
     <string name="show_large_answer_buttons" maxLength="41">Show large answer buttons</string>
     <string name="show_large_answer_buttons_summ">Show answer button in 2&#160;rows</string>
+    <string name="remove_animations" maxLength="41">Remove animations</string>
+    <string name="remove_animations_summary">Also enabled if animations are removed on the system settings</string>
     <string name="show_top_bar" maxLength="41">Show top bar</string>
     <string name="show_top_bar_summary">Show card counts, answer timer, flag and mark in top bar</string>
     <string name="show_progress" maxLength="41">Show remaining</string>

--- a/AnkiDroid/src/main/res/xml/preferences_accessibility.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_accessibility.xml
@@ -83,4 +83,13 @@
         android:stepSize="10"
         app:displayFormat="@string/pref_milliseconds"
         />
+    <PreferenceCategory
+        android:title="@string/screen">
+        <SwitchPreferenceCompat
+            android:key="@string/safe_display_key"
+            android:defaultValue="false"
+            android:title="@string/remove_animations"
+            android:summary="@string/remove_animations_summary"
+            />
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -49,11 +49,6 @@
                 android:title="@string/software_render" />
             <SwitchPreferenceCompat
                 android:defaultValue="false"
-                android:key="@string/safe_display_key"
-                android:summary="@string/safe_display_summ"
-                android:title="@string/safe_display" />
-            <SwitchPreferenceCompat
-                android:defaultValue="false"
                 android:key="@string/use_input_tag_key"
                 android:disableDependentsState="true"
                 android:summary="@string/use_input_tag_summ"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

to the accessibility settings

note: the "use safer method for drawing cards" part apparently does nothing, based on the current uses of the preference

## Approach

In the commits

## How Has This Been Tested?

Emulator 31

[Screen_recording_20260518_115911.webm](https://github.com/user-attachments/assets/4e1893d4-1241-41be-bf08-eb4bdbd2986d)

FAB pressed color is bugged, I know. Already fixed on a rebase

[Screen_recording_20260518_123750.webm](https://github.com/user-attachments/assets/1a427ddc-d67c-48d5-8c18-57a1d369db2f)


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->