### PR TITLE
fix(whiteboard): stop flickering [Samsung/OnePlus]

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -877,7 +877,14 @@ abstract class AbstractFlashcardViewer :
     // Set the content view to the one provided and initialize accessors.
     protected open fun initLayout() {
         topBarLayout = findViewById(R.id.top_bar)
-        cardFrame = findViewById(R.id.flashcard)
+        cardFrame =
+            findViewById<FrameLayout>(R.id.flashcard).apply {
+                // Force the WebView's container onto its own GPU texture so it isn't dropped from
+                // composition when the overlapping Whiteboard sibling invalidates each touch frame.
+                // Without this, Samsung WebView (since a recent update) hides the card mid-stroke
+                // until the next full hierarchy invalidation. (#19364)
+                setLayerType(View.LAYER_TYPE_HARDWARE, null)
+            }
         cardFrameParent = cardFrame!!.parent as ViewGroup
         touchLayer =
             findViewById<FrameLayout>(R.id.touch_layer).apply { setOnTouchListener(gestureListener) }
@@ -2312,7 +2319,12 @@ abstract class AbstractFlashcardViewer :
         destroyWebView(webView)
         webView = null
         // inflate a new instance of mCardFrame
-        cardFrame = inflateNewView<FrameLayout>(R.id.flashcard)
+        cardFrame =
+            inflateNewView<FrameLayout>(R.id.flashcard).apply {
+                // 'recreateWebView' applies setRenderWorkaround so the hardware renderer remains
+                // disabled if a user requests it
+                setLayerType(View.LAYER_TYPE_HARDWARE, null)
+            }
         // Even with the above, I occasionally saw the above error. Manually trigger the GC.
         // I'll keep this line unless I see another crash, which would point to another underlying issue.
         System.gc()


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - all

## Purpose / Description
The whiteboard flickered on the old study screen on my S21 5G

## Fixes
* Fixes #19364

## Approach

Previously, each view was drawn using the parent's render context (merged into `RelativeLayout` via `include_reviewer_flashcard_fullscreen`)

The whiteboard invalidate() call was performed on every touch event, and I presume the WebView heuristics caused the WebView to not be composed.

`LAYER_TYPE_HARDWARE` (instead of `LAYER_TYPE_NONE`) means the WebView has a texture/Framebuffer object of its own, and is therefore not impacted by the Whiteboard.

Trivial performance impact - still hardware rendered.

## How Has This Been Tested?

Samsung S21 5G

```
Device Info = samsung | samsung | o1s | o1sxeea | SM-G991B | exynos2100  
WebView Info = [com.google.android.webview | 777812003]: Mozilla/5.0 (Linux; Android 15; SM-G991B Build/AP3A.240905.015.A2; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/148.0.7778.120 Mobile Safari/537.36  
```

* Whiteboard on old study screen
* Scribble
* Text on the card no longer flickers

Tested on an API 33 emulator - no issues when scrolling and playing https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/1080/Big_Buck_Bunny_1080_10s_1MB.mp4

## Learning
Rendering/compositing is hard


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)