### PR TITLE
docs(compat): convert licenses to SPDX format

### DIFF
--- a/compat/src/main/java/com/ichi2/anki/compat/BaseCompat.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/BaseCompat.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (c) 2017 Profpatsch <mail@profpatsch.de>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2017 Profpatsch <mail@profpatsch.de>
 
 package com.ichi2.anki.compat
 

--- a/compat/src/main/java/com/ichi2/anki/compat/Compat.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/Compat.kt
@@ -1,19 +1,6 @@
-/*
- * Copyright (c) 2011 Flavio Lerda <flerda@gmail.com>
- * Copyright (c) 2022 Arthur Milchior <arthur@milchior.fr>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2011 Flavio Lerda <flerda@gmail.com>
+// SPDX-FileCopyrightText: Copyright (c) 2022 Arthur Milchior <arthur@milchior.fr>
 
 package com.ichi2.anki.compat
 

--- a/compat/src/main/java/com/ichi2/anki/compat/CompatHelper.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/CompatHelper.kt
@@ -1,18 +1,6 @@
-/*
- * Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>
+
 package com.ichi2.anki.compat
 
 import android.annotation.SuppressLint

--- a/compat/src/main/java/com/ichi2/anki/compat/CompatV26.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/CompatV26.kt
@@ -1,19 +1,7 @@
-/*
- * Copyright (c) 2018 Mike Hardy <github@mikehardy.net>
- * Copyright (c) 2022 Arthur Milchior <arthur@milchior.fr>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2018 Mike Hardy <github@mikehardy.net>
+// SPDX-FileCopyrightText: Copyright (c) 2022 Arthur Milchior <arthur@milchior.fr>
+
 package com.ichi2.anki.compat
 
 import android.content.Context

--- a/compat/src/main/java/com/ichi2/anki/compat/CompatV28.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/CompatV28.kt
@@ -1,18 +1,4 @@
-/*
- *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 package com.ichi2.anki.compat
 

--- a/compat/src/main/java/com/ichi2/anki/compat/CompatV29.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/CompatV29.kt
@@ -1,18 +1,5 @@
-/*
- *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.ichi2.anki.compat
 
 import android.content.ContentValues

--- a/compat/src/main/java/com/ichi2/anki/compat/CompatV31.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/CompatV31.kt
@@ -1,18 +1,6 @@
-/*
- *  Copyright (c) 2021 Mike Hardy <mike@mikehardy.net>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2021 Mike Hardy <mike@mikehardy.net>
+
 package com.ichi2.anki.compat
 
 import android.content.Context

--- a/compat/src/main/java/com/ichi2/anki/compat/CompatV33.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/CompatV33.kt
@@ -1,19 +1,6 @@
-/*
- *  Copyright (c) 2022 Ashish Yadav <mailtoashish693@gmail.com>
- *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2022 Ashish Yadav <mailtoashish693@gmail.com>
+
 package com.ichi2.anki.compat
 
 import android.content.Context

--- a/compat/src/main/java/com/ichi2/anki/compat/CompatV34.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/CompatV34.kt
@@ -1,18 +1,4 @@
-/*
- *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 package com.ichi2.anki.compat
 

--- a/compat/src/main/java/com/ichi2/anki/compat/DirectoryCompat.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/DirectoryCompat.kt
@@ -1,18 +1,4 @@
-/*
- *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 package com.ichi2.anki.compat
 

--- a/compat/src/main/java/com/ichi2/anki/compat/UtteranceProgressListenerCompat.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/UtteranceProgressListenerCompat.kt
@@ -1,18 +1,4 @@
-/*
- *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 package com.ichi2.anki.compat
 

--- a/compat/src/test/java/com/ichi2/anki/model/DirectoryTest.kt
+++ b/compat/src/test/java/com/ichi2/anki/model/DirectoryTest.kt
@@ -1,18 +1,4 @@
-/*
- *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 package com.ichi2.anki.model
 

--- a/compat/src/test/java/com/ichi2/compat/CompatCopyFileTest.kt
+++ b/compat/src/test/java/com/ichi2/compat/CompatCopyFileTest.kt
@@ -1,18 +1,6 @@
-/*
- * Copyright (c) 2021 Shridhar Goel <shridhar.goel@gmail.com>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2021 Shridhar Goel <shridhar.goel@gmail.com>
+
 package com.ichi2.compat
 
 import com.ichi2.anki.TestUtils

--- a/compat/src/test/java/com/ichi2/compat/CompatDeleteFileTest.kt
+++ b/compat/src/test/java/com/ichi2/compat/CompatDeleteFileTest.kt
@@ -1,18 +1,4 @@
-/*
- *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 package com.ichi2.compat
 

--- a/compat/src/test/java/com/ichi2/compat/CompatDirectoryContentTest.kt
+++ b/compat/src/test/java/com/ichi2/compat/CompatDirectoryContentTest.kt
@@ -1,18 +1,5 @@
-/*
- *  Copyright (c) 2022 Arthur Milchior <Arthur@Milchior.fr>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2022 Arthur Milchior <Arthur@Milchior.fr>
 
 package com.ichi2.compat
 

--- a/compat/src/test/java/com/ichi2/compat/CreateDirectoriesTest.kt
+++ b/compat/src/test/java/com/ichi2/compat/CreateDirectoriesTest.kt
@@ -1,18 +1,4 @@
-/*
- *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 package com.ichi2.compat
 

--- a/compat/src/test/java/com/ichi2/compat/HasFilesTest.kt
+++ b/compat/src/test/java/com/ichi2/compat/HasFilesTest.kt
@@ -1,18 +1,4 @@
-/*
- *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 package com.ichi2.compat
 

--- a/compat/src/testFixtures/java/com/ichi2/compat/Test21And26.kt
+++ b/compat/src/testFixtures/java/com/ichi2/compat/Test21And26.kt
@@ -1,18 +1,5 @@
-/*
- *  Copyright (c) 2022 Arthur Milchior <arthur@milchior.fr>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2022 Arthur Milchior <arthur@milchior.fr>
 
 package com.ichi2.compat
 


### PR DESCRIPTION

<!--- Please fill the necessary details below -->
## Purpose / Description
AnkiDroid is standardizing licenses to SPDX. I will start with the small modules.

## Fixes
* Related to #20954

## Approach

I removed my copyright lines from the files as-per docs/contributing/copyright-headers.md

## How Has This Been Tested?
This change was not performed using LLMs and I have verified visually and in diff-view that it is correct

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)