### PR TITLE
refactor: move 10 strings to the backend translations 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -842,7 +842,7 @@ open class Reviewer :
         if (currentCard != null && isMarked(getColUnsafe, currentCard!!.note(getColUnsafe))) {
             markCardIcon.setTitle(R.string.menu_unmark_note).setIcon(R.drawable.ic_star_white)
         } else {
-            markCardIcon.setTitle(R.string.menu_mark_note).setIcon(R.drawable.ic_star_border_white)
+            markCardIcon.setTitle(TR.sentenceCase.markNote).setIcon(R.drawable.ic_star_border_white)
         }
         markCardIcon.iconAlpha = alpha
 
@@ -860,6 +860,21 @@ open class Reviewer :
 
         // Anki Desktop Translations
         menu.findItem(R.id.action_reschedule_card).title = TR.sentenceCase.setDueDate
+        menu.findItem(R.id.action_card_info)?.title = TR.sentenceCase.cardInfo
+        menu.findItem(R.id.action_previous_card_info)?.title = TR.sentenceCase.previousCardInfo
+        // top-level (visible=false in XML) items, shown when only the card-level action is available
+        menu.findItem(R.id.action_bury_card)?.title = TR.sentenceCase.buryCard
+        menu.findItem(R.id.action_suspend_card)?.title = TR.sentenceCase.suspendCard
+        menu.findItem(R.id.action_bury)?.let { buryItem ->
+            buryItem.title = TR.studyingBury()
+            buryItem.subMenu?.findItem(R.id.action_bury_card)?.title = TR.sentenceCase.buryCard
+            buryItem.subMenu?.findItem(R.id.action_bury_note)?.title = TR.sentenceCase.buryNote
+        }
+        menu.findItem(R.id.action_suspend)?.let { suspendItem ->
+            suspendItem.title = TR.studyingSuspend()
+            suspendItem.subMenu?.findItem(R.id.action_suspend_card)?.title = TR.sentenceCase.suspendCard
+            suspendItem.subMenu?.findItem(R.id.action_suspend_note)?.title = TR.sentenceCase.suspendNote
+        }
 
         // Undo button
         @DrawableRes val undoIconId: Int

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -611,6 +611,7 @@ class CardBrowserFragment :
 
                     menu.findItem(R.id.action_reschedule_cards).title = TR.sentenceCase.setDueDate
                     menu.findItem(R.id.action_grade_now).title = TR.sentenceCase.gradeNow
+                    menu.findItem(R.id.action_view_card_info).title = TR.sentenceCase.cardInfo
 
                     // note: this menu item is available with and without a selection of items
                     menu.findItem(R.id.action_find_replace)?.title = TR.sentenceCase.findAndReplace

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
@@ -95,6 +95,7 @@ class BrowserOptionsDialog : AppCompatDialogFragment(R.layout.dialog_browser_opt
 
         binding.truncateCheckBox.isChecked = isTruncated
         binding.toggleCardsNotesTitle.text = TR.sentenceCase.toggleCardsNotes
+        binding.flagTitle.text = TR.browsingFlag()
 
         binding.renameFlag.setOnClickListener {
             Timber.d("Rename flag clicked")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
@@ -172,6 +172,30 @@ class ControlsSettingsFragment :
         findPreference<ControlPreference>(getString(R.string.remove_flag_command_key))?.let {
             it.title = getString(R.string.gesture_flag_remove).toSentenceCase(R.string.sentence_gesture_flag_remove)
         }
+        findPreference<ControlPreference>(getString(R.string.bury_card_command_key))?.let {
+            it.title = TR.sentenceCase.buryCard
+        }
+        findPreference<ControlPreference>(getString(R.string.suspend_card_command_key))?.let {
+            it.title = TR.sentenceCase.suspendCard
+        }
+        findPreference<ControlPreference>(getString(R.string.card_info_command_key))?.let {
+            it.title = TR.sentenceCase.cardInfo
+        }
+        findPreference<ControlPreference>(getString(R.string.bury_note_command_key))?.let {
+            it.title = TR.sentenceCase.buryNote
+        }
+        findPreference<ControlPreference>(getString(R.string.suspend_note_command_key))?.let {
+            it.title = TR.sentenceCase.suspendNote
+        }
+        findPreference<ControlPreference>(getString(R.string.mark_command_key))?.let {
+            it.title = TR.sentenceCase.markNote
+        }
+        findPreference<ControlPreference>(getString(R.string.previewer_mark_key))?.let {
+            it.title = TR.sentenceCase.markNote
+        }
+        findPreference<ControlPreference>(getString(R.string.previous_card_info_command_key))?.let {
+            it.title = TR.sentenceCase.previousCardInfo
+        }
     }
 
     private fun setupNewStudyScreenSettings() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomButtonsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomButtonsSettingsFragment.kt
@@ -18,8 +18,11 @@ package com.ichi2.anki.preferences
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.edit
+import androidx.preference.ListPreference
 import androidx.preference.Preference
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
 import com.ichi2.utils.show
@@ -32,6 +35,8 @@ class CustomButtonsSettingsFragment : SettingsFragment() {
         get() = "prefs.custom_buttons"
 
     override fun initSubscreen() {
+        setDynamicTitles()
+
         // Reset toolbar button customizations
         val resetCustomButtons = requirePreference<Preference>("reset_custom_buttons")
         resetCustomButtons.onPreferenceClickListener =
@@ -54,6 +59,15 @@ class CustomButtonsSettingsFragment : SettingsFragment() {
                 }
                 true
             }
+    }
+
+    private fun setDynamicTitles() {
+        findPreference<ListPreference>(getString(R.string.custom_button_flag_key))?.title = TR.browsingFlag()
+        findPreference<ListPreference>(getString(R.string.custom_button_card_info_key))?.title = TR.sentenceCase.cardInfo
+        findPreference<ListPreference>(getString(R.string.custom_button_bury_key))?.title = TR.studyingBury()
+        findPreference<ListPreference>(getString(R.string.custom_button_suspend_key))?.title = TR.studyingSuspend()
+        findPreference<ListPreference>(getString(R.string.custom_button_mark_card_key))?.title = TR.sentenceCase.markNote
+        findPreference<ListPreference>(getString(R.string.custom_button_previous_card_info_key))?.title = TR.sentenceCase.previousCardInfo
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
@@ -20,7 +20,6 @@ import android.content.SharedPreferences
 import android.view.KeyEvent
 import androidx.annotation.DrawableRes
 import androidx.annotation.IdRes
-import androidx.annotation.StringRes
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.Flag
 import com.ichi2.anki.R
@@ -48,56 +47,50 @@ import com.ichi2.anki.ui.internationalization.toSentenceCase
 enum class ViewerAction(
     @IdRes val menuId: Int = 0,
     @DrawableRes val drawableRes: Int? = null,
-    @StringRes private val titleRes: Int = R.string.empty_string,
     val defaultDisplayType: MenuDisplayType? = null,
     val parentMenu: ViewerAction? = null,
 ) : MappableAction<ReviewerBinding> {
     // Always
-    UNDO(R.id.action_undo, R.drawable.ic_undo_white, R.string.undo, ALWAYS),
+    UNDO(R.id.action_undo, R.drawable.ic_undo_white, ALWAYS),
 
     // Menu only
-    REDO(R.id.action_redo, R.drawable.ic_redo, R.string.redo, MENU_ONLY),
-    FLAG_MENU(R.id.action_flag, R.drawable.ic_flag_transparent, R.string.menu_flag, MENU_ONLY),
-    MARK(R.id.action_mark, R.drawable.ic_star, R.string.menu_mark_note, MENU_ONLY),
-    EDIT(R.id.action_edit_note, R.drawable.ic_mode_edit_white, R.string.cardeditor_title_edit_card, MENU_ONLY),
-    BURY_MENU(R.id.action_bury, R.drawable.ic_flip_to_back_white, R.string.menu_bury, MENU_ONLY),
-    SUSPEND_MENU(R.id.action_suspend, R.drawable.ic_suspend, R.string.menu_suspend, MENU_ONLY),
-    DELETE(R.id.action_delete, R.drawable.ic_delete_white, R.string.menu_delete_note, MENU_ONLY),
-    TOGGLE_WHITEBOARD(R.id.action_toggle_whiteboard, R.drawable.ic_enable_whiteboard, R.string.gesture_toggle_whiteboard, MENU_ONLY),
+    REDO(R.id.action_redo, R.drawable.ic_redo, MENU_ONLY),
+    FLAG_MENU(R.id.action_flag, R.drawable.ic_flag_transparent, MENU_ONLY),
+    MARK(R.id.action_mark, R.drawable.ic_star, MENU_ONLY),
+    EDIT(R.id.action_edit_note, R.drawable.ic_mode_edit_white, MENU_ONLY),
+    BURY_MENU(R.id.action_bury, R.drawable.ic_flip_to_back_white, MENU_ONLY),
+    SUSPEND_MENU(R.id.action_suspend, R.drawable.ic_suspend, MENU_ONLY),
+    DELETE(R.id.action_delete, R.drawable.ic_delete_white, MENU_ONLY),
+    TOGGLE_WHITEBOARD(R.id.action_toggle_whiteboard, R.drawable.ic_enable_whiteboard, MENU_ONLY),
 
     // Disabled
-    BROWSE(R.id.action_browse, R.drawable.ic_flashcard_black, R.string.empty_string, DISABLED),
-    STATISTICS(R.id.action_statistics, R.drawable.ic_bar_chart_black, R.string.empty_string, DISABLED),
-    DECK_OPTIONS(R.id.action_deck_options, R.drawable.ic_tune_white, R.string.menu__deck_options, DISABLED),
-    CARD_INFO(R.id.action_card_info, R.drawable.ic_dialog_info, R.string.card_info_title, DISABLED),
-    PREVIOUS_CARD_INFO(R.id.action_previous_card_info, R.drawable.ic_outline_info_24, R.string.empty_string, DISABLED),
-    ADD_NOTE(R.id.action_add_note, R.drawable.ic_add, R.string.menu_add_note, DISABLED),
-    TAG(R.id.action_edit_tags, R.drawable.ic_tag, R.string.menu_edit_tags, DISABLED),
-    RESCHEDULE_NOTE(R.id.action_set_due_date, R.drawable.ic_reschedule, titleRes = R.string.empty_string, DISABLED),
-    RESET_PROGRESS(
-        R.id.action_reset_progress,
-        drawableRes = R.drawable.ic_backup_restore,
-        titleRes = R.string.card_editor_reset_card,
-        DISABLED,
-    ),
-    TOGGLE_AUTO_ADVANCE(R.id.action_toggle_auto_advance, R.drawable.ic_fast_forward, R.string.toggle_auto_advance, DISABLED),
-    RECORD_VOICE(R.id.action_record_voice, R.drawable.ic_action_mic, R.string.record_voice, DISABLED),
-    PLAY_MEDIA(R.id.action_replay_media, R.drawable.ic_play_circle_white, R.string.replay_media, DISABLED),
-    USER_ACTION_1(R.id.user_action_1, R.drawable.user_action_1, R.string.user_action_1, DISABLED),
-    USER_ACTION_2(R.id.user_action_2, R.drawable.user_action_2, R.string.user_action_2, DISABLED),
-    USER_ACTION_3(R.id.user_action_3, R.drawable.user_action_3, R.string.user_action_3, DISABLED),
-    USER_ACTION_4(R.id.user_action_4, R.drawable.user_action_4, R.string.user_action_4, DISABLED),
-    USER_ACTION_5(R.id.user_action_5, R.drawable.user_action_5, R.string.user_action_5, DISABLED),
-    USER_ACTION_6(R.id.user_action_6, R.drawable.user_action_6, R.string.user_action_6, DISABLED),
-    USER_ACTION_7(R.id.user_action_7, R.drawable.user_action_7, R.string.user_action_7, DISABLED),
-    USER_ACTION_8(R.id.user_action_8, R.drawable.user_action_8, R.string.user_action_8, DISABLED),
-    USER_ACTION_9(R.id.user_action_9, R.drawable.user_action_9, R.string.user_action_9, DISABLED),
+    BROWSE(R.id.action_browse, R.drawable.ic_flashcard_black, DISABLED),
+    STATISTICS(R.id.action_statistics, R.drawable.ic_bar_chart_black, DISABLED),
+    DECK_OPTIONS(R.id.action_deck_options, R.drawable.ic_tune_white, DISABLED),
+    CARD_INFO(R.id.action_card_info, R.drawable.ic_dialog_info, DISABLED),
+    PREVIOUS_CARD_INFO(R.id.action_previous_card_info, R.drawable.ic_outline_info_24, DISABLED),
+    ADD_NOTE(R.id.action_add_note, R.drawable.ic_add, DISABLED),
+    TAG(R.id.action_edit_tags, R.drawable.ic_tag, DISABLED),
+    RESCHEDULE_NOTE(R.id.action_set_due_date, R.drawable.ic_reschedule, DISABLED),
+    RESET_PROGRESS(R.id.action_reset_progress, R.drawable.ic_backup_restore, DISABLED),
+    TOGGLE_AUTO_ADVANCE(R.id.action_toggle_auto_advance, R.drawable.ic_fast_forward, DISABLED),
+    RECORD_VOICE(R.id.action_record_voice, R.drawable.ic_action_mic, DISABLED),
+    PLAY_MEDIA(R.id.action_replay_media, R.drawable.ic_play_circle_white, DISABLED),
+    USER_ACTION_1(R.id.user_action_1, R.drawable.user_action_1, DISABLED),
+    USER_ACTION_2(R.id.user_action_2, R.drawable.user_action_2, DISABLED),
+    USER_ACTION_3(R.id.user_action_3, R.drawable.user_action_3, DISABLED),
+    USER_ACTION_4(R.id.user_action_4, R.drawable.user_action_4, DISABLED),
+    USER_ACTION_5(R.id.user_action_5, R.drawable.user_action_5, DISABLED),
+    USER_ACTION_6(R.id.user_action_6, R.drawable.user_action_6, DISABLED),
+    USER_ACTION_7(R.id.user_action_7, R.drawable.user_action_7, DISABLED),
+    USER_ACTION_8(R.id.user_action_8, R.drawable.user_action_8, DISABLED),
+    USER_ACTION_9(R.id.user_action_9, R.drawable.user_action_9, DISABLED),
 
     // Child items
-    BURY_NOTE(R.id.action_bury_note, drawableRes = null, titleRes = R.string.menu_bury_note, parentMenu = BURY_MENU),
-    BURY_CARD(R.id.action_bury_card, drawableRes = null, titleRes = R.string.menu_bury_card, parentMenu = BURY_MENU),
-    SUSPEND_NOTE(R.id.action_suspend_note, drawableRes = null, titleRes = R.string.menu_suspend_note, parentMenu = SUSPEND_MENU),
-    SUSPEND_CARD(R.id.action_suspend_card, drawableRes = null, titleRes = R.string.menu_suspend_card, parentMenu = SUSPEND_MENU),
+    BURY_NOTE(R.id.action_bury_note, drawableRes = null, parentMenu = BURY_MENU),
+    BURY_CARD(R.id.action_bury_card, drawableRes = null, parentMenu = BURY_MENU),
+    SUSPEND_NOTE(R.id.action_suspend_note, drawableRes = null, parentMenu = SUSPEND_MENU),
+    SUSPEND_CARD(R.id.action_suspend_card, drawableRes = null, parentMenu = SUSPEND_MENU),
     UNSET_FLAG(Flag.NONE.id, Flag.NONE.drawableRes, parentMenu = FLAG_MENU),
     FLAG_RED(Flag.RED.id, Flag.RED.drawableRes, parentMenu = FLAG_MENU),
     FLAG_ORANGE(Flag.ORANGE.id, Flag.ORANGE.drawableRes, parentMenu = FLAG_MENU),
@@ -269,7 +262,63 @@ enum class ViewerAction(
             STATISTICS -> TR.statisticsTitle()
             RESCHEDULE_NOTE -> with(context) { TR.sentenceCase.setDueDate }
             PREVIOUS_CARD_INFO -> TR.actionsPreviousCardInfo().toSentenceCase(context, R.string.sentence_actions_previous_card_info)
-            else -> context.getString(titleRes)
+            UNDO -> context.getString(R.string.undo)
+            REDO -> context.getString(R.string.redo)
+            FLAG_MENU -> context.getString(R.string.menu_flag)
+            MARK -> context.getString(R.string.menu_mark_note)
+            EDIT -> context.getString(R.string.cardeditor_title_edit_card)
+            BURY_MENU -> context.getString(R.string.menu_bury)
+            SUSPEND_MENU -> context.getString(R.string.menu_suspend)
+            DELETE -> context.getString(R.string.menu_delete_note)
+            TOGGLE_WHITEBOARD -> context.getString(R.string.gesture_toggle_whiteboard)
+            DECK_OPTIONS -> context.getString(R.string.menu__deck_options)
+            CARD_INFO -> context.getString(R.string.card_info_title)
+            ADD_NOTE -> context.getString(R.string.menu_add_note)
+            TAG -> context.getString(R.string.menu_edit_tags)
+            RESET_PROGRESS -> context.getString(R.string.card_editor_reset_card)
+            TOGGLE_AUTO_ADVANCE -> context.getString(R.string.toggle_auto_advance)
+            RECORD_VOICE -> context.getString(R.string.record_voice)
+            PLAY_MEDIA -> context.getString(R.string.replay_media)
+            USER_ACTION_1 -> context.getString(R.string.user_action_1)
+            USER_ACTION_2 -> context.getString(R.string.user_action_2)
+            USER_ACTION_3 -> context.getString(R.string.user_action_3)
+            USER_ACTION_4 -> context.getString(R.string.user_action_4)
+            USER_ACTION_5 -> context.getString(R.string.user_action_5)
+            USER_ACTION_6 -> context.getString(R.string.user_action_6)
+            USER_ACTION_7 -> context.getString(R.string.user_action_7)
+            USER_ACTION_8 -> context.getString(R.string.user_action_8)
+            USER_ACTION_9 -> context.getString(R.string.user_action_9)
+            BURY_NOTE -> context.getString(R.string.menu_bury_note)
+            BURY_CARD -> context.getString(R.string.menu_bury_card)
+            SUSPEND_NOTE -> context.getString(R.string.menu_suspend_note)
+            SUSPEND_CARD -> context.getString(R.string.menu_suspend_card)
+            UNSET_FLAG,
+            FLAG_RED,
+            FLAG_ORANGE,
+            FLAG_GREEN,
+            FLAG_BLUE,
+            FLAG_PINK,
+            FLAG_TURQUOISE,
+            FLAG_PURPLE,
+            SHOW_ANSWER,
+            ANSWER_AGAIN,
+            ANSWER_HARD,
+            ANSWER_GOOD,
+            ANSWER_EASY,
+            TOGGLE_FLAG_RED,
+            TOGGLE_FLAG_ORANGE,
+            TOGGLE_FLAG_GREEN,
+            TOGGLE_FLAG_BLUE,
+            TOGGLE_FLAG_PINK,
+            TOGGLE_FLAG_TURQUOISE,
+            TOGGLE_FLAG_PURPLE,
+            SHOW_HINT,
+            SHOW_ALL_HINTS,
+            REPLAY_VOICE,
+            PAGE_UP,
+            PAGE_DOWN,
+            EXIT,
+            -> context.getString(R.string.empty_string)
         }
 
     private fun keycode(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
@@ -35,7 +35,6 @@ import com.ichi2.anki.reviewer.CardSide
 import com.ichi2.anki.reviewer.MappableAction
 import com.ichi2.anki.reviewer.ReviewerBinding
 import com.ichi2.anki.ui.internationalization.sentenceCase
-import com.ichi2.anki.ui.internationalization.toSentenceCase
 
 /**
  * @param menuId menu Id of the action
@@ -257,68 +256,70 @@ enum class ViewerAction(
     fun isSubMenu() = ViewerAction.entries.any { it.parentMenu == this }
 
     fun title(context: Context): String =
-        when (this) {
-            BROWSE -> TR.qtMiscBrowse()
-            STATISTICS -> TR.statisticsTitle()
-            RESCHEDULE_NOTE -> with(context) { TR.sentenceCase.setDueDate }
-            PREVIOUS_CARD_INFO -> TR.actionsPreviousCardInfo().toSentenceCase(context, R.string.sentence_actions_previous_card_info)
-            UNDO -> context.getString(R.string.undo)
-            REDO -> context.getString(R.string.redo)
-            FLAG_MENU -> context.getString(R.string.menu_flag)
-            MARK -> context.getString(R.string.menu_mark_note)
-            EDIT -> context.getString(R.string.cardeditor_title_edit_card)
-            BURY_MENU -> context.getString(R.string.menu_bury)
-            SUSPEND_MENU -> context.getString(R.string.menu_suspend)
-            DELETE -> context.getString(R.string.menu_delete_note)
-            TOGGLE_WHITEBOARD -> context.getString(R.string.gesture_toggle_whiteboard)
-            DECK_OPTIONS -> context.getString(R.string.menu__deck_options)
-            CARD_INFO -> context.getString(R.string.card_info_title)
-            ADD_NOTE -> context.getString(R.string.menu_add_note)
-            TAG -> context.getString(R.string.menu_edit_tags)
-            RESET_PROGRESS -> context.getString(R.string.card_editor_reset_card)
-            TOGGLE_AUTO_ADVANCE -> context.getString(R.string.toggle_auto_advance)
-            RECORD_VOICE -> context.getString(R.string.record_voice)
-            PLAY_MEDIA -> context.getString(R.string.replay_media)
-            USER_ACTION_1 -> context.getString(R.string.user_action_1)
-            USER_ACTION_2 -> context.getString(R.string.user_action_2)
-            USER_ACTION_3 -> context.getString(R.string.user_action_3)
-            USER_ACTION_4 -> context.getString(R.string.user_action_4)
-            USER_ACTION_5 -> context.getString(R.string.user_action_5)
-            USER_ACTION_6 -> context.getString(R.string.user_action_6)
-            USER_ACTION_7 -> context.getString(R.string.user_action_7)
-            USER_ACTION_8 -> context.getString(R.string.user_action_8)
-            USER_ACTION_9 -> context.getString(R.string.user_action_9)
-            BURY_NOTE -> context.getString(R.string.menu_bury_note)
-            BURY_CARD -> context.getString(R.string.menu_bury_card)
-            SUSPEND_NOTE -> context.getString(R.string.menu_suspend_note)
-            SUSPEND_CARD -> context.getString(R.string.menu_suspend_card)
-            UNSET_FLAG,
-            FLAG_RED,
-            FLAG_ORANGE,
-            FLAG_GREEN,
-            FLAG_BLUE,
-            FLAG_PINK,
-            FLAG_TURQUOISE,
-            FLAG_PURPLE,
-            SHOW_ANSWER,
-            ANSWER_AGAIN,
-            ANSWER_HARD,
-            ANSWER_GOOD,
-            ANSWER_EASY,
-            TOGGLE_FLAG_RED,
-            TOGGLE_FLAG_ORANGE,
-            TOGGLE_FLAG_GREEN,
-            TOGGLE_FLAG_BLUE,
-            TOGGLE_FLAG_PINK,
-            TOGGLE_FLAG_TURQUOISE,
-            TOGGLE_FLAG_PURPLE,
-            SHOW_HINT,
-            SHOW_ALL_HINTS,
-            REPLAY_VOICE,
-            PAGE_UP,
-            PAGE_DOWN,
-            EXIT,
-            -> context.getString(R.string.empty_string)
+        with(context) {
+            when (this@ViewerAction) {
+                BROWSE -> TR.qtMiscBrowse()
+                STATISTICS -> TR.statisticsTitle()
+                RESCHEDULE_NOTE -> TR.sentenceCase.setDueDate
+                PREVIOUS_CARD_INFO -> TR.sentenceCase.previousCardInfo
+                UNDO -> getString(R.string.undo)
+                REDO -> getString(R.string.redo)
+                FLAG_MENU -> TR.browsingFlag()
+                MARK -> TR.sentenceCase.markNote
+                EDIT -> getString(R.string.cardeditor_title_edit_card)
+                BURY_MENU -> TR.studyingBury()
+                SUSPEND_MENU -> TR.studyingSuspend()
+                DELETE -> getString(R.string.menu_delete_note)
+                TOGGLE_WHITEBOARD -> getString(R.string.gesture_toggle_whiteboard)
+                DECK_OPTIONS -> getString(R.string.menu__deck_options)
+                CARD_INFO -> TR.sentenceCase.cardInfo
+                ADD_NOTE -> getString(R.string.menu_add_note)
+                TAG -> getString(R.string.menu_edit_tags)
+                RESET_PROGRESS -> getString(R.string.card_editor_reset_card)
+                TOGGLE_AUTO_ADVANCE -> getString(R.string.toggle_auto_advance)
+                RECORD_VOICE -> getString(R.string.record_voice)
+                PLAY_MEDIA -> getString(R.string.replay_media)
+                USER_ACTION_1 -> getString(R.string.user_action_1)
+                USER_ACTION_2 -> getString(R.string.user_action_2)
+                USER_ACTION_3 -> getString(R.string.user_action_3)
+                USER_ACTION_4 -> getString(R.string.user_action_4)
+                USER_ACTION_5 -> getString(R.string.user_action_5)
+                USER_ACTION_6 -> getString(R.string.user_action_6)
+                USER_ACTION_7 -> getString(R.string.user_action_7)
+                USER_ACTION_8 -> getString(R.string.user_action_8)
+                USER_ACTION_9 -> getString(R.string.user_action_9)
+                BURY_NOTE -> TR.sentenceCase.buryNote
+                BURY_CARD -> TR.sentenceCase.buryCard
+                SUSPEND_NOTE -> TR.sentenceCase.suspendNote
+                SUSPEND_CARD -> TR.sentenceCase.suspendCard
+                UNSET_FLAG,
+                FLAG_RED,
+                FLAG_ORANGE,
+                FLAG_GREEN,
+                FLAG_BLUE,
+                FLAG_PINK,
+                FLAG_TURQUOISE,
+                FLAG_PURPLE,
+                SHOW_ANSWER,
+                ANSWER_AGAIN,
+                ANSWER_HARD,
+                ANSWER_GOOD,
+                ANSWER_EASY,
+                TOGGLE_FLAG_RED,
+                TOGGLE_FLAG_ORANGE,
+                TOGGLE_FLAG_GREEN,
+                TOGGLE_FLAG_BLUE,
+                TOGGLE_FLAG_PINK,
+                TOGGLE_FLAG_TURQUOISE,
+                TOGGLE_FLAG_PURPLE,
+                SHOW_HINT,
+                SHOW_ALL_HINTS,
+                REPLAY_VOICE,
+                PAGE_UP,
+                PAGE_DOWN,
+                EXIT,
+                -> getString(R.string.empty_string)
+            }
         }
 
     private fun keycode(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
@@ -48,7 +48,7 @@ import com.ichi2.anki.ui.internationalization.toSentenceCase
 enum class ViewerAction(
     @IdRes val menuId: Int = 0,
     @DrawableRes val drawableRes: Int? = null,
-    @StringRes val titleRes: Int = R.string.empty_string,
+    @StringRes private val titleRes: Int = R.string.empty_string,
     val defaultDisplayType: MenuDisplayType? = null,
     val parentMenu: ViewerAction? = null,
 ) : MappableAction<ReviewerBinding> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
@@ -32,6 +32,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.slider.Slider
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.DispatchKeyEventListener
 import com.ichi2.anki.Flag
 import com.ichi2.anki.R
@@ -44,6 +45,7 @@ import com.ichi2.anki.reviewer.BindingProcessor
 import com.ichi2.anki.reviewer.MappableBinding
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.ext.collectIn
 import com.ichi2.anki.utils.ext.setIconRes
 import com.ichi2.anki.utils.ext.sharedPrefs
@@ -114,7 +116,7 @@ class PreviewerFragment :
                             setTitle(R.string.menu_unmark_note)
                         } else {
                             setIcon(R.drawable.ic_star_border_white)
-                            setTitle(R.string.menu_mark_note)
+                            title = TR.sentenceCase.markNote
                         }
                     }
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
@@ -163,6 +163,48 @@ object SentenceCase {
 
     context(_: Fragment)
     val logOut get() = TR.syncLogOutButton().toSentenceCase(R.string.sentence_log_out)
+
+    context(_: Context)
+    val cardInfo get() = TR.actionsCardInfo().toSentenceCase(R.string.sentence_card_info)
+
+    context(_: Fragment)
+    val cardInfo get() = TR.actionsCardInfo().toSentenceCase(R.string.sentence_card_info)
+
+    context(_: Context)
+    val buryNote get() = TR.studyingBuryNote().toSentenceCase(R.string.sentence_bury_note)
+
+    context(_: Fragment)
+    val buryNote get() = TR.studyingBuryNote().toSentenceCase(R.string.sentence_bury_note)
+
+    context(_: Context)
+    val buryCard get() = TR.studyingBuryCard().toSentenceCase(R.string.sentence_bury_card)
+
+    context(_: Fragment)
+    val buryCard get() = TR.studyingBuryCard().toSentenceCase(R.string.sentence_bury_card)
+
+    context(_: Context)
+    val suspendNote get() = TR.studyingSuspendNote().toSentenceCase(R.string.sentence_suspend_note)
+
+    context(_: Fragment)
+    val suspendNote get() = TR.studyingSuspendNote().toSentenceCase(R.string.sentence_suspend_note)
+
+    context(_: Context)
+    val suspendCard get() = TR.actionsSuspendCard().toSentenceCase(R.string.sentence_suspend_card)
+
+    context(_: Fragment)
+    val suspendCard get() = TR.actionsSuspendCard().toSentenceCase(R.string.sentence_suspend_card)
+
+    context(_: Context)
+    val markNote get() = TR.studyingMarkNote().toSentenceCase(R.string.sentence_mark_note)
+
+    context(_: Fragment)
+    val markNote get() = TR.studyingMarkNote().toSentenceCase(R.string.sentence_mark_note)
+
+    context(_: Context)
+    val previousCardInfo get() = TR.actionsPreviousCardInfo().toSentenceCase(R.string.sentence_actions_previous_card_info)
+
+    context(_: Fragment)
+    val previousCardInfo get() = TR.actionsPreviousCardInfo().toSentenceCase(R.string.sentence_actions_previous_card_info)
 }
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerMenu.kt
@@ -22,9 +22,11 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.coroutineScope
 import androidx.lifecycle.flowWithLifecycle
 import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.preferences.reviewer.ReviewerMenuView
 import com.ichi2.anki.preferences.reviewer.ViewerAction
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.ext.collectLatestIn
 import com.ichi2.anki.utils.ext.menu
 import com.ichi2.anki.utils.ext.removeSubMenu
@@ -56,7 +58,7 @@ fun ReviewerMenuView.setup(
                     markItem.setTitle(R.string.menu_unmark_note)
                 } else {
                     markItem.setPaddedIcon(context, R.drawable.ic_star_border_white)
-                    markItem.setTitle(R.string.menu_mark_note)
+                    markItem.title = with(context) { TR.sentenceCase.markNote }
                 }
             }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerMenu.kt
@@ -84,16 +84,16 @@ fun ReviewerMenuView.setup(
         suspendFlow.collectLatestIn(lifecycle.coroutineScope) { canSuspendNote ->
             if (canSuspendNote) {
                 if (suspendItem.hasSubMenu()) return@collectLatestIn
-                suspendItem.setTitle(ViewerAction.SUSPEND_MENU.titleRes)
+                suspendItem.title = ViewerAction.SUSPEND_MENU.title(context)
                 val submenu =
                     SubMenuBuilder(context, suspendItem.menu, suspendItem).apply {
-                        add(Menu.NONE, ViewerAction.SUSPEND_NOTE.menuId, Menu.NONE, ViewerAction.SUSPEND_NOTE.titleRes)
-                        add(Menu.NONE, ViewerAction.SUSPEND_CARD.menuId, Menu.NONE, ViewerAction.SUSPEND_CARD.titleRes)
+                        add(Menu.NONE, ViewerAction.SUSPEND_NOTE.menuId, Menu.NONE, ViewerAction.SUSPEND_NOTE.title(context))
+                        add(Menu.NONE, ViewerAction.SUSPEND_CARD.menuId, Menu.NONE, ViewerAction.SUSPEND_CARD.title(context))
                     }
                 suspendItem.setSubMenu(submenu)
             } else {
                 suspendItem.removeSubMenu()
-                suspendItem.setTitle(ViewerAction.SUSPEND_CARD.titleRes)
+                suspendItem.title = ViewerAction.SUSPEND_CARD.title(context)
             }
         }
     }
@@ -103,16 +103,16 @@ fun ReviewerMenuView.setup(
         buryFlow.collectLatestIn(lifecycle.coroutineScope) { canBuryNote ->
             if (canBuryNote) {
                 if (buryItem.hasSubMenu()) return@collectLatestIn
-                buryItem.setTitle(ViewerAction.BURY_MENU.titleRes)
+                buryItem.title = ViewerAction.BURY_MENU.title(context)
                 val submenu =
                     SubMenuBuilder(context, buryItem.menu, buryItem).apply {
-                        add(Menu.NONE, ViewerAction.BURY_NOTE.menuId, Menu.NONE, ViewerAction.BURY_NOTE.titleRes)
-                        add(Menu.NONE, ViewerAction.BURY_CARD.menuId, Menu.NONE, ViewerAction.BURY_CARD.titleRes)
+                        add(Menu.NONE, ViewerAction.BURY_NOTE.menuId, Menu.NONE, ViewerAction.BURY_NOTE.title(context))
+                        add(Menu.NONE, ViewerAction.BURY_CARD.menuId, Menu.NONE, ViewerAction.BURY_CARD.title(context))
                     }
                 buryItem.setSubMenu(submenu)
             } else {
                 buryItem.removeSubMenu()
-                buryItem.setTitle(ViewerAction.BURY_CARD.titleRes)
+                buryItem.title = ViewerAction.BURY_CARD.title(context)
             }
         }
     }

--- a/AnkiDroid/src/main/res/layout/dialog_browser_options.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_browser_options.xml
@@ -129,9 +129,10 @@
         android:layout_margin="8dp">
 
             <TextView
+            android:id="@+id/flag_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/menu_flag"
+            tools:text="Flag"
             android:textStyle="bold"
             android:layout_marginHorizontal="16dp" />
 

--- a/AnkiDroid/src/main/res/menu/card_browser_multiselect.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser_multiselect.xml
@@ -13,7 +13,7 @@
     <item
         android:id="@+id/action_view_card_info"
         android:icon="@drawable/ic_dialog_info"
-        android:title="@string/card_info_title" />
+        tools:title="Card info" />
 
     <item
         ankidroid:showAsAction="ifRoom"

--- a/AnkiDroid/src/main/res/menu/previewer.xml
+++ b/AnkiDroid/src/main/res/menu/previewer.xml
@@ -34,7 +34,7 @@
     <item
         android:id="@+id/action_mark"
         android:icon="@drawable/ic_star_border_white"
-        android:title="@string/menu_mark_note"
+        tools:title="Mark note"
         app:showAsAction="always"/>
     <item
         android:id="@+id/action_edit"

--- a/AnkiDroid/src/main/res/menu/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu/reviewer.xml
@@ -111,12 +111,12 @@
     <item
         android:id="@+id/action_card_info"
         android:icon="@drawable/ic_dialog_info"
-        android:title="@string/card_info_title"
+        tools:title="Card info"
         ankidroid:showAsAction="never"/>
     <item
         android:id="@+id/action_previous_card_info"
         android:icon="@drawable/ic_outline_info_24"
-        android:title="@string/previous_card_info_title"
+        tools:title="Previous card info"
         ankidroid:showAsAction="never"/>
     <item
         android:id="@+id/action_tag"
@@ -125,39 +125,39 @@
         ankidroid:showAsAction="never"/>
     <item
         android:id="@+id/action_bury_card"
-        android:title="@string/menu_bury_card"
+        tools:title="Bury card"
         android:icon="@drawable/ic_flip_to_back_white"
         android:visible="false"
         />
     <item
         android:id="@+id/action_bury"
-        android:title="@string/menu_bury"
+        tools:title="Bury"
         android:icon="@drawable/ic_flip_to_back_white">
         <menu>
             <item
                 android:id="@+id/action_bury_card"
-                android:title="@string/menu_bury_card" />
+                tools:title="Bury card" />
             <item
                 android:id="@+id/action_bury_note"
-                android:title="@string/menu_bury_note" />
+                tools:title="Bury note" />
         </menu>
 
     </item>
     <item android:id="@+id/action_suspend_card"
-        android:title="@string/menu_suspend_card"
+        tools:title="Suspend card"
         android:icon="@drawable/ic_suspend"
         android:visible="false"/>
     <item
         android:id="@+id/action_suspend"
-        android:title="@string/menu_suspend"
+        tools:title="Suspend"
         android:icon="@drawable/ic_suspend">
         <menu>
             <item
                 android:id="@+id/action_suspend_card"
-                android:title="@string/menu_suspend_card" />
+                tools:title="Suspend card" />
             <item
                 android:id="@+id/action_suspend_note"
-                android:title="@string/menu_suspend_note" />
+                tools:title="Suspend note" />
         </menu>
     </item>
 
@@ -168,7 +168,7 @@
     <item
         android:id="@+id/action_mark_card"
         android:icon="@drawable/ic_star_border_white"
-        android:title="@string/menu_mark_note"
+        tools:title="Mark note"
         ankidroid:showAsAction="ifRoom"/>
     <item
         android:id="@+id/action_schedule"

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -81,20 +81,12 @@
     <string name="menu_add_note" maxLength="28">Add note</string>
     <string name="menu_my_account" comment="Label of the window in which the user should enter their account. This text can't be found in AnkiDroid directly.">Sync account</string>
     <string name="menu_dismiss_note" maxLength="41" >Hide / delete</string>
-    <string name="menu_bury_card" maxLength="28">Bury card</string>
-    <string name="menu_bury_note" maxLength="28">Bury note</string>
-    <string name="menu_suspend_card" maxLength="28">Suspend card</string>
-    <string name="menu_suspend_note" maxLength="28">Suspend note</string>
-    <string name="menu_bury" maxLength="28">Bury</string>
-    <string name="menu_suspend" maxLength="28">Suspend</string>
     <string name="menu_delete_note" maxLength="28">Delete note</string>
-    <string name="menu_flag" maxLength="41">Flag</string>
     <string name="rename_flag">Rename flags</string>
     <string name="menu_flag_card" maxLength="28">Flag card</string>
     <string name="menu_edit_tags" maxLength="28">Edit tags</string>
     <string name="delete_note_message">Really delete this note and all its cards?\n%s</string>
     <string name="menu_search" maxLength="28">Lookup in %1$s</string>
-    <string name="menu_mark_note" maxLength="28">Mark note</string>
     <string name="menu_unmark_note">Unmark note</string>
     <string name="menu_enable_voice_playback" maxLength="28">Enable voice playback</string>
     <string name="menu_disable_voice_playback">Disable voice playback</string>
@@ -150,8 +142,6 @@
     <string name="card_template_browser_appearance_title">Browser appearance</string>
 
     <!-- card Info -->
-    <string name="card_info_title" maxLength="28">Card info</string>
-    <string name="previous_card_info_title" maxLength="28">Previous card info</string>
 
     <!-- Permissions -->
     <string name="read_write_permission_label">Read and write to the AnkiDroid database</string>

--- a/AnkiDroid/src/main/res/values/sentence-case.xml
+++ b/AnkiDroid/src/main/res/values/sentence-case.xml
@@ -69,4 +69,10 @@ undoActionUndone()
     <string name="sentence_delete_deck">Delete deck</string>
     <string name="sentence_log_in">Log in</string>
     <string name="sentence_log_out">Log out</string>
+    <string name="sentence_card_info">Card info</string>
+    <string name="sentence_bury_note">Bury note</string>
+    <string name="sentence_bury_card">Bury card</string>
+    <string name="sentence_suspend_note">Suspend note</string>
+    <string name="sentence_suspend_card">Suspend card</string>
+    <string name="sentence_mark_note">Mark note</string>
 </resources>

--- a/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
@@ -27,6 +27,7 @@ TODO: Add a unit test
 -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:title="@string/custom_buttons"
     android:key="@string/pref_app_bar_buttons_screen_key">
     <Preference
@@ -59,7 +60,7 @@ TODO: Add a unit test
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_flag_key"
-            android:title="@string/menu_flag"
+            tools:title="Flag"
             app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="1"
@@ -94,14 +95,14 @@ TODO: Add a unit test
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_card_info_key"
-            android:title="@string/card_info_title"
+            tools:title="Card info"
             app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="3"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_previous_card_info_key"
-            android:title="@string/previous_card_info_title"
+            tools:title="Previous card info"
             app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="0"
@@ -122,7 +123,7 @@ TODO: Add a unit test
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_mark_card_key"
-            android:title="@string/menu_mark_note"
+            tools:title="Mark note"
             app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="0"
@@ -145,14 +146,14 @@ TODO: Add a unit test
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_bury_key"
-            android:title="@string/menu_bury"
+            tools:title="Bury"
             app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="0"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_suspend_key"
-            android:title="@string/menu_suspend"
+            tools:title="Suspend"
             app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="0"

--- a/AnkiDroid/src/main/res/xml/preferences_previewer_controls.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_previewer_controls.xml
@@ -16,7 +16,7 @@
         />
     <com.ichi2.preferences.ControlPreference
         android:key="@string/previewer_mark_key"
-        android:title="@string/menu_mark_note"
+        tools:title="Mark note"
         android:icon="@drawable/ic_star_border_white"
         />
     <com.ichi2.preferences.ControlPreference

--- a/AnkiDroid/src/main/res/xml/preferences_reviewer_controls.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewer_controls.xml
@@ -84,12 +84,12 @@
     <PreferenceCategory android:title="@string/card">
         <com.ichi2.preferences.ReviewerControlPreference
             android:key="@string/bury_card_command_key"
-            android:title="@string/menu_bury_card"
+            tools:title="Bury card"
             android:icon="@drawable/ic_flip_to_back_white"
             />
         <com.ichi2.preferences.ReviewerControlPreference
             android:key="@string/suspend_card_command_key"
-            android:title="@string/menu_suspend_card"
+            tools:title="Suspend card"
             android:icon="@drawable/ic_suspend"
             />
         <com.ichi2.preferences.ReviewerControlPreference
@@ -99,12 +99,12 @@
             />
         <com.ichi2.preferences.ReviewerControlPreference
             android:key="@string/card_info_command_key"
-            android:title="@string/card_info_title"
+            tools:title="Card info"
             android:icon="@drawable/ic_dialog_info"
             />
         <com.ichi2.preferences.ReviewerControlPreference
             android:key="@string/previous_card_info_command_key"
-            android:title="@string/previous_card_info_title"
+            tools:title="Previous card info"
             android:icon="@drawable/ic_outline_info_24"
             />
     </PreferenceCategory>
@@ -112,12 +112,12 @@
     <PreferenceCategory android:title="@string/note">
         <com.ichi2.preferences.ReviewerControlPreference
             android:key="@string/bury_note_command_key"
-            android:title="@string/menu_bury_note"
+            tools:title="Bury note"
             android:icon="@drawable/ic_flip_to_back_white"
             />
         <com.ichi2.preferences.ReviewerControlPreference
             android:key="@string/suspend_note_command_key"
-            android:title="@string/menu_suspend_note"
+            tools:title="Suspend note"
             android:icon="@drawable/ic_suspend"
             />
         <com.ichi2.preferences.ReviewerControlPreference
@@ -127,7 +127,7 @@
             />
         <com.ichi2.preferences.ReviewerControlPreference
             android:key="@string/mark_command_key"
-            android:title="@string/menu_mark_note"
+            tools:title="Mark note"
             android:icon="@drawable/ic_star_border_white"
             />
         <com.ichi2.preferences.ReviewerControlPreference

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
@@ -182,7 +182,6 @@ class TranslationTest : RobolectricTest() {
                 "Appearance", // R.string.pref_cat_appearance | TR.preferencesAppearance()
                 "Back", // R.string.back_field_name, R.string.previewer_back
                 // TR.notetypesBackField()
-                "Bury", // R.string.menu_bury | TR.studyingBury()
                 "Cancel", // R.string.dialog_cancel
                 // TR.actionsCancel()
                 // TR.syncCancelButton()
@@ -232,7 +231,6 @@ class TranslationTest : RobolectricTest() {
                 // TR.editingFields()
                 // TR.notetypesFields()
                 // TR.changeNotetypeFields()
-                "Flag", // R.string.menu_flag | TR.browsingFlag()
                 "Flags", // R.string.filter_by_flags | TR.browsingSidebarFlags()
                 "Flip", // R.string.image_cropper_action_flip | TR.cardTemplatesFlip()
                 "Front", // R.string.front_field_name | TR.notetypesFrontField()
@@ -301,7 +299,6 @@ class TranslationTest : RobolectricTest() {
                 "Show remaining card count", // R.string.show_progress_summ | TR.preferencesShowRemainingCardCount()
                 "Statistics", // R.string.statistics | TR.statisticsTitle()
                 "Study", // R.string.studyoptions_start | TR.decksStudy()
-                "Suspend", // R.string.menu_suspend | TR.studyingSuspend()
                 "Sync", // R.string.button_sync, R.string.pref_cat_sync
                 // TR.qtMiscSync()
                 "Synchronization", // R.string.sync_title | TR.preferencesTabSynchronisation()
@@ -347,9 +344,6 @@ class TranslationTest : RobolectricTest() {
                 "Blank", // R.string.reviewer_tts_cloze_spoken_replacement | TR.cardTemplatesBlank()
                 "Browser appearance", // R.string.card_template_browser_appearance_title | TR.browsingBrowserAppearance()
                 "Browser options", // R.string.browser_options_dialog_heading | TR.browsingBrowserOptions()
-                "Bury card", // R.string.menu_bury_card | TR.studyingBuryCard()
-                "Bury note", // R.string.menu_bury_note | TR.studyingBuryNote()
-                "Card info", // R.string.card_info_title | TR.actionsCardInfo()
                 "Change deck", // R.string.card_browser_change_deck | TR.browsingChangeDeck()
                 "Copy debug info", // R.string.feedback_copy_debug
                 // TR.aboutCopyDebugInfo()
@@ -365,8 +359,6 @@ class TranslationTest : RobolectricTest() {
                 "Manage note types", // R.string.model_browser_label
                 // TR.browsingManageNoteTypes()
                 // TR.qtMiscManageNoteTypes()
-                "Mark note", // R.string.menu_mark_note | TR.studyingMarkNote()
-                "Previous card info", // R.string.previous_card_info_title | TR.actionsPreviousCardInfo()
                 "Rename deck", // R.string.rename_deck | TR.actionsRenameDeck()
                 "Select all", // R.string.card_browser_select_all | TR.editingImageOcclusionSelectAll()
                 "Select deck", // R.string.select_deck | TR.browsingSelectDeck()
@@ -374,8 +366,6 @@ class TranslationTest : RobolectricTest() {
                 "Show answer", // R.string.show_answer
                 // TR.studyingShowAnswer()
                 // TR.deckConfigQuestionActionShowAnswer()
-                "Suspend card", // R.string.menu_suspend_card | TR.actionsSuspendCard()
-                "Suspend note", // R.string.menu_suspend_note | TR.studyingSuspendNote()
             )
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
@@ -70,6 +70,13 @@ class SentenceCaseTest : RobolectricTest() {
                 assertThat(TR.sentenceCase.deleteDeck, equalTo("Delete deck"))
                 assertThat(TR.sentenceCase.logIn, equalTo("Log in"))
                 assertThat(TR.sentenceCase.logOut, equalTo("Log out"))
+                assertThat(TR.sentenceCase.cardInfo, equalTo("Card info"))
+                assertThat(TR.sentenceCase.buryNote, equalTo("Bury note"))
+                assertThat(TR.sentenceCase.buryCard, equalTo("Bury card"))
+                assertThat(TR.sentenceCase.suspendNote, equalTo("Suspend note"))
+                assertThat(TR.sentenceCase.suspendCard, equalTo("Suspend card"))
+                assertThat(TR.sentenceCase.markNote, equalTo("Mark note"))
+                assertThat(TR.sentenceCase.previousCardInfo, equalTo("Previous card info"))
 
                 assertThat("syncMediaLogTitle", TR.syncMediaLogTitle(), equalTo("Media Sync Log"))
                 assertThat(TR.sentenceCase.mediaSyncLog, equalTo("Media sync log"))


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - all

## Purpose / Description
This means less work for our translators - especially as 01-core is required for a translation to be included in the app

## How Has This Been Tested?
I opened the menu + bury/suspend submenus in the old/new study screen, API 29 emulator

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)