### PR TITLE
Fix deck names related argument crash in DeckSelectionDialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -31,6 +31,7 @@ import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.res.getDrawableOrThrow
 import androidx.core.content.res.use
+import androidx.core.os.BundleCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
@@ -118,7 +119,8 @@ class DeckSelectionDialog : AnalyticsDialogFragment() {
         )
     }
 
-    private fun getDeckNames(): ArrayList<SelectableDeck> = requireNotNull(requireArguments().getParcelableCompat(DECK_NAMES))
+    private fun getDeckNames(): ArrayList<SelectableDeck> =
+        BundleCompat.getParcelableArrayList(requireArguments(), DECK_NAMES, SelectableDeck::class.java)!!
 
     private fun setupMenu() {
         val toolbar: Toolbar = binding.toolbar


### PR DESCRIPTION
## Purpose / Description

I've incorrectly modified how the decks arguments was fetched in DeckSelectionDialog. This incorrect version **works** on API levels 34 and above, but crashes on lower versions.
I reverted to the previous implementation, this part of the code will be removed anyway.

## Fixes
* Fixes #21091

## How Has This Been Tested?

Ran on lower versions.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

