### PR TITLE
docs(lint-rules): convert licenses to SPDX format & remove redundant lint suppressions

### DIFF
--- a/.idea/dictionaries/usernames.xml
+++ b/.idea/dictionaries/usernames.xml
@@ -48,6 +48,7 @@
       <w>Oltmanns</w>
       <w>Patil</w>
       <w>Piyush</w>
+      <w>Poisseroux</w>
       <w>Prateek</w>
       <w>Prehn</w>
       <w>Profpatsch</w>
@@ -65,6 +66,7 @@
       <w>Sotoudeh</w>
       <w>Spyropoulos</w>
       <w>Srivastav</w>
+      <w>Sumit</w>
       <w>Svaerd</w>
       <w>Svard</w>
       <w>Svärd</w>

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
@@ -1,18 +1,6 @@
-/*
- * Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
+
 @file:Suppress("UnstableApiUsage")
 
 package com.ichi2.anki.lint

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
 
-@file:Suppress("UnstableApiUsage")
-
 package com.ichi2.anki.lint
 
 import com.android.tools.lint.client.api.IssueRegistry

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/AvoidAlertDialogUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/AvoidAlertDialogUsage.kt
@@ -1,18 +1,6 @@
-/*
- *  Copyright (c) 2024 Sumit Singh <sumitsinghkoranga7@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2024 Sumit Singh <sumitsinghkoranga7@gmail.com>
+
 @file:Suppress("UnstableApiUsage")
 
 package com.ichi2.anki.lint.rules

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/AvoidAlertDialogUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/AvoidAlertDialogUsage.kt
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: Copyright (c) 2024 Sumit Singh <sumitsinghkoranga7@gmail.com>
 
-@file:Suppress("UnstableApiUsage")
-
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.client.api.UElementHandler

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectCalendarInstanceUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectCalendarInstanceUsage.kt
@@ -1,18 +1,6 @@
-/*
- * Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
+
 @file:Suppress("UnstableApiUsage")
 
 package com.ichi2.anki.lint.rules

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectCalendarInstanceUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectCalendarInstanceUsage.kt
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
 
-@file:Suppress("UnstableApiUsage")
-
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.Detector

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectDateInstantiation.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectDateInstantiation.kt
@@ -1,18 +1,6 @@
-/*
- * Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
+
 @file:Suppress("UnstableApiUsage")
 
 package com.ichi2.anki.lint.rules

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectDateInstantiation.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectDateInstantiation.kt
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
 
-@file:Suppress("UnstableApiUsage")
-
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.Detector

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectGregorianInstantiation.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectGregorianInstantiation.kt
@@ -1,18 +1,6 @@
-/*
- * Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
+
 @file:Suppress("UnstableApiUsage")
 
 package com.ichi2.anki.lint.rules

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectGregorianInstantiation.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectGregorianInstantiation.kt
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
 
-@file:Suppress("UnstableApiUsage")
-
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.Detector

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsage.kt
@@ -1,18 +1,6 @@
-/*
- * Copyright (c) 2021 Mrudul Tora <mrudultora@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2021 Mrudul Tora <mrudultora@gmail.com>
+
 @file:Suppress("UnstableApiUsage")
 
 package com.ichi2.anki.lint.rules

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsage.kt
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: Copyright (c) 2021 Mrudul Tora <mrudultora@gmail.com>
 
-@file:Suppress("UnstableApiUsage")
-
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.Detector

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemCurrentTimeMillisUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemCurrentTimeMillisUsage.kt
@@ -1,18 +1,6 @@
-/*
- * Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
+
 @file:Suppress("UnstableApiUsage")
 
 package com.ichi2.anki.lint.rules

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemCurrentTimeMillisUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemCurrentTimeMillisUsage.kt
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
 
-@file:Suppress("UnstableApiUsage")
-
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.Detector

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemTimeInstantiation.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemTimeInstantiation.kt
@@ -1,18 +1,6 @@
-/*
- * Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
+
 @file:Suppress("UnstableApiUsage")
 
 package com.ichi2.anki.lint.rules

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemTimeInstantiation.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemTimeInstantiation.kt
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
 
-@file:Suppress("UnstableApiUsage")
-
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.Detector

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectToastMakeTextUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectToastMakeTextUsage.kt
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: Copyright (c) 2021 Nicola Dardanis <nicdard@gmail.com>
 
-@file:Suppress("UnstableApiUsage")
-
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.Detector

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectToastMakeTextUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectToastMakeTextUsage.kt
@@ -1,18 +1,6 @@
-/*
- * Copyright (c) 2021 Nicola Dardanis <nicdard@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2021 Nicola Dardanis <nicdard@gmail.com>
+
 @file:Suppress("UnstableApiUsage")
 
 package com.ichi2.anki.lint.rules

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.kt
@@ -32,7 +32,6 @@
  *
  *  https://android.googlesource.com/platform/tools/base/+/studio-master-dev/lint/libs/lint-checks/src/main/java/com/android/tools/lint/checks/StringCasingDetector.kt?autodive=0%2F
  */
-@file:Suppress("UnstableApiUsage")
 
 package com.ichi2.anki.lint.rules
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLength.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLength.kt
@@ -1,18 +1,5 @@
-/*
- *  Copyright (c) 2021 Prateek Singh <prateeksingh3212@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2021 Prateek Singh <prateeksingh3212@gmail.com>
 
 @file:Suppress("UnstableApiUsage")
 
@@ -29,7 +16,6 @@ import com.android.tools.lint.detector.api.XmlContext
 import com.android.tools.lint.detector.api.XmlScanner
 import com.ichi2.anki.lint.utils.Constants
 import org.w3c.dom.Element
-import java.lang.IllegalArgumentException
 import java.util.Locale
 
 /**

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLength.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLength.kt
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: Copyright (c) 2021 Prateek Singh <prateeksingh3212@gmail.com>
 
-@file:Suppress("UnstableApiUsage")
-
 package com.ichi2.anki.lint.rules
 
 import com.android.resources.ResourceFolderType

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/HardcodedPreferenceKey.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/HardcodedPreferenceKey.kt
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
 
-@file:Suppress("UnstableApiUsage")
-
 package com.ichi2.anki.lint.rules
 
 import com.android.resources.ResourceFolderType

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/HardcodedPreferenceKey.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/HardcodedPreferenceKey.kt
@@ -1,18 +1,6 @@
-/*
- *  Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+
 @file:Suppress("UnstableApiUsage")
 
 package com.ichi2.anki.lint.rules

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetector.kt
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: Copyright (c) 2022 Divyansh Dwivedi <justdvnsh2208@gmail.com>
 
-@file:Suppress("UnstableApiUsage")
-
 package com.ichi2.anki.lint.rules
 
 import com.android.SdkConstants.TAG_PLURALS

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetector.kt
@@ -1,18 +1,5 @@
-/*
- *  Copyright (c) 2022 Divyansh Dwivedi <justdvnsh2208@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2022 Divyansh Dwivedi <justdvnsh2208@gmail.com>
 
 @file:Suppress("UnstableApiUsage")
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/JUnitNullAssertionDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/JUnitNullAssertionDetector.kt
@@ -1,18 +1,4 @@
-/*
- *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 @file:Suppress("UnstableApiUsage")
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/JUnitNullAssertionDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/JUnitNullAssertionDetector.kt
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-@file:Suppress("UnstableApiUsage")
-
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.Detector

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/LayoutPrefixDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/LayoutPrefixDetector.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (c) 2026 lukstbit <52494258+lukstbit@users.noreply.github.com>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2026 lukstbit <52494258+lukstbit@users.noreply.github.com>
 
 package com.ichi2.anki.lint.rules
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/LicenseHeaderExists.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/LicenseHeaderExists.kt
@@ -1,18 +1,6 @@
-/*
- *  Copyright (c) 2021 Almas Ahmad <ahmadalmas.786.aa@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2021 Almas Ahmad <ahmadalmas.786.aa@gmail.com>
+
 @file:Suppress("UnstableApiUsage")
 
 package com.ichi2.anki.lint.rules

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/LicenseHeaderExists.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/LicenseHeaderExists.kt
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: Copyright (c) 2021 Almas Ahmad <ahmadalmas.786.aa@gmail.com>
 
-@file:Suppress("UnstableApiUsage")
-
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.Context
@@ -13,7 +11,6 @@ import com.android.tools.lint.detector.api.LintFix
 import com.android.tools.lint.detector.api.Location
 import com.android.tools.lint.detector.api.Scope
 import com.android.tools.lint.detector.api.SourceCodeScanner
-import com.google.common.annotations.Beta
 import com.google.common.annotations.VisibleForTesting
 import com.ichi2.anki.lint.utils.Constants
 import org.jetbrains.uast.UClass
@@ -28,7 +25,6 @@ import java.util.regex.Pattern
  *
  * @see .EXPLANATION
  */
-@Beta
 class LicenseHeaderExists :
     Detector(),
     SourceCodeScanner {

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/LocaleRootDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/LocaleRootDetector.kt
@@ -1,18 +1,6 @@
-/*
- *  Copyright (c) 2024 Spencer Poisseroux <me@spoisseroux.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2024 Spencer Poisseroux <me@spoisseroux.com>
+
 @file:Suppress("UnstableApiUsage")
 
 package com.ichi2.anki.lint.rules

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/LocaleRootDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/LocaleRootDetector.kt
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: Copyright (c) 2024 Spencer Poisseroux <me@spoisseroux.com>
 
-@file:Suppress("UnstableApiUsage")
-
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.client.api.UElementHandler

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutions.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutions.kt
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-@file:Suppress("UnstableApiUsage")
-
 package com.ichi2.anki.lint.rules
 
 import com.android.SdkConstants

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutions.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutions.kt
@@ -1,18 +1,4 @@
-/*
- *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 @file:Suppress("UnstableApiUsage")
 
@@ -32,7 +18,6 @@ import com.ichi2.anki.lint.utils.StringFormatDetector
 import com.ichi2.anki.lint.utils.childrenSequence
 import org.w3c.dom.Element
 import org.w3c.dom.Node
-import java.lang.IllegalStateException
 
 /**
  * Fix for "Multiple substitutions specified in non-positional format"

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/OpenInputStreamSafeDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/OpenInputStreamSafeDetector.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (c) 2025 Nishtha Jain <jnishtha305@gmail.com>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2025 Nishtha Jain <jnishtha305@gmail.com>
 
 package com.ichi2.anki.lint.rules
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PrintStackTraceUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PrintStackTraceUsage.kt
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-@file:Suppress("UnstableApiUsage")
-
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.Detector

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PrintStackTraceUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PrintStackTraceUsage.kt
@@ -1,18 +1,5 @@
-/*
- *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 @file:Suppress("UnstableApiUsage")
 
 package com.ichi2.anki.lint.rules

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/SentenceCaseConventions.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/SentenceCaseConventions.kt
@@ -1,18 +1,4 @@
-/*
- *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 package com.ichi2.anki.lint.rules
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-@file:Suppress("UnstableApiUsage")
-
 package com.ichi2.anki.lint.rules
 
 import com.android.resources.ResourceFolderType

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt
@@ -1,18 +1,4 @@
-/*
- *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 @file:Suppress("UnstableApiUsage")
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/VariableNamingDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/VariableNamingDetector.kt
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: Copyright (c) 2021 Nicola Dardanis <nicdard@gmail.com>
 
-@file:Suppress("UnstableApiUsage")
-
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.client.api.UElementHandler

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/VariableNamingDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/VariableNamingDetector.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (c) 2021 Nicola Dardanis <nicdard@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2021 Nicola Dardanis <nicdard@gmail.com>
 
 @file:Suppress("UnstableApiUsage")
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Constants.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Constants.kt
@@ -1,18 +1,6 @@
-/*
- * Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
+
 @file:Suppress("UnstableApiUsage")
 
 package com.ichi2.anki.lint.utils

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Constants.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Constants.kt
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
 
-@file:Suppress("UnstableApiUsage")
-
 package com.ichi2.anki.lint.utils
 
 import com.android.tools.lint.detector.api.Category

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Crowdin.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Crowdin.kt
@@ -1,18 +1,4 @@
-/*
- *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 package com.ichi2.anki.lint.utils
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/DomExtensions.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/DomExtensions.kt
@@ -1,18 +1,4 @@
-/*
- *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 package com.ichi2.anki.lint.utils
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/LintUtils.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/LintUtils.kt
@@ -1,18 +1,6 @@
-/*
- * Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
+
 package com.ichi2.anki.lint.utils
 
 import org.jetbrains.uast.UClass

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/ext/XmlContext.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/ext/XmlContext.kt
@@ -1,18 +1,4 @@
-/*
- *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 package com.ichi2.anki.lint.utils.ext
 

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectCalendarInstanceUsageTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectCalendarInstanceUsageTest.kt
@@ -5,13 +5,10 @@ package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile
 import com.android.tools.lint.checks.infrastructure.TestLintTask
-import com.google.common.annotations.Beta
 import org.intellij.lang.annotations.Language
 import org.junit.Assert
 import org.junit.Test
 
-@Suppress("UnstableApiUsage")
-@Beta
 class DirectCalendarInstanceUsageTest {
     @Language("JAVA")
     private val stubCalendar = """                                   

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectCalendarInstanceUsageTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectCalendarInstanceUsageTest.kt
@@ -1,18 +1,6 @@
-/*
- * Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
+
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectDateInstantiationTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectDateInstantiationTest.kt
@@ -5,13 +5,10 @@ package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile
 import com.android.tools.lint.checks.infrastructure.TestLintTask
-import com.google.common.annotations.Beta
 import org.intellij.lang.annotations.Language
 import org.junit.Assert
 import org.junit.Test
 
-@Suppress("UnstableApiUsage")
-@Beta
 class DirectDateInstantiationTest {
     @Language("JAVA")
     private val stubDate = """                         

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectDateInstantiationTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectDateInstantiationTest.kt
@@ -1,18 +1,6 @@
-/*
- * Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
+
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectGregorianInstantiationTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectGregorianInstantiationTest.kt
@@ -5,13 +5,10 @@ package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile
 import com.android.tools.lint.checks.infrastructure.TestLintTask
-import com.google.common.annotations.Beta
 import org.intellij.lang.annotations.Language
 import org.junit.Assert
 import org.junit.Test
 
-@Suppress("UnstableApiUsage")
-@Beta
 class DirectGregorianInstantiationTest {
     @Language("JAVA")
     private val stubZoned = """                                      

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectGregorianInstantiationTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectGregorianInstantiationTest.kt
@@ -1,18 +1,6 @@
-/*
- * Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
+
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsageTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsageTest.kt
@@ -5,13 +5,10 @@ package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile
 import com.android.tools.lint.checks.infrastructure.TestLintTask
-import com.google.common.annotations.Beta
 import org.intellij.lang.annotations.Language
 import org.junit.Assert
 import org.junit.Test
 
-@Suppress("UnstableApiUsage")
-@Beta
 class DirectSnackbarMakeUsageTest {
     @Language("JAVA")
     private val stubSnackbar = """                                      

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsageTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsageTest.kt
@@ -1,18 +1,6 @@
-/*
- * Copyright (c) 2021 Mrudul Tora <mrudultora@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2021 Mrudul Tora <mrudultora@gmail.com>
+
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectSystemCurrentTimeMillisUsageTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectSystemCurrentTimeMillisUsageTest.kt
@@ -1,18 +1,6 @@
-/*
- * Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
+
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile.create

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectSystemTimeInstantiationTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectSystemTimeInstantiationTest.kt
@@ -1,18 +1,6 @@
-/*
- * Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2020 lukstbit <52494258+lukstbit@users.noreply.github.com>
+
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile.create

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectToastMakeTextUsageTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectToastMakeTextUsageTest.kt
@@ -1,18 +1,6 @@
-/*
- * Copyright (c) 2021 Nicola Dardanis <nicdard@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2021 Nicola Dardanis <nicdard@gmail.com>
+
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile.create

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStringsTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStringsTest.kt
@@ -1,18 +1,5 @@
-/*
- *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.checks.infrastructure.TestFiles

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLengthTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLengthTest.kt
@@ -1,18 +1,6 @@
-/*
- *  Copyright (c) 2021 Prateek Singh <prateeksingh3212@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2021 Prateek Singh <prateeksingh3212@gmail.com>
+
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.checks.infrastructure.TestFiles

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/HardcodedPreferenceKeyTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/HardcodedPreferenceKeyTest.kt
@@ -1,18 +1,6 @@
-/*
- *  Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.checks.infrastructure.TestFiles

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetectorTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetectorTest.kt
@@ -1,18 +1,5 @@
-/*
- *  Copyright (c) 2022 Divyansh Dwivedi <justdvnsh2208@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2022 Divyansh Dwivedi <justdvnsh2208@gmail.com>
 
 package com.ichi2.anki.lint.rules
 

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/LayoutPrefixDetectorTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/LayoutPrefixDetectorTest.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (c) 2026 lukstbit <52494258+lukstbit@users.noreply.github.com>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2026 lukstbit <52494258+lukstbit@users.noreply.github.com>
 
 package com.ichi2.anki.lint.rules
 

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/LicenseHeaderExistsTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/LicenseHeaderExistsTest.kt
@@ -1,18 +1,6 @@
-/*
- *  Copyright (c) 2021 Almas Ahmad <ahmadalmas.786.aa@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2021 Almas Ahmad <ahmadalmas.786.aa@gmail.com>
+
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.checks.infrastructure.ProjectDescription

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/LicenseHeaderExistsTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/LicenseHeaderExistsTest.kt
@@ -6,14 +6,11 @@ package com.ichi2.anki.lint.rules
 import com.android.tools.lint.checks.infrastructure.ProjectDescription
 import com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile.create
 import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
-import com.google.common.annotations.Beta
 import org.intellij.lang.annotations.Language
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /** Test for [LicenseHeaderExists] */
-@Suppress("UnstableApiUsage")
-@Beta
 class LicenseHeaderExistsTest {
     @Language("JAVA")
     private val fileWithLicense = """/*

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/LocaleRootDetectorTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/LocaleRootDetectorTest.kt
@@ -1,18 +1,6 @@
-/*
- * Copyright (c) 2024 Spencer Poisseroux <me@spoisseroux.com>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2024 Spencer Poisseroux <me@spoisseroux.com>
+
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile.create

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutionsTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutionsTest.kt
@@ -1,18 +1,4 @@
-/*
- *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 package com.ichi2.anki.lint.rules
 

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/OpenInputStreamSafeDetectorTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/OpenInputStreamSafeDetectorTest.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (c) 2025 Nishtha Jain <jnishtha305@gmail.com>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2025 Nishtha Jain <jnishtha305@gmail.com>
 
 package com.ichi2.anki.lint.rules
 

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/PrintStackTraceUsageTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/PrintStackTraceUsageTest.kt
@@ -1,18 +1,5 @@
-/*
- *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile.create

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/PrintStackTraceUsageTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/PrintStackTraceUsageTest.kt
@@ -8,7 +8,6 @@ import org.intellij.lang.annotations.Language
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-@Suppress("UnstableApiUsage") // .issues() is unstable
 class PrintStackTraceUsageTest {
     @Suppress("EmptyTryBlock") // in code samples
     companion object {

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/SentenceCaseConventionsTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/SentenceCaseConventionsTest.kt
@@ -1,18 +1,4 @@
-/*
- *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 package com.ichi2.anki.lint.rules
 

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/TranslationTypoTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/TranslationTypoTest.kt
@@ -1,18 +1,4 @@
-/*
- *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 package com.ichi2.anki.lint.rules
 

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/VariableNamingDetectorTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/VariableNamingDetectorTest.kt
@@ -1,18 +1,6 @@
-/*
- * Copyright (c) 2021 Nicola Dardanis <nicdard@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2021 Nicola Dardanis <nicdard@gmail.com>
+
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.checks.infrastructure.LintDetectorTest.java

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/testutils/LintAssert.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/testutils/LintAssert.kt
@@ -1,18 +1,4 @@
-/*
- *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 package com.ichi2.anki.lint.testutils
 

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/utils/CrowdinLanguageTagTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/utils/CrowdinLanguageTagTest.kt
@@ -1,18 +1,4 @@
-/*
- *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 package com.ichi2.anki.lint.utils
 


### PR DESCRIPTION
This change was not performed using LLMs and I have verified that it is correct

## Purpose / Description
AnkiDroid is standardizing licenses to SPDX.

I removed my copyright lines from the files as-per `docs/contributing/copyright-headers.md`

## Fixes
* Part of #20954

## How Has This Been Tested?
I reran tests to be sure the removal of suppressions did not cause an issue

I went through each diff in Android Studio and ensures that the copyright line was unchanged

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)