### PR TITLE
fix: Handle deprecation of overridePendingTransition (API 34)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.kt
@@ -6,7 +6,7 @@ import android.app.Activity
 import android.content.Context
 import android.os.Parcelable
 import android.util.LayoutDirection
-import androidx.core.app.ActivityOptionsCompat
+import com.ichi2.anim.ActivityTransitionAnimation.getInverseTransition
 import com.ichi2.anki.R
 import kotlinx.parcelize.Parcelize
 
@@ -39,48 +39,6 @@ object ActivityTransitionAnimation {
             }
         }
     }
-
-    fun getAnimationOptions(
-        activity: Activity,
-        direction: Direction?,
-    ): ActivityOptionsCompat =
-        when (direction) {
-            Direction.START ->
-                if (isRightToLeft(
-                        activity,
-                    )
-                ) {
-                    ActivityOptionsCompat.makeCustomAnimation(
-                        activity,
-                        R.anim.slide_right_in,
-                        R.anim.slide_right_out,
-                    )
-                } else {
-                    ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_left_in, R.anim.slide_left_out)
-                }
-            Direction.END ->
-                if (isRightToLeft(
-                        activity,
-                    )
-                ) {
-                    ActivityOptionsCompat.makeCustomAnimation(
-                        activity,
-                        R.anim.slide_left_in,
-                        R.anim.slide_left_out,
-                    )
-                } else {
-                    ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_right_in, R.anim.slide_right_out)
-                }
-            Direction.RIGHT -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_right_in, R.anim.slide_right_out)
-            Direction.LEFT -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_left_in, R.anim.slide_left_out)
-            Direction.FADE -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.fade_in, R.anim.fade_out)
-            Direction.UP -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_up_in, R.anim.slide_up_out)
-            Direction.DOWN -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_down_in, R.anim.slide_down_out)
-            Direction.NONE -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.none, R.anim.none)
-            Direction.DEFAULT -> // this is the default animation, we shouldn't try to override it
-                ActivityOptionsCompat.makeBasic()
-            else -> ActivityOptionsCompat.makeBasic()
-        }
 
     private fun isRightToLeft(c: Context): Boolean = c.resources.configuration.layoutDirection == LayoutDirection.RTL
 

--- a/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.kt
@@ -6,37 +6,50 @@ import android.app.Activity
 import android.content.Context
 import android.os.Parcelable
 import android.util.LayoutDirection
+import androidx.annotation.AnimRes
 import com.ichi2.anim.ActivityTransitionAnimation.getInverseTransition
 import com.ichi2.anki.R
+import com.ichi2.anki.compat.CompatHelper
 import kotlinx.parcelize.Parcelize
 
 object ActivityTransitionAnimation {
-    @Suppress("DEPRECATION", "deprecated in API34 for predictive back, must plumb through new open/close parameter")
+    /**
+     * @param open when `true`, overrides the animation for entering this activity.
+     * When `false`, overrides the animation for closing this activity
+     */
     fun slide(
         activity: Activity,
         direction: Direction,
+        open: Boolean,
     ) {
+        fun overrideTransition(
+            @AnimRes enter: Int,
+            @AnimRes exit: Int,
+        ) {
+            CompatHelper.compat.overrideTransition(activity, enter, exit, open)
+        }
+
         when (direction) {
             Direction.START ->
                 if (isRightToLeft(activity)) {
-                    activity.overridePendingTransition(R.anim.slide_right_in, R.anim.slide_right_out)
+                    overrideTransition(R.anim.slide_right_in, R.anim.slide_right_out)
                 } else {
-                    activity.overridePendingTransition(R.anim.slide_left_in, R.anim.slide_left_out)
+                    overrideTransition(R.anim.slide_left_in, R.anim.slide_left_out)
                 }
             Direction.END ->
                 if (isRightToLeft(activity)) {
-                    activity.overridePendingTransition(R.anim.slide_left_in, R.anim.slide_left_out)
+                    overrideTransition(R.anim.slide_left_in, R.anim.slide_left_out)
                 } else {
-                    activity.overridePendingTransition(R.anim.slide_right_in, R.anim.slide_right_out)
+                    overrideTransition(R.anim.slide_right_in, R.anim.slide_right_out)
                 }
-            Direction.RIGHT -> activity.overridePendingTransition(R.anim.slide_right_in, R.anim.slide_right_out)
-            Direction.LEFT -> activity.overridePendingTransition(R.anim.slide_left_in, R.anim.slide_left_out)
-            Direction.FADE -> activity.overridePendingTransition(R.anim.fade_in, R.anim.fade_out)
-            Direction.UP -> activity.overridePendingTransition(R.anim.slide_up_in, R.anim.slide_up_out)
-            Direction.DOWN -> activity.overridePendingTransition(R.anim.slide_down_in, R.anim.slide_down_out)
-            Direction.NONE -> activity.overridePendingTransition(R.anim.none, R.anim.none)
-            Direction.DEFAULT -> {
-            }
+
+            Direction.RIGHT -> overrideTransition(R.anim.slide_right_in, R.anim.slide_right_out)
+            Direction.LEFT -> overrideTransition(R.anim.slide_left_in, R.anim.slide_left_out)
+            Direction.FADE -> overrideTransition(R.anim.fade_in, R.anim.fade_out)
+            Direction.UP -> overrideTransition(R.anim.slide_up_in, R.anim.slide_up_out)
+            Direction.DOWN -> overrideTransition(R.anim.slide_down_in, R.anim.slide_down_out)
+            Direction.NONE -> overrideTransition(R.anim.none, R.anim.none)
+            Direction.DEFAULT -> { }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -347,7 +347,7 @@ open class AnkiActivity(
     ) {
         enableIntentAnimation(intent)
         super.startActivity(intent)
-        enableActivityAnimation(animation)
+        enableActivityAnimation(animation, open = true)
     }
 
     override fun finish() {
@@ -357,15 +357,19 @@ open class AnkiActivity(
     fun finishWithAnimation(animation: Direction) {
         Timber.i("finishWithAnimation %s", animation)
         super.finish()
-        enableActivityAnimation(animation)
+        enableActivityAnimation(animation, open = false)
     }
 
     private fun disableIntentAnimation(intent: Intent) {
         intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
     }
 
-    private fun disableActivityAnimation() {
-        ActivityTransitionAnimation.slide(this, NONE)
+    /**
+     * @param open when `true`, overrides the animation for entering this activity.
+     * When `false`, overrides the animation for closing this activity
+     */
+    private fun disableActivityAnimation(open: Boolean) {
+        ActivityTransitionAnimation.slide(this, NONE, open)
     }
 
     @KotlinCleanup("Maybe rename this? This only disables the animation conditionally")
@@ -375,11 +379,18 @@ open class AnkiActivity(
         }
     }
 
-    private fun enableActivityAnimation(animation: Direction) {
+    /**
+     * @param open when `true`, overrides the animation for entering this activity.
+     * When `false`, overrides the animation for closing this activity
+     */
+    private fun enableActivityAnimation(
+        animation: Direction,
+        open: Boolean,
+    ) {
         if (animationDisabled()) {
-            disableActivityAnimation()
+            disableActivityAnimation(open)
         } else {
-            ActivityTransitionAnimation.slide(this, animation)
+            ActivityTransitionAnimation.slide(this, animation, open)
         }
     }
 

--- a/compat/src/main/java/com/ichi2/anki/compat/BaseCompat.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/BaseCompat.kt
@@ -3,6 +3,7 @@
 
 package com.ichi2.anki.compat
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageInfo
@@ -17,6 +18,7 @@ import android.os.Environment
 import android.os.Vibrator
 import android.provider.MediaStore
 import android.view.View
+import androidx.annotation.AnimRes
 import androidx.appcompat.widget.TooltipCompat
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import timber.log.Timber
@@ -37,6 +39,18 @@ open class BaseCompat : Compat {
     // Until API26, tooltips cannot be defined declaratively in layouts
     override fun setTooltipTextByContentDescription(view: View) {
         TooltipCompat.setTooltipText(view, view.contentDescription)
+    }
+
+    override fun overrideTransition(
+        activity: Activity,
+        @AnimRes enter: Int,
+        @AnimRes exit: Int,
+        open: Boolean,
+    ) {
+        activity.overridePendingTransition(
+            enter,
+            exit,
+        )
     }
 
     // Until API 26 just specify time, after that specify effect also

--- a/compat/src/main/java/com/ichi2/anki/compat/Compat.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/Compat.kt
@@ -4,6 +4,7 @@
 
 package com.ichi2.anki.compat
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageInfo
@@ -17,6 +18,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.os.Environment
 import android.view.View
+import androidx.annotation.AnimRes
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
@@ -72,6 +74,13 @@ interface Compat {
     )
 
     fun getMediaRecorder(context: Context): MediaRecorder
+
+    fun overrideTransition(
+        activity: Activity,
+        @AnimRes enter: Int,
+        @AnimRes exit: Int,
+        open: Boolean,
+    )
 
     fun resolveActivity(
         packageManager: PackageManager,

--- a/compat/src/main/java/com/ichi2/anki/compat/CompatV34.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/CompatV34.kt
@@ -2,7 +2,9 @@
 
 package com.ichi2.anki.compat
 
+import android.app.Activity
 import android.view.MotionEvent
+import androidx.annotation.AnimRes
 import androidx.annotation.RequiresApi
 
 @RequiresApi(34)
@@ -13,4 +15,19 @@ open class CompatV34 : CompatV33() {
     override val AXIS_GESTURE_SCROLL_X_DISTANCE = MotionEvent.AXIS_GESTURE_SCROLL_X_DISTANCE
     override val AXIS_GESTURE_SCROLL_Y_DISTANCE = MotionEvent.AXIS_GESTURE_SCROLL_Y_DISTANCE
     override val AXIS_GESTURE_PINCH_SCALE_FACTOR = MotionEvent.AXIS_GESTURE_PINCH_SCALE_FACTOR
+
+    override fun overrideTransition(
+        activity: Activity,
+        @AnimRes enter: Int,
+        @AnimRes exit: Int,
+        open: Boolean,
+    ) {
+        val ty =
+            if (open) {
+                Activity.OVERRIDE_TRANSITION_OPEN
+            } else {
+                Activity.OVERRIDE_TRANSITION_CLOSE
+            }
+        activity.overrideActivityTransition(ty, enter, exit)
+    }
 }


### PR DESCRIPTION
> [!NOTE]
> This PR summary was copied from https://github.com/swe-productivity/Anki-Android/pull/9
> I [David] have reviewed this PR and support it

----

<!--- Please fill the necessary details below -->
## Purpose / Description

Plumbs a new `open` parameter through to `ActivityTransitionAnimation`, to handle deprecation of `overridePendingTransition`.

Call new `overrideActivityTransition` whenever possible, using `open` parameter to set whether the animation is used for a back press.

## Fixes
* Fixes #14558

## How Has This Been Tested?

- From primary deck picker view, select the hamburger menu, and select Card browser
  - A sliding animation plays (in this case, for an acivity start)
- Press back (or swipe from the side of the screen)
  - A sliding animation (in reverse) plays (in this case, for a back button press)

This was tested both before and after the change, both should perform the same animations.

Tested on a Pixel 7, running GrapheneOS.

- Android 16.0
- Api level 36.1

## Learning (optional, can help others)

https://developer.android.com/reference/android/app/Activity#overrideActivityTransition(int,%20int,%20int)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)