### PR TITLE
arch(application): new startup pattern: 'setup'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -65,6 +65,7 @@ import com.ichi2.utils.ExceptionUtil
 import com.ichi2.utils.LanguageUtil
 import com.ichi2.utils.LanguageUtil.withAppLocale
 import com.ichi2.utils.Permissions
+import com.ichi2.utils.measureTime
 import com.ichi2.utils.setWebContentsDebuggingEnabled
 import com.ichi2.widget.DayRolloverAlarm
 import com.ichi2.widget.cardanalysis.CardAnalysisWidget
@@ -95,23 +96,33 @@ open class AnkiDroidApp :
     var progressDialogShown = false
 
     /**
+     * Executes a setup method: [block], logging execution time.
+     * Exceptions are logged and rethrown.
+     *
+     * @param methodName Method name, used for logging.
+     * @param block The method to execute and return
+     */
+    // 'inline fun' so logs use the correct context
+    inline fun <T> setup(
+        methodName: String,
+        crossinline block: () -> T,
+    ): T {
+        // TODO: #20168 warn users of non-fatal component errors rather than rethrowing
+        try {
+            return measureTime(methodName = methodName) { block() }
+        } catch (e: Exception) {
+            // NOTE: this can be called before Timber is initialized
+            Timber.w(e, "failed to execute $methodName")
+            throw e
+        }
+    }
+
+    /**
      * On application creation.
      */
     @KotlinCleanup("analytics can be moved to attachBaseContext()")
     override fun onCreate() {
-        try {
-            Os.setenv("PLATFORM", syncPlatform(), false)
-            // enable debug logging of sync actions
-            if (BuildConfig.DEBUG) {
-                Os.setenv("RUST_LOG", "info,anki::sync=debug,anki::media=debug,fsrs=error", false)
-            }
-        } catch (_: Exception) {
-        }
-        // Uncomment the following lines to see a log of all SQL statements
-        // executed by the backend. The log may be delayed by 100ms, so you should not
-        // assume than a given SQL statement has run after a Timber.* line just
-        // because the SQL statement appeared later.
-        //   Os.setenv("TRACESQL", "1", false);
+        initAnkiBackend(debugTraceSqlCalls = false)
         super.onCreate()
         val appLifecycleObserver = AppLifecycleObserver(applicationContext)
 
@@ -269,6 +280,30 @@ open class AnkiDroidApp :
         TtsVoices.launchBuildLocalesJob()
         // enable {{tts-voices:}} field filter
         TtsVoicesFieldFilter.ensureApplied()
+    }
+
+    /**
+     * @param debugTraceSqlCalls Log all SQL statements executed by the backend.
+     * **Warning** The log may be delayed by 100ms, so you should not assume than a given SQL
+     * statement has run after a Timber.* line just because the SQL statement appeared later.
+     */
+    private fun initAnkiBackend(
+        @Suppress("SameParameterValue") debugTraceSqlCalls: Boolean = false,
+    ) {
+        runCatching {
+            setup(methodName = "initAnkiBackend") {
+                // Note: This method runs before logs are enabled.
+                Os.setenv("PLATFORM", syncPlatform(), false)
+                // enable debug logging of sync actions
+                if (BuildConfig.DEBUG) {
+                    Os.setenv("RUST_LOG", "info,anki::sync=debug,anki::media=debug,fsrs=error", false)
+                }
+
+                if (debugTraceSqlCalls) {
+                    Os.setenv("TRACESQL", "1", false)
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
> [!NOTE]
> * Split out from https://github.com/ankidroid/Anki-Android/pull/20593
>
> Claude flagged the above PR size. I felt that one squashed merge would be better than a ton of small refactor commits for this one, but it's gone stale, and I'd rather move towards working on it incrementally


## Purpose / Description
Setup ensures:

- one place where fatal and nonfatal initialization errors occurred
- startup does not throw and hard crash [TODO]
- startup can be profiled, compared and optimized

## Fixes
* Part of issue #20168

## Approach
- add `AnkiDroidApp.setup` call:
  - log execution time
  - simplify try... catch, ensuring one component failure won't kill the app
- extract our first method: 'initAnkiBackend' to simplify startup
  - change from uncommenting to a parameter
  - document the method

The full implementation of this pattern is seen in: https://redirect.github.com/ankidroid/Anki-Android/pull/20593

## How Has This Been Tested?
⚠️ I tested in the original implementation, this cherry-pick was untested

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)