### PR TITLE
refactor: move 4 strings to the backend translations 

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -488,7 +488,6 @@
         </activity>
         <activity
             android:name=".CardTemplateBrowserAppearanceEditor"
-            android:label="@string/card_template_browser_appearance_title"
             android:exported="false"
             android:configChanges="keyboardHidden|orientation|screenSize"
             />

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1506,7 +1506,7 @@ abstract class AbstractFlashcardViewer :
 
     @VisibleForTesting
     fun readCardTts(side: SingleCardSide) {
-        val tags = legacyGetTtsTags(getColUnsafe, currentCard!!, side, this)
+        val tags = legacyGetTtsTags(getColUnsafe, currentCard!!, side)
         tts.readCardText(getColUnsafe, tags, currentCard!!, side.toCardSide())
     }
 
@@ -1533,7 +1533,6 @@ abstract class AbstractFlashcardViewer :
         if (ttsInitialized) {
             tts.selectTts(
                 getColUnsafe,
-                this,
                 currentCard!!,
                 if (displayAnswer) CardSide.ANSWER else CardSide.QUESTION,
             )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
@@ -139,7 +139,7 @@ class CardTemplateBrowserAppearanceEditor : AnkiActivity(R.layout.activity_card_
         discardChangesCallback.isEnabled = hasChanges()
 
         enableToolbar()
-        setTitle(R.string.card_template_browser_appearance_title)
+        title = TR.sentenceCase.browserAppearance
     }
 
     private fun answerHasChanged(intent: Intent): Boolean = intent.getStringExtra(INTENT_ANSWER_FORMAT) != answerFormat

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -1040,7 +1040,8 @@ open class CardTemplateEditor : AnkiActivity(R.layout.activity_card_template_edi
          * Setups the part of the menu that can be used either in template editor or in previewer fragment.
          */
         fun setupCommonMenu(menu: Menu) {
-            menu.findItem(R.id.action_restore_to_default).title = CollectionManager.TR.cardTemplatesRestoreToDefault()
+            menu.findItem(R.id.action_restore_to_default).title = TR.cardTemplatesRestoreToDefault()
+            menu.findItem(R.id.action_card_browser_appearance).title = TR.sentenceCase.browserAppearance
             if (noteTypeCreatesDynamicNumberOfNotes()) {
                 Timber.d("Editing cloze/occlusion note type, disabling add/delete card template and deck override functionality")
                 menu.findItem(R.id.action_add).isVisible = false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.kt
@@ -24,6 +24,7 @@ import android.view.WindowManager.BadTokenException
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.cardviewer.SingleCardSide
 import com.ichi2.anki.i18n.getIso3LanguageOrNull
 import com.ichi2.anki.libanki.Card
@@ -405,12 +406,11 @@ fun legacyGetTtsTags(
     col: Collection,
     card: Card,
     cardSide: SingleCardSide,
-    context: Context,
 ): List<TTSTag> {
     val cardSideContent: String =
         when (cardSide) {
             SingleCardSide.FRONT -> card.question(col)
             SingleCardSide.BACK -> card.pureAnswer(col)
         }
-    return TtsParser.getTextsToRead(cardSideContent, context.getString(R.string.reviewer_tts_cloze_spoken_replacement))
+    return TtsParser.getTextsToRead(cardSideContent, TR.cardTemplatesBlank())
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -862,6 +862,7 @@ open class Reviewer :
         menu.findItem(R.id.action_reschedule_card).title = TR.sentenceCase.setDueDate
         menu.findItem(R.id.action_card_info)?.title = TR.sentenceCase.cardInfo
         menu.findItem(R.id.action_previous_card_info)?.title = TR.sentenceCase.previousCardInfo
+        menu.findItem(R.id.action_delete)?.title = TR.sentenceCase.deleteNote
         // top-level (visible=false in XML) items, shown when only the card-level action is available
         menu.findItem(R.id.action_bury_card)?.title = TR.sentenceCase.buryCard
         menu.findItem(R.id.action_suspend_card)?.title = TR.sentenceCase.suspendCard

--- a/AnkiDroid/src/main/java/com/ichi2/anki/account/LoggedInFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/account/LoggedInFragment.kt
@@ -37,7 +37,6 @@ import com.ichi2.anki.dialogs.help.HelpDialog
 import com.ichi2.anki.pages.RemoveAccountFragment
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ui.internationalization.sentenceCase
-import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.utils.ext.isCompactWidth
 import com.ichi2.anki.utils.ext.removeFragmentFromContainer
 import com.ichi2.anki.utils.ext.showDialogFragment
@@ -67,7 +66,7 @@ class LoggedInFragment : Fragment(R.layout.fragment_my_account_logged_in) {
         activity.setSupportActionBar(toolbar)
 
         activity.supportActionBar?.apply {
-            title = TR.preferencesAccount().toSentenceCase(R.string.sync_account)
+            title = TR.sentenceCase.ankiWebAccount
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowHomeEnabled(true)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/account/LoginFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/account/LoginFragment.kt
@@ -47,7 +47,6 @@ import com.ichi2.anki.dialogs.help.HelpDialog
 import com.ichi2.anki.getEndpoint
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.internationalization.sentenceCase
-import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.utils.ext.isCompactWidth
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.utils.hideKeyboard
@@ -83,7 +82,7 @@ class LoginFragment : Fragment(R.layout.fragment_my_account) {
         activity.setSupportActionBar(toolbar)
 
         activity.supportActionBar?.apply {
-            title = TR.preferencesAccount().toSentenceCase(R.string.sync_account)
+            title = TR.sentenceCase.ankiWebAccount
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowHomeEnabled(true)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TTS.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TTS.kt
@@ -20,7 +20,7 @@ package com.ichi2.anki.cardviewer
 
 import android.content.Context
 import com.ichi2.anki.CardUtils
-import com.ichi2.anki.R
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.ReadText
 import com.ichi2.anki.backend.stripHTML
 import com.ichi2.anki.libanki.Card
@@ -78,26 +78,21 @@ class TTS {
      */
     fun selectTts(
         col: Collection,
-        context: Context,
         card: Card,
         qa: CardSide,
     ) {
         val textToRead = if (qa == CardSide.QUESTION) card.question(col, true) else card.pureAnswer(col)
         // get the text from the card
         ReadText.selectTts(
-            getTextForTts(context, textToRead),
+            getTextForTts(textToRead),
             CardUtils.getDeckIdForCard(card),
             getOrdUsingCardType(card, col),
             qa,
         )
     }
 
-    private fun getTextForTts(
-        context: Context,
-        text: String,
-    ): String {
-        val clozeReplacement = context.getString(R.string.reviewer_tts_cloze_spoken_replacement)
-        val clozeReplaced = text.replace(TemplateFilters.CLOZE_DELETION_REPLACEMENT, clozeReplacement)
+    private fun getTextForTts(text: String): String {
+        val clozeReplaced = text.replace(TemplateFilters.CLOZE_DELETION_REPLACEMENT, TR.cardTemplatesBlank())
         return stripHTML(clozeReplaced)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
@@ -196,6 +196,9 @@ class ControlsSettingsFragment :
         findPreference<ControlPreference>(getString(R.string.previous_card_info_command_key))?.let {
             it.title = TR.sentenceCase.previousCardInfo
         }
+        findPreference<ControlPreference>(getString(R.string.delete_command_key))?.let {
+            it.title = TR.sentenceCase.deleteNote
+        }
     }
 
     private fun setupNewStudyScreenSettings() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomButtonsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomButtonsSettingsFragment.kt
@@ -68,6 +68,7 @@ class CustomButtonsSettingsFragment : SettingsFragment() {
         findPreference<ListPreference>(getString(R.string.custom_button_suspend_key))?.title = TR.studyingSuspend()
         findPreference<ListPreference>(getString(R.string.custom_button_mark_card_key))?.title = TR.sentenceCase.markNote
         findPreference<ListPreference>(getString(R.string.custom_button_previous_card_info_key))?.title = TR.sentenceCase.previousCardInfo
+        findPreference<ListPreference>(getString(R.string.custom_button_delete_key))?.title = TR.sentenceCase.deleteNote
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
@@ -49,6 +49,12 @@ class HeaderFragment : SettingsFragment() {
         requirePreference<HeaderPreference>(R.string.pref_backup_limits_screen_key)
             .title = TR.preferencesBackups()
 
+        requirePreference<HeaderPreference>(R.string.pref_sync_screen_key).summary =
+            HeaderPreference.buildHeaderSummary(
+                TR.sentenceCase.ankiWebAccount,
+                getString(R.string.automatic_sync_choice),
+            )
+
         requirePreference<Preference>(R.string.pref_advanced_screen_key).apply {
             if (AdaptionUtil.isXiaomiRestrictedLearningDevice) {
                 isVisible = false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SyncSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SyncSettingsFragment.kt
@@ -27,6 +27,7 @@ import com.ichi2.anki.common.crashreporting.runCatchingWithReport
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.ext.ifNullOrEmpty
 import com.ichi2.preferences.NumberRangePreferenceCompat
 import com.ichi2.utils.show
@@ -79,6 +80,7 @@ class SyncSettingsFragment : SettingsFragment() {
         }
 
         requirePreference<Preference>(R.string.sync_account_key).apply {
+            title = TR.sentenceCase.ankiWebAccount
             setOnPreferenceClickListener {
                 val accountActivityIntent = AccountActivity.getIntent(requireContext())
                 startActivity(accountActivityIntent)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
@@ -269,7 +269,7 @@ enum class ViewerAction(
                 EDIT -> getString(R.string.cardeditor_title_edit_card)
                 BURY_MENU -> TR.studyingBury()
                 SUSPEND_MENU -> TR.studyingSuspend()
-                DELETE -> getString(R.string.menu_delete_note)
+                DELETE -> TR.sentenceCase.deleteNote
                 TOGGLE_WHITEBOARD -> getString(R.string.gesture_toggle_whiteboard)
                 DECK_OPTIONS -> getString(R.string.menu__deck_options)
                 CARD_INFO -> TR.sentenceCase.cardInfo

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
@@ -211,6 +211,12 @@ object SentenceCase {
 
     context(_: Fragment)
     val previousCardInfo get() = TR.actionsPreviousCardInfo().toSentenceCase(R.string.sentence_actions_previous_card_info)
+
+    context(_: Context)
+    val ankiWebAccount get() = TR.preferencesAccount().toSentenceCase(R.string.sentence_ankiweb_account)
+
+    context(_: Fragment)
+    val ankiWebAccount get() = TR.preferencesAccount().toSentenceCase(R.string.sentence_ankiweb_account)
 }
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
@@ -201,6 +201,12 @@ object SentenceCase {
     val markNote get() = TR.studyingMarkNote().toSentenceCase(R.string.sentence_mark_note)
 
     context(_: Context)
+    val deleteNote get() = TR.studyingDeleteNote().toSentenceCase(R.string.sentence_delete_note)
+
+    context(_: Fragment)
+    val deleteNote get() = TR.studyingDeleteNote().toSentenceCase(R.string.sentence_delete_note)
+
+    context(_: Context)
     val previousCardInfo get() = TR.actionsPreviousCardInfo().toSentenceCase(R.string.sentence_actions_previous_card_info)
 
     context(_: Fragment)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
@@ -217,6 +217,12 @@ object SentenceCase {
 
     context(_: Fragment)
     val ankiWebAccount get() = TR.preferencesAccount().toSentenceCase(R.string.sentence_ankiweb_account)
+
+    context(_: Context)
+    val browserAppearance get() = TR.browsingBrowserAppearance().toSentenceCase(R.string.sentence_browser_appearance)
+
+    context(_: Fragment)
+    val browserAppearance get() = TR.browsingBrowserAppearance().toSentenceCase(R.string.sentence_browser_appearance)
 }
 
 /**

--- a/AnkiDroid/src/main/res/menu/card_template_editor.xml
+++ b/AnkiDroid/src/main/res/menu/card_template_editor.xml
@@ -34,7 +34,7 @@
     <item
         android:id="@+id/action_card_browser_appearance"
         android:icon="@drawable/ic_view_list_white_24dp"
-        android:title="@string/card_template_editor_menu_card_browser_appearance"
+        tools:title="Browser appearance"
         ankidroid:showAsAction="ifRoom"/>
     <!-- never show - no icon. Title is dynamic (on/off) -->
     <item

--- a/AnkiDroid/src/main/res/menu/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu/reviewer.xml
@@ -163,7 +163,7 @@
 
     <item
         android:id="@+id/action_delete"
-        android:title="@string/menu_delete_note"
+        tools:title="Delete note"
         android:icon="@drawable/ic_delete_white"/>
     <item
         android:id="@+id/action_mark_card"

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -110,7 +110,6 @@
 
     <!-- Card template editor -->
     <string name="title_activity_template_editor">Card types</string>
-    <string name="card_template_editor_menu_card_browser_appearance" maxLength="28">Card Browser Appearance</string>
     <string name="card_template_editor_deck_override" maxLength="28">Deck override</string>
     <string name="card_template_editor_insert_field" maxLength="28">Insert field</string>
     <string name="card_template_editor_select_field">Select field</string>
@@ -125,11 +124,6 @@
     </plurals>
     <string name="card_template_editor_save_error">Unable to save card template changes: %s</string>
     <string name="template_for_current_card_deleted">The card type for the current card was deleted.</string>
-
-    <!-- Card Browser Appearance -->
-    <string name="card_template_browser_appearance_title">Browser appearance</string>
-
-    <!-- card Info -->
 
     <!-- Permissions -->
     <string name="read_write_permission_label">Read and write to the AnkiDroid database</string>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -70,7 +70,6 @@
     <string name="menu_add_note" maxLength="28">Add note</string>
     <string name="menu_my_account" comment="Label of the window in which the user should enter their account. This text can't be found in AnkiDroid directly.">Sync account</string>
     <string name="menu_dismiss_note" maxLength="41" >Hide / delete</string>
-    <string name="menu_delete_note" maxLength="28">Delete note</string>
     <string name="rename_flag">Rename flags</string>
     <string name="menu_flag_card" maxLength="28">Flag card</string>
     <string name="menu_edit_tags" maxLength="28">Edit tags</string>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -200,8 +200,6 @@
     <!-- Card Template Browser Appearance -->
     <string name="restore_default" maxLength="28">Restore default</string>
 
-    <string name="reviewer_tts_cloze_spoken_replacement">Blank</string>
-
     <!-- Whiteboard eraser mode toggle message in Reviewer -->
     <string name="white_board_eraser_enabled">Eraser mode activated</string>
     <string name="white_board_eraser_disabled">Eraser mode deactivated</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -95,7 +95,6 @@
     <string name="tts_summ">Reads out question and answer if no sound file is included</string>
     <!-- Sync -->
     <string name="sync_fetch_missing_media" maxLength="41">Fetch media on sync</string>
-    <string name="sync_account" maxLength="41">AnkiWeb account</string>
     <string name="sync_account_summ_logged_out">Not logged in</string>
     <string name="automatic_sync_choice" maxLength="41">Automatic synchronization</string>
     <string name="automatic_sync_choice_summ">Sync automatically on app start/exit if the last sync was more than 10

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -282,7 +282,6 @@
     </string-array>
 
     <string-array name="sync_summary_entries">
-        <item>@string/sync_account</item>
         <item>@string/automatic_sync_choice</item>
     </string-array>
 

--- a/AnkiDroid/src/main/res/values/sentence-case.xml
+++ b/AnkiDroid/src/main/res/values/sentence-case.xml
@@ -77,4 +77,5 @@ undoActionUndone()
     <string name="sentence_mark_note">Mark note</string>
     <string name="sentence_delete_note">Delete note</string>
     <string name="sentence_ankiweb_account" maxLength="41">AnkiWeb account</string>
+    <string name="sentence_browser_appearance">Browser appearance</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/sentence-case.xml
+++ b/AnkiDroid/src/main/res/values/sentence-case.xml
@@ -76,4 +76,5 @@ undoActionUndone()
     <string name="sentence_suspend_card">Suspend card</string>
     <string name="sentence_mark_note">Mark note</string>
     <string name="sentence_delete_note">Delete note</string>
+    <string name="sentence_ankiweb_account" maxLength="41">AnkiWeb account</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/sentence-case.xml
+++ b/AnkiDroid/src/main/res/values/sentence-case.xml
@@ -75,4 +75,5 @@ undoActionUndone()
     <string name="sentence_suspend_note">Suspend note</string>
     <string name="sentence_suspend_card">Suspend card</string>
     <string name="sentence_mark_note">Mark note</string>
+    <string name="sentence_delete_note">Delete note</string>
 </resources>

--- a/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
@@ -160,7 +160,7 @@ TODO: Add a unit test
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_delete_key"
-            android:title="@string/menu_delete_note"
+            tools:title="Delete note"
             app:useSimpleSummaryProvider="true"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/pref_cat_whiteboard" >

--- a/AnkiDroid/src/main/res/xml/preferences_reviewer_controls.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewer_controls.xml
@@ -122,7 +122,7 @@
             />
         <com.ichi2.preferences.ReviewerControlPreference
             android:key="@string/delete_command_key"
-            android:title="@string/menu_delete_note"
+            tools:title="Delete note"
             android:icon="@drawable/ic_delete_white"
             />
         <com.ichi2.preferences.ReviewerControlPreference

--- a/AnkiDroid/src/main/res/xml/preferences_sync.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_sync.xml
@@ -21,10 +21,9 @@
     android:key="@string/pref_sync_screen_key"
     xmlns:tools="http://schemas.android.com/tools">
     <Preference
-        android:dialogTitle="@string/sync_account"
         android:key="@string/sync_account_key"
         android:summary="@string/sync_account_summ_logged_out"
-        android:title="@string/sync_account" >
+        tools:title="AnkiWeb account" >
     </Preference>
     <ListPreference
         android:defaultValue="@string/sync_media_always_value"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
@@ -336,7 +336,6 @@ class TranslationTest : RobolectricTest() {
                 "Add field", // R.string.model_field_editor_add | TR.fieldsAddField()
                 "Add note", // R.string.menu_add_note | TR.actionsAddNote()
                 "All decks", // R.string.card_browser_all_decks | TR.exportingAllDecks()
-                "AnkiWeb account", // R.string.sync_account | TR.preferencesAccount()
                 "Answer again", // R.string.answer_again | TR.deckConfigAnswerAgain()
                 "Answer buttons", // R.string.answer_buttons | TR.statisticsAnswerButtonsTitle()
                 "Answer good", // R.string.answer_good | TR.deckConfigAnswerGood()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
@@ -340,7 +340,6 @@ class TranslationTest : RobolectricTest() {
                 "Answer buttons", // R.string.answer_buttons | TR.statisticsAnswerButtonsTitle()
                 "Answer good", // R.string.answer_good | TR.deckConfigAnswerGood()
                 "Answer hard", // R.string.answer_hard | TR.deckConfigAnswerHard()
-                "Blank", // R.string.reviewer_tts_cloze_spoken_replacement | TR.cardTemplatesBlank()
                 "Browser appearance", // R.string.card_template_browser_appearance_title | TR.browsingBrowserAppearance()
                 "Browser options", // R.string.browser_options_dialog_heading | TR.browsingBrowserOptions()
                 "Change deck", // R.string.card_browser_change_deck | TR.browsingChangeDeck()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
@@ -340,7 +340,6 @@ class TranslationTest : RobolectricTest() {
                 "Answer buttons", // R.string.answer_buttons | TR.statisticsAnswerButtonsTitle()
                 "Answer good", // R.string.answer_good | TR.deckConfigAnswerGood()
                 "Answer hard", // R.string.answer_hard | TR.deckConfigAnswerHard()
-                "Browser appearance", // R.string.card_template_browser_appearance_title | TR.browsingBrowserAppearance()
                 "Browser options", // R.string.browser_options_dialog_heading | TR.browsingBrowserOptions()
                 "Change deck", // R.string.card_browser_change_deck | TR.browsingChangeDeck()
                 "Copy debug info", // R.string.feedback_copy_debug

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
@@ -350,7 +350,6 @@ class TranslationTest : RobolectricTest() {
                 // TR.errorsCopyDebugInfoButton()
                 "Create deck", // R.string.new_deck | TR.decksCreateDeck()
                 "Deck options", // R.string.menu__deck_options | TR.deckConfigTitle()
-                "Delete note", // R.string.menu_delete_note | TR.studyingDeleteNote()
                 "Empty cards", // R.string.empty_cards
                 // TR.actionsEmptyCards()
                 // TR.emptyCardsWindowTitle()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
@@ -79,6 +79,7 @@ class SentenceCaseTest : RobolectricTest() {
                 assertThat(TR.sentenceCase.deleteNote, equalTo("Delete note"))
                 assertThat(TR.sentenceCase.previousCardInfo, equalTo("Previous card info"))
                 assertThat(TR.sentenceCase.ankiWebAccount, equalTo("AnkiWeb account"))
+                assertThat(TR.sentenceCase.browserAppearance, equalTo("Browser appearance"))
 
                 assertThat("syncMediaLogTitle", TR.syncMediaLogTitle(), equalTo("Media Sync Log"))
                 assertThat(TR.sentenceCase.mediaSyncLog, equalTo("Media sync log"))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
@@ -78,6 +78,7 @@ class SentenceCaseTest : RobolectricTest() {
                 assertThat(TR.sentenceCase.markNote, equalTo("Mark note"))
                 assertThat(TR.sentenceCase.deleteNote, equalTo("Delete note"))
                 assertThat(TR.sentenceCase.previousCardInfo, equalTo("Previous card info"))
+                assertThat(TR.sentenceCase.ankiWebAccount, equalTo("AnkiWeb account"))
 
                 assertThat("syncMediaLogTitle", TR.syncMediaLogTitle(), equalTo("Media Sync Log"))
                 assertThat(TR.sentenceCase.mediaSyncLog, equalTo("Media sync log"))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
@@ -76,6 +76,7 @@ class SentenceCaseTest : RobolectricTest() {
                 assertThat(TR.sentenceCase.suspendNote, equalTo("Suspend note"))
                 assertThat(TR.sentenceCase.suspendCard, equalTo("Suspend card"))
                 assertThat(TR.sentenceCase.markNote, equalTo("Mark note"))
+                assertThat(TR.sentenceCase.deleteNote, equalTo("Delete note"))
                 assertThat(TR.sentenceCase.previousCardInfo, equalTo("Previous card info"))
 
                 assertThat("syncMediaLogTitle", TR.syncMediaLogTitle(), equalTo("Media Sync Log"))


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - all

## Purpose / Description
Another minor reduction in app size and translator effort

## How Has This Been Tested?

* The 'Sync' header fragment & Browser appearance were tested

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)