### PR TITLE
refactor(note-editor): simplify Intent handling

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorActivity.kt
@@ -16,18 +16,11 @@
 
 package com.ichi2.anki
 
-import android.content.Context
-import android.content.Intent
 import android.os.Bundle
-import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentContainerView
 import androidx.fragment.app.commit
 import com.google.android.material.tabs.TabLayout
-import com.ichi2.anki.NoteEditorActivity.Companion.FRAGMENT_ARGS_EXTRA
-import com.ichi2.anki.NoteEditorActivity.Companion.FRAGMENT_NAME_EXTRA
-import com.ichi2.anki.NoteEditorFragment.Companion.NoteEditorCaller
 import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.ShortcutGroupProvider
 import com.ichi2.anki.databinding.ActivityNoteEditorBinding
@@ -44,8 +37,6 @@ import com.ichi2.anki.utils.ext.doOnTabSelected
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import timber.log.Timber
-import kotlin.reflect.KClass
-import kotlin.reflect.jvm.jvmName
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
@@ -105,7 +96,8 @@ class NoteEditorActivity :
         previewerFrame = binding.previewerFrame
         Timber.i("Note Editor is in %s mode", if (fragmented) "split" else "single-pane")
 
-        val fragmentArgs = NoteIntentParser.parse(intent)
+        // TODO: specify how non-null but invalid extras are handled
+        val fragmentArgs = intent.extras ?: NoteEditorFragment.addNoteArgs()
 
         val existingFragment = supportFragmentManager.findFragmentByTag(FRAGMENT_TAG)
 
@@ -381,8 +373,6 @@ class NoteEditorActivity :
     //endregion
 
     companion object {
-        const val FRAGMENT_ARGS_EXTRA = "fragmentArgs"
-        const val FRAGMENT_NAME_EXTRA = "fragmentName"
         const val FRAGMENT_TAG = "NoteEditorFragmentTag"
 
         // Keys for saving pane weights in SharedPreferences
@@ -390,62 +380,5 @@ class NoteEditorActivity :
         private const val PREF_PREVIEWER_PANE_WEIGHT = "previewerPaneWeight"
 
         private val REFRESH_NOTE_EDITOR_PREVIEW_DELAY = 100.milliseconds
-
-        /**
-         * Creates an Intent to launch the NoteEditor activity with a specific fragment class and arguments.
-         *
-         * @param context The context from which the intent will be launched
-         * @param fragmentClass The Kotlin class of the Fragment to instantiate
-         * @param arguments Optional bundle of arguments to pass to the fragment
-         * @param intentAction Optional action to set on the intent
-         * @return An Intent configured to launch NoteEditor with the specified fragment
-         */
-        fun getIntent(
-            context: Context,
-            fragmentClass: KClass<out Fragment>,
-            arguments: Bundle? = null,
-            intentAction: String? = null,
-        ): Intent =
-            Intent(context, NoteEditorActivity::class.java).apply {
-                putExtra(FRAGMENT_NAME_EXTRA, fragmentClass.jvmName)
-                putExtra(FRAGMENT_ARGS_EXTRA, arguments)
-                action = intentAction
-            }
     }
-}
-
-/**
- * Helper to parse Intents for [NoteEditorActivity] into the [Bundle] used as
- * [NoteEditorFragment] arguments.
- *
- * Supports multiple note editing workflows by inspecting intent extras:
- *
- * - [NoteEditorActivity.Companion.FRAGMENT_NAME_EXTRA]: Fully qualified name of the fragment class.
- *   If set to [NoteEditorFragment], the bundle in [NoteEditorActivity.Companion.FRAGMENT_ARGS_EXTRA] is used.
- *
- * - [NoteEditorActivity.Companion.FRAGMENT_ARGS_EXTRA]: Bundle containing parameters (note ID, deck ID, etc.).
- */
-// TODO: This is over-complex, caused by dab784f22e
-//  To fix: Remove `FRAGMENT_` keys and return to a flat bundle
-//  This would have been useful for SingleFragmentActivity, but NoteEditorActivity replaced it
-private object NoteIntentParser {
-    fun parse(intent: Intent): Bundle =
-        if (intent.hasExtra(FRAGMENT_NAME_EXTRA)) {
-            handleFragmentIntent(intent)
-        } else {
-            handleLegacyIntent(intent)
-        }
-
-    private fun handleFragmentIntent(intent: Intent): Bundle =
-        intent.getStringExtra(FRAGMENT_NAME_EXTRA)?.let { fragmentName ->
-            when (fragmentName) {
-                NoteEditorFragment::class.java.name ->
-                    intent.getBundleExtra(FRAGMENT_ARGS_EXTRA) ?: addNoteArgs()
-                else -> addNoteArgs()
-            }
-        } ?: addNoteArgs()
-
-    private fun handleLegacyIntent(intent: Intent): Bundle = intent.getBundleExtra(FRAGMENT_ARGS_EXTRA) ?: intent.extras ?: addNoteArgs()
-
-    private fun addNoteArgs(): Bundle = bundleOf(NoteEditorFragment.EXTRA_CALLER to NoteEditorCaller.DECKPICKER.value)
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorActivity.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentContainerView
@@ -26,13 +27,13 @@ import androidx.fragment.app.commit
 import com.google.android.material.tabs.TabLayout
 import com.ichi2.anki.NoteEditorActivity.Companion.FRAGMENT_ARGS_EXTRA
 import com.ichi2.anki.NoteEditorActivity.Companion.FRAGMENT_NAME_EXTRA
+import com.ichi2.anki.NoteEditorFragment.Companion.NoteEditorCaller
 import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.ShortcutGroupProvider
 import com.ichi2.anki.databinding.ActivityNoteEditorBinding
 import com.ichi2.anki.libanki.CardOrdinal
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.noteeditor.NoteEditorFragmentDelegate
-import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.previewer.TemplatePreviewerArguments
 import com.ichi2.anki.previewer.TemplatePreviewerFragment
 import com.ichi2.anki.settings.Prefs
@@ -104,13 +105,13 @@ class NoteEditorActivity :
         previewerFrame = binding.previewerFrame
         Timber.i("Note Editor is in %s mode", if (fragmented) "split" else "single-pane")
 
-        val launcher = NoteIntentParser.parse(intent)
+        val fragmentArgs = NoteIntentParser.parse(intent)
 
         val existingFragment = supportFragmentManager.findFragmentByTag(FRAGMENT_TAG)
 
         if (existingFragment == null) {
             supportFragmentManager.commit {
-                replace(R.id.note_editor_fragment_frame, NoteEditorFragment.newInstance(launcher), FRAGMENT_TAG)
+                replace(R.id.note_editor_fragment_frame, NoteEditorFragment.newInstance(fragmentArgs), FRAGMENT_TAG)
                 setReorderingAllowed(true)
                 /*
                  * Initializes the noteEditorFragment reference only after the transaction is committed.
@@ -414,46 +415,37 @@ class NoteEditorActivity :
 }
 
 /**
- * Helper to parse Intents for [NoteEditorActivity].
+ * Helper to parse Intents for [NoteEditorActivity] into the [Bundle] used as
+ * [NoteEditorFragment] arguments.
  *
- * It supports multiple note editing workflows using fragments by choosing the
- * appropriate [noteeditor.NoteEditorLauncher] based on intent extras:
+ * Supports multiple note editing workflows by inspecting intent extras:
  *
  * - [NoteEditorActivity.Companion.FRAGMENT_NAME_EXTRA]: Fully qualified name of the fragment class.
- * If set to [NoteEditorFragment], it initializes with arguments in [NoteEditorActivity.Companion.FRAGMENT_ARGS_EXTRA].
+ *   If set to [NoteEditorFragment], the bundle in [NoteEditorActivity.Companion.FRAGMENT_ARGS_EXTRA] is used.
  *
  * - [NoteEditorActivity.Companion.FRAGMENT_ARGS_EXTRA]: Bundle containing parameters (note ID, deck ID, etc.).
  */
+// TODO: This is over-complex, caused by dab784f22e
+//  To fix: Remove `FRAGMENT_` keys and return to a flat bundle
+//  This would have been useful for SingleFragmentActivity, but NoteEditorActivity replaced it
 private object NoteIntentParser {
-    fun parse(intent: Intent): NoteEditorLauncher =
+    fun parse(intent: Intent): Bundle =
         if (intent.hasExtra(FRAGMENT_NAME_EXTRA)) {
             handleFragmentIntent(intent)
         } else {
             handleLegacyIntent(intent)
         }
 
-    private fun handleFragmentIntent(intent: Intent): NoteEditorLauncher =
+    private fun handleFragmentIntent(intent: Intent): Bundle =
         intent.getStringExtra(FRAGMENT_NAME_EXTRA)?.let { fragmentName ->
             when (fragmentName) {
                 NoteEditorFragment::class.java.name ->
-                    intent
-                        .getBundleExtra(FRAGMENT_ARGS_EXTRA)
-                        ?.let { NoteEditorLauncher.PassArguments(it) }
-                        ?: NoteEditorLauncher.AddNote()
-                else -> NoteEditorLauncher.AddNote()
+                    intent.getBundleExtra(FRAGMENT_ARGS_EXTRA) ?: addNoteArgs()
+                else -> addNoteArgs()
             }
-        } ?: NoteEditorLauncher.AddNote()
+        } ?: addNoteArgs()
 
-    private fun handleLegacyIntent(intent: Intent): NoteEditorLauncher {
-        intent.getBundleExtra(FRAGMENT_ARGS_EXTRA)?.let { args ->
-            return NoteEditorLauncher.PassArguments(args)
-        }
-        intent.extras?.let { bundle ->
-            bundle.getBundle(FRAGMENT_ARGS_EXTRA)?.let { wrappedArgs ->
-                return NoteEditorLauncher.PassArguments(wrappedArgs)
-            }
-            return NoteEditorLauncher.PassArguments(bundle)
-        }
-        return NoteEditorLauncher.AddNote()
-    }
+    private fun handleLegacyIntent(intent: Intent): Bundle = intent.getBundleExtra(FRAGMENT_ARGS_EXTRA) ?: intent.extras ?: addNoteArgs()
+
+    private fun addNoteArgs(): Bundle = bundleOf(NoteEditorFragment.EXTRA_CALLER to NoteEditorCaller.DECKPICKER.value)
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -96,7 +96,6 @@ import com.ichi2.anki.common.utils.ext.ifZero
 import com.ichi2.anki.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.anki.compat.setTooltipTextCompat
 import com.ichi2.anki.dialogs.ChangeNoteTypeDialog
-import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.anki.dialogs.DiscardChangesDialog
 import com.ichi2.anki.dialogs.IntegerDialog
 import com.ichi2.anki.dialogs.registerDeckSelectedHandler
@@ -2943,10 +2942,12 @@ class NoteEditorFragment :
         private const val PREF_NOTE_EDITOR_FONT_SIZE = "note_editor_font_size"
         private const val PREF_NOTE_EDITOR_CUSTOM_BUTTONS = "note_editor_custom_buttons"
 
-        fun newInstance(launcher: NoteEditorLauncher): NoteEditorFragment =
+        fun newInstance(args: Bundle): NoteEditorFragment =
             NoteEditorFragment().apply {
-                this.arguments = launcher.toBundle()
+                this.arguments = args
             }
+
+        fun newInstance(launcher: NoteEditorLauncher): NoteEditorFragment = newInstance(launcher.toBundle())
 
         fun shouldReplaceNewlines(): Boolean =
             AnkiDroidApp.instance

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -2941,6 +2941,9 @@ class NoteEditorFragment :
 
         fun newInstance(launcher: NoteEditorLauncher): NoteEditorFragment = newInstance(launcher.toBundle())
 
+        /** Default fragment arguments for "add a new note from the deck picker." */
+        fun addNoteArgs(): Bundle = Bundle().apply { putInt(EXTRA_CALLER, NoteEditorCaller.DECKPICKER.value) }
+
         fun shouldReplaceNewlines(): Boolean =
             AnkiDroidApp.instance
                 .sharedPrefs()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -196,7 +196,6 @@ import timber.log.Timber
 import java.io.File
 import java.util.LinkedList
 import java.util.Locale
-import java.util.function.Consumer
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
@@ -1638,22 +1637,15 @@ class NoteEditorFragment :
         }
 
     private fun addNewNote() {
-        launchNoteEditor(NoteEditorLauncher.AddNote(deckId)) { }
+        launchNoteEditor(NoteEditorLauncher.AddNote(deckId))
     }
 
     fun copyNote() {
-        launchNoteEditor(NoteEditorLauncher.CopyNote(deckId, fieldsText, selectedTags)) { }
+        launchNoteEditor(NoteEditorLauncher.CopyNote(deckId, fieldsText, selectedTags))
     }
 
-    private fun launchNoteEditor(
-        arguments: NoteEditorLauncher,
-        intentEnricher: Consumer<Bundle>,
-    ) {
-        val intent = arguments.toIntent(requireContext())
-        val bundle = arguments.toBundle()
-        // Mutate event with additional properties
-        intentEnricher.accept(bundle)
-        requestAddLauncher.launch(intent)
+    private fun launchNoteEditor(arguments: NoteEditorLauncher) {
+        requestAddLauncher.launch(arguments.toIntent(requireContext()))
     }
 
     // ----------------------------------------------------------------------------

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
@@ -106,20 +106,15 @@ sealed interface NoteEditorLauncher : Destination {
     data class AddNoteFromCardBrowser(
         val viewModel: CardBrowserViewModel,
     ) : NoteEditorLauncher {
-        override fun toBundle(): Bundle {
-            val fragmentArgs =
-                bundleOf(
-                    NoteEditorFragment.EXTRA_CALLER to NoteEditorCaller.CARDBROWSER_ADD.value,
-                    NoteEditorFragment.EXTRA_TEXT_FROM_SEARCH_VIEW to viewModel.searchTerms,
-                    NoteEditorFragment.IN_CARD_BROWSER_ACTIVITY to false,
-                )
-            if (viewModel.lastDeckId?.let { id -> id > 0 } == true) {
-                fragmentArgs.putLong(NoteEditorFragment.EXTRA_DID, viewModel.lastDeckId!!)
+        override fun toBundle(): Bundle =
+            Bundle().apply {
+                putInt(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.CARDBROWSER_ADD.value)
+                putString(NoteEditorFragment.EXTRA_TEXT_FROM_SEARCH_VIEW, viewModel.searchTerms)
+                putBoolean(NoteEditorFragment.IN_CARD_BROWSER_ACTIVITY, false)
+                if (viewModel.lastDeckId?.let { id -> id > 0 } == true) {
+                    putLong(NoteEditorFragment.EXTRA_DID, viewModel.lastDeckId!!)
+                }
             }
-            return bundleOf(
-                NoteEditorActivity.FRAGMENT_ARGS_EXTRA to fragmentArgs,
-            )
-        }
     }
 
     /**
@@ -129,23 +124,11 @@ sealed interface NoteEditorLauncher : Destination {
     data class AddNoteFromReviewer(
         val animation: ActivityTransitionAnimation.Direction? = null,
     ) : NoteEditorLauncher {
-        override fun toBundle(): Bundle {
-            val fragmentArgs =
-                bundleOf(
-                    NoteEditorFragment.EXTRA_CALLER to NoteEditorCaller.REVIEWER_ADD.value,
-                ).also { bundle ->
-                    animation?.let { animation ->
-                        bundle.putParcelable(
-                            AnkiActivity.FINISH_ANIMATION_EXTRA,
-                            animation as Parcelable,
-                        )
-                    }
-                }
-
-            return bundleOf(
-                NoteEditorActivity.FRAGMENT_ARGS_EXTRA to fragmentArgs,
-            )
-        }
+        override fun toBundle(): Bundle =
+            Bundle().apply {
+                putInt(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.REVIEWER_ADD.value)
+                animation?.let { putParcelable(AnkiActivity.FINISH_ANIMATION_EXTRA, it as Parcelable) }
+            }
     }
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -555,8 +555,7 @@ class CardBrowserTest : RobolectricTest() {
             assertThat("The target deck should be selected", b.lastDeckId, equalTo(targetDid))
 
             val addIntent = b.addNoteLauncher.toIntent(targetContext)
-            val bundle = addIntent.getBundleExtra(NoteEditorActivity.FRAGMENT_ARGS_EXTRA)
-            IntentAssert.hasExtra(bundle, NoteEditorFragment.EXTRA_DID, targetDid)
+            IntentAssert.hasExtra(addIntent.extras, NoteEditorFragment.EXTRA_DID, targetDid)
         }
 
     /** 7420  */
@@ -569,8 +568,7 @@ class CardBrowserTest : RobolectricTest() {
         assertThat("The initial deck should be selected", b.lastDeckId, equalTo(initialDid))
 
         val addIntent = b.addNoteLauncher.toIntent(targetContext)
-        val bundle = addIntent.getBundleExtra(NoteEditorActivity.FRAGMENT_ARGS_EXTRA)
-        IntentAssert.hasExtra(bundle, NoteEditorFragment.EXTRA_DID, initialDid)
+        IntentAssert.hasExtra(addIntent.extras, NoteEditorFragment.EXTRA_DID, initialDid)
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -142,10 +142,9 @@ class ReviewerTest : RobolectricTest() {
         // Assert
         val shadowApplication = Shadows.shadowOf(ApplicationProvider.getApplicationContext<Application>())
         val intent = shadowApplication.nextStartedActivity
-        val fragmentBundle = intent.getBundleExtra(NoteEditorActivity.FRAGMENT_ARGS_EXTRA)
         val actualAnimation =
             BundleCompat.getParcelable(
-                fragmentBundle!!,
+                intent.extras!!,
                 AnkiActivity.FINISH_ANIMATION_EXTRA,
                 ActivityTransitionAnimation.Direction::class.java,
             )

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -25,7 +25,6 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.Flag
-import com.ichi2.anki.NoteEditorActivity
 import com.ichi2.anki.NoteEditorFragment
 import com.ichi2.anki.browser.CardBrowserColumn.ANSWER
 import com.ichi2.anki.browser.CardBrowserColumn.CARD
@@ -288,8 +287,7 @@ class CardBrowserViewModelTest : JvmTest() {
             assertThat("All decks should be selected", hasSelectedAllDecks())
 
             val addIntent = CardBrowser.createAddNoteLauncher(this).toIntent(mockIt())
-            val bundle = addIntent.getBundleExtra(NoteEditorActivity.FRAGMENT_ARGS_EXTRA)
-            IntentAssert.doesNotHaveExtra(bundle, NoteEditorFragment.EXTRA_DID)
+            IntentAssert.doesNotHaveExtra(addIntent.extras, NoteEditorFragment.EXTRA_DID)
         }
 
     @Test


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - lots of discussion, then the implementation

## Purpose / Description
I wanted to move `NoteEditorLauncher` to the `Destination` pattern, so I could remove `import com.ichi2.anki.common.destinations.Destination as NavigateDestination`

But, I found that `NoteEditorParser` used `NoteEditorLauncher` to validate an intent which had been passed into `NoteEditorActivity`, rather than function solely as a `Destination`.

This led me to understand that `NoteEditorParser` only existed because we moved `NoteEditor` to `NoteEditorFragment` (`SingleFragmentActivity`), then we added `NoteEditorActivity`, which meant the `SingleFragmentActivity` args were no longer necessary.

## Approach
* Flatten the bundle
* Remove all the `SingleFragmentActivity` related code

## How Has This Been Tested?
Unit tested

## Learning (optional, can help others)
So much complexity... step back and think

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)