### PR TITLE
feat: bottom nav base class

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/BottomNavActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BottomNavActivity.kt
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+package com.ichi2.anki
+
+import android.view.View
+import androidx.activity.OnBackPressedCallback
+import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.commit
+import com.google.android.material.bottomnavigation.BottomNavigationView
+import com.ichi2.anki.databinding.ActivityBottomNavBinding
+import dev.androidbroadcast.vbpd.viewBinding
+import timber.log.Timber
+
+/**
+ * Base class that provides the bottom navigation bar
+ *
+ * Subclasses will extend this instead of the NavigationDrawerActivity
+ * when the bottom navigation bar developer option is enabled. The bottom nav
+ * replaces the navigation drawer for phone-sized screens.
+ *
+ * Fragments are managed using show/hide to allow for state persistence.
+ */
+abstract class BottomNavActivity : AnkiActivity() {
+    private val binding by viewBinding(ActivityBottomNavBinding::bind)
+    lateinit var bottomNavigationView: BottomNavigationView private set
+    private var currentNavigationItem: NavigationItem = NavigationItem.HOME
+
+    enum class NavigationItem {
+        HOME,
+        BROWSER,
+        STATS,
+        MORE,
+    }
+
+    protected val bottomNavBackCallback =
+        object : OnBackPressedCallback(enabled = false) {
+            override fun handleOnBackPressed() {
+                if (currentNavigationItem != NavigationItem.HOME) {
+                    binding.bottomNavigation.selectedItemId = R.id.nav_home
+                } else {
+                    isEnabled = false
+                    onBackPressedDispatcher.onBackPressed()
+                }
+            }
+        }
+
+    /**
+     * Intializes the bottom navigation bar and wires the tab selection listeners.
+     * Called by DeckPicker after it's content view is set up.
+     */
+    protected fun setupBottomNavigation() {
+        onBackPressedDispatcher.addCallback(this, bottomNavBackCallback)
+        binding.bottomNavigation.setOnItemSelectedListener { item ->
+            when (item.itemId) {
+                R.id.nav_home -> {
+                    switchToNavigationItem(NavigationItem.HOME)
+                    true
+                }
+                R.id.nav_browser -> {
+                    switchToNavigationItem(NavigationItem.BROWSER)
+                    true
+                }
+                R.id.nav_stats -> {
+                    switchToNavigationItem(NavigationItem.STATS)
+                    true
+                }
+                R.id.nav_more -> {
+                    onMoreSelected()
+                    false
+                }
+                else -> false
+            }
+        }
+    }
+
+    private fun switchToNavigationItem(navItem: NavigationItem) {
+        if (navItem == currentNavigationItem) return
+        Timber.i("Bottom nav switching to %s", navItem.name)
+        currentNavigationItem = navItem
+        bottomNavBackCallback.isEnabled = navItem != NavigationItem.HOME
+        when (navItem) {
+            NavigationItem.HOME -> onHomeSelected()
+            NavigationItem.BROWSER -> onBrowserSelected()
+            NavigationItem.STATS -> onStatsSelected()
+            NavigationItem.MORE -> {}
+        }
+    }
+
+    /** Show the deck picker and hide any fragments. */
+    protected abstract fun onHomeSelected()
+
+    /** Show the card browser fragment. */
+    protected abstract fun onBrowserSelected()
+
+    /** Show the statistics fragment. */
+    protected abstract fun onStatsSelected()
+
+    /** Show the "More" bottom sheet with settings, help, etc. */
+    protected abstract fun onMoreSelected()
+
+    /**
+     * Shows a fragment in the fragment container using show/hide.
+     * Fragments are added on first visit and then reused.
+     */
+    protected fun showFragment(
+        fragment: Fragment,
+        tag: String,
+    ) {
+        binding.bottomNavFragmentContainer.isVisible = true
+
+        val transaction =
+            supportFragmentManager.commit {
+                supportFragmentManager.fragments.forEach { existing ->
+                    if (existing.id == R.id.bottom_nav_fragment_container) {
+                        hide(existing)
+                    }
+                }
+                val existing = supportFragmentManager.findFragmentByTag(tag)
+                if (existing != null) {
+                    show(existing)
+                } else {
+                    add(R.id.bottom_nav_fragment_container, fragment, tag)
+                }
+            }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -407,6 +407,9 @@ open class PrefsRepository(
     val devIsCardBrowserFragmented: Boolean
         get() = getBoolean(R.string.dev_card_browser_fragmented, false)
 
+    val devBottomNavEnabled: Boolean
+        get() = getBoolean(R.string.dev_bottom_nav_key, false)
+
     @set:VisibleForTesting
     var devUsingCardBrowserSearchView: Boolean by booleanPref(R.string.dev_card_browser_search_view, false)
 

--- a/AnkiDroid/src/main/res/layout/activity_bottom_nav.xml
+++ b/AnkiDroid/src/main/res/layout/activity_bottom_nav.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+~ SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+~ SPDX-License-Identifier: GPL-3.0-or-later
+-->
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/bottom_nav_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:ignore="UnusedResources">
+
+    <FrameLayout
+        android:id="@+id/bottom_nav_content_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginBottom="80dp" />
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/bottom_nav_fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginBottom="80dp"
+        android:visibility="gone" />
+
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bottom_navigation"
+        android:layout_width="match_parent"
+        android:layout_height="80dp"
+        android:layout_gravity="bottom"
+        app:menu="@menu/bottom_nav_menu" />
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/main/res/menu/bottom_nav_menu.xml
+++ b/AnkiDroid/src/main/res/menu/bottom_nav_menu.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+~ SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+~ SPDX-License-Identifier: GPL-3.0-or-later
+-->
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="UnusedResources">
+<item
+        android:id="@+id/nav_home"
+        android:icon="@drawable/ic_list_black"
+        android:title="@string/decks" />
+    <item
+        android:id="@+id/nav_browser"
+        android:icon="@drawable/ic_flashcard_black"
+        android:title="@string/card_browser" />
+    <item
+        android:id="@+id/nav_stats"
+        android:icon="@drawable/ic_bar_chart_black"
+        android:title="@string/statistics" />
+    <item
+        android:id="@+id/nav_more"
+        android:icon="@drawable/ic_menu_24"
+        android:title="@string/bottom_nav_more" />
+</menu>

--- a/AnkiDroid/src/main/res/values/12-dont-translate.xml
+++ b/AnkiDroid/src/main/res/values/12-dont-translate.xml
@@ -43,5 +43,7 @@ If you want to use a string in your code that can't be translated, please use:
     <!-- TODO: Move this to a proper string resource file and collect all other strings associated with this feature once it is stable. -->
     <string name="schedule_reminders_do_not_translate" maxLength="28" comment="Do not translate this string, this feature is still in development. Name of the screen that appears when review reminders are being scheduled.">Schedule reminders</string>
     <string name="review_reminders_do_not_translate" comment="Do not translate this string, this feature is still in development. Name of the notification channel for review reminders.">Review Reminders</string>
+    <!-- Bottom Nav Bar: In progress for GSoC 2026 -->
+    <string name="bottom_nav_more" maxLength="28">More</string>
 </resources>
 

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -237,6 +237,7 @@
     <string name="use_fixed_port_pref_key">useFixedPort</string>
     <string name="dev_card_browser_fragmented">cardBrowserFragmented</string>
     <string name="dev_card_browser_search_view">cardBrowserSearchView</string>
+    <string name="dev_bottom_nav_key">devBottomNav</string>
     <string name="dev_open_tts_voices">openTtsVoices</string>
     <!-- Developer options > Create fake notes -->
     <string name="pref_fill_default_deck_number_key">FillDefaultNumberDeck</string>

--- a/AnkiDroid/src/main/res/xml/preferences_developer_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_developer_options.xml
@@ -119,5 +119,10 @@
             android:title="Switch Profile option"
             android:key="@string/pref_enable_switch_profile_key"
             android:defaultValue="false"/>
+        <SwitchPreferenceCompat
+            android:title="Bottom navigation bar"
+            android:summary="Replaces the navigation drawer with a bottom nav bar"
+            android:key="@string/dev_bottom_nav_key"
+            android:defaultValue="false"/>
     </com.ichi2.anki.preferences.ExtendedPreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This PR adds:
* Scaffolding for the bottom nav activity base class and relevant layouts (subject to change due to compose migration) which will later be used by the deck picker as opposed to the nav drawer.
* Adds bottom nav bar to developer options. (Could be renamed to "New deck picker screen" later on.

## Fixes
* For GSoC 2026: Redesign deck picker

## Approach
Commit 1: Add developer option toggle for bottom nav bar
This commit introduces a toggle for the bottom nav bar:
-  Adds dev_bottom_nav_key preference key in preferences.xml
- Adds a SwitchPreferenceCompat in the WIP section of dev options

Commit 2: Add bottomNavActivity base class and layouts
- BottomNavActivity extends AnkiActivity and provides abstract tab routing for Home, Browse, Stats, and More destinations
- showFragment() and hideAllFragments() use show/hide (not replace) to maintain state persistence
- OnBackPressedCallback intercepts back presses to return to the Home tab before exiting
- bottom_nav_menu.xml defines the four navigation destinations
- activity_bottom_nav.xml provides a CoordinatorLayout wrapper with content and fragment containers (subject to change)
- No activity extends this class yet, DeckPicker will be wired in a follow-up PR

## How Has This Been Tested?
Code compiles successfully.
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/ad727210-fdcd-416b-a658-d39b247cfc57" />

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->