### PR TITLE
Fix: whiteboard image format

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DrawingFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DrawingFragment.kt
@@ -18,7 +18,6 @@ package com.ichi2.anki
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
 import android.net.Uri
@@ -84,6 +83,9 @@ class DrawingFragment : Fragment(R.layout.fragment_drawing) {
         val bitmap = createBitmap(view.width, view.height)
         val canvas = Canvas(bitmap)
 
+        // TODO: drop the baked-in background and save with a transparent canvas, so the drawing
+        //  adapts to whichever theme the card is reviewed under and empty space costs nothing
+        //  in the file.
         val backgroundColor =
             if (Themes.isNightTheme) {
                 Color.BLACK
@@ -95,7 +97,14 @@ class DrawingFragment : Fragment(R.layout.fragment_drawing) {
         view.draw(canvas)
 
         val baseFileName = "Whiteboard" + getTimestamp(TimeManager.time)
-        return CompatHelper.compat.saveImage(requireContext(), bitmap, baseFileName, "jpg", Bitmap.CompressFormat.JPEG, 95)
+        return CompatHelper.compat.saveImage(
+            requireContext(),
+            bitmap,
+            baseFileName,
+            "webp",
+            CompatHelper.compat.webpLossyFormat,
+            90,
+        )
     }
 
     companion object {

--- a/compat/src/main/java/com/ichi2/anki/compat/BaseCompat.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/BaseCompat.kt
@@ -185,6 +185,8 @@ open class BaseCompat : Compat {
         }
     }
 
+    override val webpLossyFormat: Bitmap.CompressFormat = Bitmap.CompressFormat.WEBP
+
     // Until API 29
     @Throws(FileNotFoundException::class)
     override fun saveImage(

--- a/compat/src/main/java/com/ichi2/anki/compat/Compat.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/Compat.kt
@@ -208,6 +208,11 @@ interface Compat {
     fun hasVideoThumbnail(path: String): Boolean?
 
     /**
+     * The [CompressFormat] constant to use for lossy WebP encoding.
+     */
+    val webpLossyFormat: CompressFormat
+
+    /**
      * Writes an image represented by bitmap to the Pictures/AnkiDroid directory under the primary
      * external storage directory. Requires the WRITE_EXTERNAL_STORAGE permission to be obtained on devices running
      * API <= 28. If this condition isn't satisfied, this method will throw a [FileNotFoundException].

--- a/compat/src/main/java/com/ichi2/anki/compat/CompatV31.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/CompatV31.kt
@@ -4,6 +4,7 @@
 package com.ichi2.anki.compat
 
 import android.content.Context
+import android.graphics.Bitmap
 import android.media.MediaRecorder
 import android.os.VibrationEffect
 import android.os.VibratorManager
@@ -25,4 +26,6 @@ open class CompatV31 : CompatV29() {
     }
 
     override fun getMediaRecorder(context: Context): MediaRecorder = MediaRecorder(context)
+
+    override val webpLossyFormat: Bitmap.CompressFormat = Bitmap.CompressFormat.WEBP_LOSSY
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The whiteboard drawing tool saves images as JPEG at quality 95. As reported on Reddit (and confirmed in #20930), this produces bigger files for representative drawings far too large for collection.media This PR switches the output to WebP at quality 90

## Fixes
* Fixes part of #20930

## Approach
Switch JPEG q95 WebP lossy q90: 2.2-2.9× smaller across all measured cases, no consumer changes, already-supported everywhere in the Anki ecosystem, I actually considered SVG first but its too complex for now to handle as a significant refactor is needed(path serialization, eraser handling, new save path), and SVG isn't always smaller. Maybe worth pursuing separately.

## How Has This Been Tested?
Pixel 10, and I tried LLM testing for comparsion of the size and it dropped significantly these tests were to confirm locally but even the Pixel 10 showed actual size drop 

## Learning (optional, can help others)
Not transparent BG yet: needs the brush-colour story sorted first added a TODO for now

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->