### PR TITLE
Add support for "answer buttons position" setting in new study screen

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -27,6 +27,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.cardviewer.TapGestureMode
 import com.ichi2.anki.common.utils.isRunningAsUnitTest
 import com.ichi2.anki.preferences.sharedPrefs
+import com.ichi2.anki.settings.enums.AnswerButtonsPosition
 import com.ichi2.anki.settings.enums.AppTheme
 import com.ichi2.anki.settings.enums.DayTheme
 import com.ichi2.anki.settings.enums.FrameStyle
@@ -345,6 +346,15 @@ open class PrefsRepository(
     val autoFocusTypeAnswer by booleanPref(R.string.type_in_answer_focus_key, true)
     val showAnswerFeedback by booleanPref(R.string.show_answer_feedback_key, defaultValue = true)
     var showAnswerButtons by booleanPref(R.string.show_answer_buttons_key, true)
+    private val _answerButtonsPosition by stringPref(R.string.answer_buttons_position_preference, "bottom")
+    val answerButtonsPosition: AnswerButtonsPosition
+        get() =
+            when (_answerButtonsPosition) {
+                "top" -> AnswerButtonsPosition.TOP
+                "bottom" -> AnswerButtonsPosition.BOTTOM
+                "none" -> AnswerButtonsPosition.NONE
+                else -> AnswerButtonsPosition.BOTTOM
+            }
     val keepScreenOn by booleanPref(R.string.keep_screen_on_preference, defaultValue = false)
     val hideHardAndEasyButtons by booleanPref(R.string.hide_hard_and_easy_key, defaultValue = false)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/enums/AnswerButtonsPosition.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/enums/AnswerButtonsPosition.kt
@@ -1,0 +1,10 @@
+package com.ichi2.anki.settings.enums
+
+/**
+ * Represents possible configurations for the position of the answer buttons on the study screen.
+ */
+enum class AnswerButtonsPosition {
+    TOP,
+    BOTTOM,
+    NONE,
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -22,6 +22,7 @@ import android.os.Bundle
 import android.view.KeyEvent
 import android.view.MenuItem
 import android.view.View
+import android.view.ViewGroup
 import android.view.WindowManager
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
@@ -38,6 +39,7 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
+import androidx.core.view.updateMargins
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
@@ -75,6 +77,7 @@ import com.ichi2.anki.scheduling.ForgetCardsDialog
 import com.ichi2.anki.scheduling.SetDueDateDialog
 import com.ichi2.anki.scheduling.registerOnForgetHandler
 import com.ichi2.anki.settings.Prefs
+import com.ichi2.anki.settings.enums.AnswerButtonsPosition
 import com.ichi2.anki.settings.enums.FrameStyle
 import com.ichi2.anki.settings.enums.HideSystemBars
 import com.ichi2.anki.settings.enums.ToolbarPosition
@@ -369,6 +372,27 @@ class ReviewerFragment :
             return
         }
 
+        val answerButtonsPosition = Prefs.answerButtonsPosition
+        when (answerButtonsPosition) {
+            AnswerButtonsPosition.TOP -> {
+                // no-op, this is the default from the layout
+            }
+            AnswerButtonsPosition.BOTTOM -> {
+                val answerAreaView = binding.answerArea
+                (answerAreaView.parent as? ViewGroup)?.removeView(answerAreaView)
+                binding.bottomLayout.addView(answerAreaView)
+                binding.answerArea.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                    // binding.bottomLayout already supplies a margin,
+                    // we don't need one on this view now
+                    updateMargins(left = 0, right = 0)
+                }
+            }
+            AnswerButtonsPosition.NONE -> {
+                binding.answerArea.isVisible = false
+                return
+            }
+        }
+
         binding.answerArea.setButtonListeners(
             onRatingClicked = { viewModel.answerCard(it) },
             onShowAnswerClicked = { viewModel.onShowAnswer() },
@@ -460,32 +484,51 @@ class ReviewerFragment :
     }
 
     private fun setupToolbarPosition() {
+        val toolbarPosition = Prefs.toolbarPosition
         when (Prefs.toolbarPosition) {
-            ToolbarPosition.TOP -> return
+            ToolbarPosition.TOP -> {
+                // no-op, this is the default in the inflated layout
+            }
             ToolbarPosition.NONE -> binding.toolsLayout.isVisible = false
             ToolbarPosition.BOTTOM -> {
                 binding.mainLayout.removeView(binding.toolsLayout)
                 binding.mainLayout.addView(binding.toolsLayout)
-
-                // Put the answer buttons inside the toolbar on big screens
-                if (!isBigScreen || !Prefs.showAnswerButtons) return
-                binding.bottomLayout.removeView(binding.answerArea)
-                binding.toolsLayout.addView(binding.answerArea)
-                binding.answerArea.updateLayoutParams<ConstraintLayout.LayoutParams> {
-                    width = 0
-                    matchConstraintPercentWidth = 0.6F
-                    matchConstraintMaxWidth = 480.dp.toPx(requireContext())
-                    topToTop = ConstraintLayout.LayoutParams.PARENT_ID
-                    bottomToBottom = ConstraintLayout.LayoutParams.PARENT_ID
-                    startToStart = ConstraintLayout.LayoutParams.PARENT_ID
-                    endToEnd = ConstraintLayout.LayoutParams.PARENT_ID
-                }
-                binding.reviewerMenuView.updateLayoutParams<ConstraintLayout.LayoutParams> {
-                    width = 0
-                    matchConstraintPercentWidth = 0.16F
-                    startToEnd = ConstraintLayout.LayoutParams.UNSET
-                }
             }
+        }
+
+        // Put the answer buttons inside the toolbar on big screens
+        val answerButtonInToolbar by lazy {
+            // check if answer button position and toolbarPosition are the same
+            // if so, the answer button can be placed in the container
+            when (Prefs.answerButtonsPosition) {
+                AnswerButtonsPosition.TOP if toolbarPosition == ToolbarPosition.TOP -> true
+                AnswerButtonsPosition.BOTTOM if toolbarPosition == ToolbarPosition.BOTTOM -> true
+                else -> false
+            }
+        }
+        if (isBigScreen && Prefs.showAnswerButtons && answerButtonInToolbar) {
+            positionAnswerButtonsInToolbar()
+        }
+    }
+
+    private fun positionAnswerButtonsInToolbar() {
+        val answerAreaView = binding.answerArea
+        (answerAreaView.parent as? ViewGroup)?.removeView(answerAreaView)
+        binding.toolsLayout.addView(answerAreaView)
+        answerAreaView.updateLayoutParams<ConstraintLayout.LayoutParams> {
+            width = 0
+            matchConstraintPercentWidth = 0.6F
+            matchConstraintMaxWidth = 480.dp.toPx(requireContext())
+            updateMargins(left = 0, right = 0)
+            topToTop = ConstraintLayout.LayoutParams.PARENT_ID
+            bottomToBottom = ConstraintLayout.LayoutParams.PARENT_ID
+            startToStart = ConstraintLayout.LayoutParams.PARENT_ID
+            endToEnd = ConstraintLayout.LayoutParams.PARENT_ID
+        }
+        binding.reviewerMenuView.updateLayoutParams<ConstraintLayout.LayoutParams> {
+            width = 0
+            matchConstraintPercentWidth = 0.16F
+            startToEnd = ConstraintLayout.LayoutParams.UNSET
         }
     }
 

--- a/AnkiDroid/src/main/res/layout/fragment_reviewer.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_reviewer.xml
@@ -82,6 +82,12 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
+        <com.ichi2.anki.ui.windows.reviewer.AnswerAreaView
+            android:id="@+id/answer_area"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/reviewer_side_margin"/>
+
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/web_view_container"
             style="@style/CardView.ViewerStyle"
@@ -187,11 +193,6 @@
                 android:elevation="2dp"
                 android:visibility="gone"
                 tools:layout="@layout/fragment_check_pronunciation" />
-
-            <com.ichi2.anki.ui.windows.reviewer.AnswerAreaView
-                android:id="@+id/answer_area"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"/>
 
         </LinearLayout>
     </LinearLayout>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -263,6 +263,7 @@
     <string name="hide_system_bars_key">hideSystemBars</string>
     <string name="ignore_display_cutout_key">ignoreDisplayCutout</string>
     <string name="show_answer_buttons_key">showAnswerButtons</string>
+    <string name="answer_buttons_position_key">answerButtonPosition</string>
     <string name="hide_hard_and_easy_key">hideHardAndEasy</string>
     <string name="reviewer_menu_settings_key">reviewerMenuSettings</string>
     <string name="reviewer_frame_style_key">reviewerFrameStyle</string>

--- a/AnkiDroid/src/main/res/xml/preferences_reviewer.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewer.xml
@@ -102,6 +102,15 @@
             android:icon="@drawable/ic_shelf_auto_hide"
             />
 
+        <ListPreference
+            android:defaultValue="bottom"
+            android:entries="@array/answer_buttons_position_labels"
+            android:entryValues="@array/answer_buttons_position"
+            android:icon="@drawable/ic_shelf_auto_hide"
+            android:key="@string/answer_buttons_position_key"
+            android:title="@string/answer_buttons_position"
+            app:useSimpleSummaryProvider="true"/>
+
         <SwitchPreferenceCompat
             android:key="@string/show_estimates_preference"
             android:icon="@drawable/ic_running_clock"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

This branch adds support for the "Answer buttons position" setting on the new study screen. The setting allows positioning the answer buttons on the top or bottom of the screen (or hiding them entirely). On large screens the answer button is placed inside the `tools_layout` container when the "Toolbar position" setting matches the "Answer buttons position" setting.

Motivation: As someone who primarily studies with the whiteboard with a stylus, I needed this setting supported in order to use the new study screen. The default position of the answer buttons on the bottom of the screen is not great because my arm rests there while I write (so I'm afraid I'll accidentally trigger the buttons).

## Fixes
I don't see an issue filed for this, it's an independent initiative on my part

## Approach
1. Adds an `enum class` to represent the AnswerButtonsPosition setting. This is useful for making the related conditional statements exhaustive in ReviewerFragment.
1. Adds a property to the PrefsRepository component to expose the setting value.
1. Adjusts the logic in ReviewerFragment `setupAnswerButtons` to position the buttons within the study screen layout based on the setting.
   1. Moves the default layout position of the answer buttons to the top, with the programmatic logic removing the buttons and adding them back to the `bottomLayout` when they're positioned at the bottom. This is easier to do programmatically than positioning `answer_area` in between `tools_layout` and `web_view_container`.
   1. I stuck with the existing pattern of applying programmatic layout updates here, because I wanted to stick to how the codebase is currently doing this. But if it's endorsed by the maintainers here, I would suggest swapping to a setup where we have multiple containers in the layout as options for where to place the `answer_area`; this would be (1) a container at the top of the layout, (2) one at the bottom, and (3) one inside the `tools_layout` for large screens. That makes it so we can apply the proper layout params to each container in the layout file without having to do anything programmatically, and the only logic in ReviewerFragment is just moving `answer_area` to the proper container.

## How Has This Been Tested?

- [x] Update "answer buttons position" to TOP in settings, verify appearance of the UI for SMALL devices
- [x] Update "answer buttons position" to BOTTOM in settings, verify appearance of the UI for SMALL devices
- [x] Update "answer buttons position" to NONE in settings, verify appearance of the UI for SMALL devices
- [x] Update "answer buttons position" to TOP in settings, verify appearance of the UI for LARGE devices
- [x] Update "answer buttons position" to BOTTOM in settings, verify appearance of the UI for LARGE devices
- [x] Update "answer buttons position" to NONE in settings, verify appearance of the UI for LARGE devices

Note: when the toolbar and answer buttons are both on top, there is noticeably no padding underneath the WebView container. That's existing behavior also when the answer buttons are disabled (an existing setting). But I could fix it here or separately.

| Device | Top/Top | Top/Bottom | Top/None | Bottom/Top | Bottom/Bottom | Bottom/None |
|---|---|---|---|---|---|---|
| (Handset) Galaxy S21 | <img width="1080" height="2185" alt="GalaxyS21_ToolbarTop_AnswerButtonsTop" src="https://github.com/user-attachments/assets/79749469-c217-4327-8e18-79f197fa1534" /> | <img width="1080" height="2185" alt="GalaxyS21_ToolbarTop_AnswerButtonsBottom" src="https://github.com/user-attachments/assets/f74c30f5-68c5-4bc3-9ace-42547257e8e0" /> | <img width="1080" height="2185" alt="GalaxyS21_ToolbarTop_AnswerButtonsNone" src="https://github.com/user-attachments/assets/9c074c27-daf9-4ead-8b2f-7bed4a402bd1" /> | <img width="1080" height="2185" alt="GalaxyS21_ToolbarBottom_AnswerButtonsTop" src="https://github.com/user-attachments/assets/4dc75e2d-1d6b-4ce7-a0ce-d1707cc087b5" /> | <img width="1080" height="2185" alt="GalaxyS21_ToolbarBottom_AnswerButtonsBottom" src="https://github.com/user-attachments/assets/d3b5765a-ce73-4e93-8fc3-9058cc4bc00d" /> | <img width="1080" height="2185" alt="GalaxyS21_ToolbarBottom_AnswerButtonsNone" src="https://github.com/user-attachments/assets/7902fe1c-d36a-45d0-821f-8efee774799e" /> |
| (Tablet) Galaxy S7+ | <img width="1752" height="2800" alt="GalaxyTabS7+_ToolbarTop_AnswerButtonsTop" src="https://github.com/user-attachments/assets/ee6a0607-42cb-4727-ba3b-06c7b083c752" /> | <img width="1752" height="2800" alt="GalaxyTabS7+_ToolbarTop_AnswerButtonsBottom" src="https://github.com/user-attachments/assets/4989ee37-b6b5-458a-b573-14c426e22ee5" /> | <img width="1752" height="2800" alt="GalaxyTabS7+_ToolbarTop_AnswerButtonsNone" src="https://github.com/user-attachments/assets/46c77cb6-5baa-479e-a15a-d9b2a845b184" /> | <img width="1752" height="2800" alt="GalaxyTabS7+_ToolbarBottom_AnswerButtonsTop" src="https://github.com/user-attachments/assets/e4ca0a6a-4720-4e0c-ad22-112d997aeb62" /> | <img width="1752" height="2800" alt="GalaxyTabS7+_ToolbarBottom_AnswerButtonsBottom" src="https://github.com/user-attachments/assets/fb624d4d-ed68-4a11-9b5a-3ff9f3cc8620" /> | <img width="1752" height="2800" alt="GalaxyTabS7+_ToolbarBottom_AnswerButtonsNone" src="https://github.com/user-attachments/assets/44d58111-2fee-4338-b522-7cde07e1a804" /> |

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
- [x] no AI was used for these changes, I'm head-to-toe legit