### PR TITLE
fix(widget): anchor snackbars for DeckPicker Widget screen

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
@@ -138,6 +138,11 @@ class DeckPickerWidgetConfig :
         deckAdapter =
             WidgetConfigScreenAdapter { deck, position ->
                 deckAdapter.removeDeck(deck.deckId)
+                // Removal always frees at least one slot, so the FAB is going
+                // to be visible. Show it now (synchronously) so the snackbar
+                // anchors to it instead of the Save button while the async
+                // updateFabVisibility() is still in flight.
+                binding.fabWidgetDeckPicker.isVisible = true
                 showSnackbar(R.string.deck_removed_from_widget)
                 updateViewVisibility()
                 updateFabVisibility()
@@ -215,7 +220,15 @@ class DeckPickerWidgetConfig :
     }
 
     override val baseSnackbarBuilder: SnackbarBuilder = {
-        anchorView = binding.fabWidgetDeckPicker.takeIf { it.isVisible }
+        // Prefer the FAB so snackbars sit above it. Fall back to the Save button
+        // for the brief window after a removal where the FAB is being un-hidden
+        // asynchronously, so snackbars never overlap the bottom button row.
+        anchorView =
+            when {
+                binding.fabWidgetDeckPicker.isVisible -> binding.fabWidgetDeckPicker
+                binding.submitButton.isVisible -> binding.submitButton
+                else -> null
+            }
     }
 
     /**


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Acnhor the snackbar on FAB and keep save button as fallback 

## Fixes
* Fixes #21132

## Approach
See commit

## How Has This Been Tested?
Google emulator API 35

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->