### PR TITLE
fix(widget): show correct empty-collection toast in deck picker widget

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
@@ -103,14 +103,15 @@ class DeckPickerWidgetConfig :
 
         registerDeckSelectedHandler(action = ::onDeckSelected)
 
-        // Check if the collection is empty before proceeding and if the collection is empty, show a toast instead of the configuration view.
+        // The widget can only be configured against an existing deck. If the collection has
+        // none, show the same message the widget itself displays and close the config screen.
         this.initTask =
             lifecycleScope.launch {
                 if (isCollectionEmpty()) {
                     Timber.w("Closing: Collection is empty")
                     showThemedToast(
                         this@DeckPickerWidgetConfig,
-                        R.string.app_not_initialized_new,
+                        R.string.empty_collection_state_in_widget,
                         false,
                     )
                     finish()


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Show correct string message for no collection for deck picker screen in widget

## Fixes
NA

## Approach
See commit (simply string change)

## How Has This Been Tested?
Pixel fold Google emulator

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->