### PR TITLE
feat(reminders): streamline review reminders UI

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -296,7 +296,7 @@
         <activity
             android:name="com.ichi2.anki.StudyOptionsActivity"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|screenSize"
+            android:configChanges="keyboardHidden|screenSize"
             android:parentActivityName=".DeckPicker"
             >
         </activity>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -214,22 +214,29 @@ open class AnkiActivity(
     }
 
     /**
-     * Sets the title of the toolbar (support action bar) for the activity.
+     * Sets the title (and possibly subtitle) of the toolbar (support action bar) for the activity.
      *
      * @param title The new title to be set for the toolbar.
+     * @param subtitle The new subtitle to be set for the toolbar. If `null`, the subtitle is removed.
      */
-    open fun setToolbarTitle(title: String) {
+    open fun setToolbarText(
+        title: String,
+        subtitle: String? = null,
+    ) {
         supportActionBar?.title = title
+        supportActionBar?.subtitle = subtitle
     }
 
     /**
-     * Sets the title of the toolbar (support action bar) for the activity.
+     * Sets the title (and possibly subtitle) of the toolbar (support action bar) for the activity.
      *
-     * @param title The new title to be set for the toolbar.
+     * @param titleRes The new title to be set for the toolbar.
+     * @param subtitleRes The new subtitle to be set for the toolbar. If `null`, the subtitle is removed.
      */
-    open fun setToolbarTitle(
+    open fun setToolbarText(
         @StringRes titleRes: Int,
-    ) = setToolbarTitle(getString(titleRes))
+        @StringRes subtitleRes: Int? = null,
+    ) = setToolbarText(getString(titleRes), subtitleRes?.let { getString(it) })
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -60,6 +60,7 @@ import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
 import androidx.draganddrop.DropHelper
 import androidx.fragment.app.FragmentContainerView
+import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
@@ -85,6 +86,8 @@ import com.ichi2.anki.InitialActivity.StartupFailure.FutureAnkidroidVersion
 import com.ichi2.anki.InitialActivity.StartupFailure.SDCardNotMounted
 import com.ichi2.anki.InitialActivity.StartupFailure.StorageUndecided
 import com.ichi2.anki.IntentHandler.Companion.intentToReviewDeckFromShortcuts
+import com.ichi2.anki.StudyOptionsFragment.Companion.registerStudyOptionsAddEditReminderHandler
+import com.ichi2.anki.StudyOptionsFragment.Companion.registerStudyOptionsStudyHandler
 import com.ichi2.anki.account.AccountActivity
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.android.back.exitViaDoubleTapBackCallback
@@ -156,7 +159,9 @@ import com.ichi2.anki.pages.AnkiPackageImporterFragment
 import com.ichi2.anki.pages.CongratsPage
 import com.ichi2.anki.pages.CongratsPage.Companion.onDeckCompleted
 import com.ichi2.anki.receiver.SdCardReceiver
+import com.ichi2.anki.reviewreminders.ReviewReminderScope
 import com.ichi2.anki.reviewreminders.ReviewRemindersDatabase
+import com.ichi2.anki.reviewreminders.ScheduleRemindersFragment
 import com.ichi2.anki.servicelayer.ScopedStorageService
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
@@ -583,9 +588,14 @@ open class DeckPicker :
             handleContextMenuSelection(result.option, result.deckId)
         }
 
-        setFragmentResultListener(StudyOptionsFragment.REQUEST_STUDY_OPTIONS_STUDY) { _, _ ->
+        registerStudyOptionsStudyHandler {
             Timber.d("Opening study screen from DeckPicker's study options panel")
             openReviewer()
+        }
+
+        registerStudyOptionsAddEditReminderHandler { did: DeckId ->
+            Timber.d("Opening review reminders screen from DeckPicker's study options panel")
+            openScheduleReminders(did)
         }
 
         pullToSyncWrapper.configureView(
@@ -795,6 +805,7 @@ open class DeckPicker :
                 data = deckList.data,
                 hasSubDecks = deckList.hasSubDecks,
             )
+            tryShowStudyOptionsPanel()
         }
 
         fun onFocusedDeckChanged(deckId: DeckId?) {
@@ -981,8 +992,8 @@ open class DeckPicker :
             }
             DeckPickerContextMenuOption.SCHEDULE_REMINDERS -> {
                 Timber.i("Scheduling review reminders for deck '%d'", deckId)
-                viewModel.scheduleReviewReminders(deckId)
                 dismissAllDialogFragments()
+                openScheduleReminders(deckId)
             }
         }
     }
@@ -1956,8 +1967,25 @@ open class DeckPicker :
      */
     private fun tryShowStudyOptionsPanel(): Boolean {
         val containerId = binding.studyoptionsFragment?.id ?: return false
+        supportFragmentManager.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
         supportFragmentManager.commit {
             replace(containerId, StudyOptionsFragment())
+        }
+        return true
+    }
+
+    @NeedsTest("Instrumented tests for review reminders")
+    private fun tryShowScheduleRemindersPanel(deckId: DeckId): Boolean {
+        val sidePanel = binding.studyoptionsFragment ?: return false
+        if (!sidePanel.isVisible) return false
+        val newFragment =
+            ScheduleRemindersFragment.newInstance(
+                scope = ReviewReminderScope.DeckSpecific(deckId),
+                host = ScheduleRemindersFragment.FragmentHost.STUDY_OPTIONS_FRAGMENT,
+            )
+        supportFragmentManager.commit {
+            replace(sidePanel.id, newFragment)
+            addToBackStack(null)
         }
         return true
     }
@@ -1993,6 +2021,15 @@ open class DeckPicker :
         val intent = Intent()
         intent.setClass(this, StudyOptionsActivity::class.java)
         reviewLauncher.launch(intent)
+    }
+
+    @NeedsTest("Instrumented tests for review reminders")
+    private fun openScheduleReminders(deckId: DeckId) {
+        if (tryShowScheduleRemindersPanel(deckId)) return
+
+        // otherwise, we need to launch the activity
+        Timber.i("Opening Schedule Reminders")
+        viewModel.scheduleReviewReminders(deckId)
     }
 
     private fun openReviewerOrStudyOptions(selectionType: DeckSelectionType) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -768,7 +768,7 @@ class NoteEditorFragment :
         setNote(editorNote, FieldChangeType.onActivityCreation(shouldReplaceNewlines()))
         if (addNote) {
             noteTypeSpinner!!.onItemSelectedListener = SetNoteTypeListener()
-            requireAnkiActivity().setToolbarTitle(R.string.menu_add)
+            requireAnkiActivity().setToolbarText(titleRes = R.string.menu_add)
             // set information transferred by intent
             var contents: String? = null
             val tags = requireArguments().getStringArray(EXTRA_TAGS)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
@@ -20,15 +20,21 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import androidx.core.view.MenuItemCompat
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import androidx.lifecycle.lifecycleScope
 import anki.collection.OpChanges
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.StudyOptionsFragment.Companion.registerStudyOptionsAddEditReminderHandler
+import com.ichi2.anki.StudyOptionsFragment.Companion.registerStudyOptionsStudyHandler
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction.Companion.REQUEST_KEY
+import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.undoAvailable
 import com.ichi2.anki.libanki.undoLabel
 import com.ichi2.anki.observability.ChangeManager
+import com.ichi2.anki.reviewreminders.ReviewReminderScope
+import com.ichi2.anki.reviewreminders.ScheduleRemindersFragment
 import com.ichi2.anki.startup.ensureStorageIsReady
 import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.ui.RtlCompliantActionProvider
@@ -62,16 +68,30 @@ class StudyOptionsActivity :
                 CustomStudyAction.CUSTOM_STUDY_SESSION,
                 CustomStudyAction.EXTEND_STUDY_LIMITS,
                 ->
-                    currentFragment!!.refreshInterface()
+                    (currentFragment as? StudyOptionsFragment)?.refreshInterface()
             }
         }
-        setFragmentResultListener(StudyOptionsFragment.REQUEST_STUDY_OPTIONS_STUDY) { _, _ ->
-            Timber.d("Opening study screen from study options screen")
+        registerStudyOptionsStudyHandler {
+            Timber.i("Opening study screen from study options screen")
             val reviewer = Reviewer.getIntent(this)
             // go back to DeckPicker after studying when not in tablet mode
             reviewer.flags = Intent.FLAG_ACTIVITY_FORWARD_RESULT
             startActivity(reviewer)
             finish()
+        }
+        registerStudyOptionsAddEditReminderHandler { did: DeckId ->
+            Timber.i("Opening review reminders screen from study options screen")
+            supportFragmentManager.commit {
+                replace(
+                    R.id.studyoptions_frame,
+                    ScheduleRemindersFragment.newInstance(
+                        scope = ReviewReminderScope.DeckSpecific(did),
+                        host = ScheduleRemindersFragment.FragmentHost.STUDY_OPTIONS_FRAME,
+                    ),
+                )
+                addToBackStack(null)
+            }
+            invalidateOptionsMenu()
         }
     }
 
@@ -82,8 +102,8 @@ class StudyOptionsActivity :
         }
     }
 
-    private val currentFragment: StudyOptionsFragment?
-        get() = supportFragmentManager.findFragmentById(R.id.studyoptions_frame) as StudyOptionsFragment?
+    private val currentFragment: Fragment?
+        get() = supportFragmentManager.findFragmentById(R.id.studyoptions_frame)
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.activity_study_options, menu)
@@ -91,7 +111,7 @@ class StudyOptionsActivity :
         val undoActionProvider = MenuItemCompat.getActionProvider(undoMenuItem) as? RtlCompliantActionProvider
         // Set the proper click target for the undo button's ActionProvider
         undoActionProvider?.clickHandler = { _, menuItem -> onOptionsItemSelected(menuItem) }
-        undoMenuItem.isVisible = undoState.hasAction
+        undoMenuItem.isVisible = undoState.hasAction && (currentFragment is StudyOptionsFragment)
         undoMenuItem.title = undoState.label
         return true
     }
@@ -128,7 +148,7 @@ class StudyOptionsActivity :
         handler: Any?,
     ) {
         refreshUndoState()
-        currentFragment?.refreshInterface()
+        (currentFragment as? StudyOptionsFragment)?.refreshInterface()
     }
 
     private fun refreshUndoState() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -112,6 +112,9 @@ class StudyOptionsFragment :
     ) {
         super.onViewCreated(view, savedInstanceState)
         requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
+        if (!fragmented) {
+            requireAnkiActivity().setToolbarText(title = "")
+        }
         viewModel.flowOfState.launchCollectionInLifecycleScope(::rebuildUi)
         refreshInterface()
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -24,6 +24,8 @@ import androidx.core.text.parseAsHtml
 import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -33,13 +35,13 @@ import com.ichi2.anki.backend.stripHTMLScriptAndStyleTags
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
 import com.ichi2.anki.filtered.FilteredDeckOptionsFragment
+import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.Decks
 import com.ichi2.anki.observability.ChangeManager
-import com.ichi2.anki.reviewreminders.ReviewReminderScope
-import com.ichi2.anki.reviewreminders.ScheduleRemindersFragment
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.ext.launchCollectionInLifecycleScope
+import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.ui.CollectionMediaImageGetter
 import org.intellij.lang.annotations.Language
@@ -83,10 +85,7 @@ class StudyOptionsFragment :
                 Timber.i("StudyOptionsFragment:: start study button pressed")
                 val state = viewModel.state
                 if (state !is StudyOptionsState.Congrats) {
-                    parentFragmentManager.setFragmentResult(
-                        REQUEST_STUDY_OPTIONS_STUDY,
-                        Bundle(),
-                    )
+                    parentFragmentManager.setStudyOptionsStudyResult()
                 } else {
                     showCustomStudyContextMenu()
                 }
@@ -207,12 +206,7 @@ class StudyOptionsFragment :
             }
             R.id.action_schedule_reminders -> {
                 Timber.i("StudyOptionsFragment:: schedule reminders button pressed")
-                val intent =
-                    ScheduleRemindersFragment.getIntent(
-                        requireContext(),
-                        ReviewReminderScope.DeckSpecific(viewModel.selectedDeckId),
-                    )
-                startActivity(intent)
+                parentFragmentManager.setStudyOptionsAddEditReminderResult(viewModel.selectedDeckId)
                 return true
             }
             R.id.action_unbury -> {
@@ -425,7 +419,18 @@ class StudyOptionsFragment :
          * Identifier for a fragment result request to study(open the reviewer). Activities using
          * this fragment need to handle this request and initialize the study screen as they see fit.
          */
-        const val REQUEST_STUDY_OPTIONS_STUDY = "request_study_option_study"
+        private const val REQUEST_STUDY_OPTIONS_STUDY = "request_study_option_study"
+
+        /**
+         * Identifier for a fragment result request to open the review reminders screen for the selected deck.
+         * Activities using this fragment need to handle this request and open the review reminders screen as they see fit.
+         */
+        private const val REQUEST_STUDY_OPTIONS_REVIEW_REMINDERS = "request_study_option_review_reminders"
+
+        /**
+         * Bundle key for the deck ID whose study options are being displayed, used when the review reminders screen is being opened.
+         */
+        private const val KEY_REVIEW_REMINDERS_DECK_ID = "review_reminders_deck_id"
 
         @VisibleForTesting
         fun formatDescription(
@@ -442,6 +447,32 @@ class StudyOptionsFragment :
             return withoutLinuxLineEndings.parseAsHtml(
                 flags = HtmlCompat.FROM_HTML_MODE_LEGACY,
                 imageGetter = imageGetter,
+            )
+        }
+
+        fun FragmentActivity.registerStudyOptionsStudyHandler(action: () -> Unit) {
+            setFragmentResultListener(REQUEST_STUDY_OPTIONS_STUDY) { _, _ ->
+                Timber.i("Received fragment result from study options fragment to start studying")
+                action()
+            }
+        }
+
+        fun FragmentActivity.registerStudyOptionsAddEditReminderHandler(action: (did: DeckId) -> Unit) {
+            setFragmentResultListener(REQUEST_STUDY_OPTIONS_REVIEW_REMINDERS) { _, bundle ->
+                Timber.i("Received fragment result from study options fragment for adding / editing review reminders")
+                val did = bundle.getLong(KEY_REVIEW_REMINDERS_DECK_ID)
+                action(did)
+            }
+        }
+
+        private fun FragmentManager.setStudyOptionsStudyResult() {
+            setFragmentResult(REQUEST_STUDY_OPTIONS_STUDY, Bundle())
+        }
+
+        private fun FragmentManager.setStudyOptionsAddEditReminderResult(did: DeckId) {
+            setFragmentResult(
+                REQUEST_STUDY_OPTIONS_REVIEW_REMINDERS,
+                Bundle().apply { putLong(KEY_REVIEW_REMINDERS_DECK_ID, did) },
             )
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaFragment.kt
@@ -81,7 +81,7 @@ abstract class MultimediaFragment(
     ) {
         super.onViewCreated(view, savedInstanceState)
 
-        requireAnkiActivity().setToolbarTitle(title)
+        requireAnkiActivity().setToolbarText(title = title)
 
         if (arguments != null) {
             Timber.d("Getting MultimediaActivityExtra values from arguments")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
@@ -18,12 +18,10 @@ import com.ichi2.anki.common.android.AdaptionUtil
 import com.ichi2.anki.compat.CompatHelper
 import com.ichi2.anki.preferences.profiles.SwitchProfilesFragment
 import com.ichi2.anki.preferences.reviewer.ReviewerMenuSettingsFragment
-import com.ichi2.anki.reviewreminders.ReviewReminderScope
 import com.ichi2.anki.reviewreminders.ScheduleRemindersFragment
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.preferences.HeaderPreference
-import timber.log.Timber
 
 class HeaderFragment : SettingsFragment() {
     override val analyticsScreenNameConstant: String
@@ -54,14 +52,6 @@ class HeaderFragment : SettingsFragment() {
 
         requirePreference<Preference>(R.string.pref_developer_options_screen_key)
             .isVisible = Prefs.isDeveloperOptionsEnabled
-
-        requirePreference<HeaderPreference>(R.string.pref_review_reminders_screen_key)
-            .setOnPreferenceClickListener {
-                Timber.i("HeaderFragment:: edit review reminders button pressed")
-                val intent = ScheduleRemindersFragment.getIntent(requireContext(), ReviewReminderScope.Global)
-                startActivity(intent)
-                true
-            }
 
         requirePreference<HeaderPreference>(R.string.pref_review_reminders_screen_key).isVisible = Prefs.newReviewRemindersEnabled
         requirePreference<HeaderPreference>(R.string.pref_notifications_screen_key).isVisible = !Prefs.newReviewRemindersEnabled
@@ -112,11 +102,11 @@ class HeaderFragment : SettingsFragment() {
                     .addBreadcrumb(R.string.pref_cat_sync)
 
                 if (Prefs.newReviewRemindersEnabled) {
-                    searchConfiguration
-                        .indexItem()
+                    indexItem()
                         .withKey(activity.getString(R.string.pref_review_reminders_screen_key))
                         .withTitle("Review reminders")
-                        .withResId(R.xml.preference_headers)
+                        .withResId(R.xml.preferences_review_reminders)
+                        .withSummary("Notifications")
                 } else {
                     index(R.xml.preferences_notifications)
                 }
@@ -250,6 +240,7 @@ class HeaderFragment : SettingsFragment() {
                 is ReviewingSettingsFragment -> R.string.pref_reviewing_screen_key
                 is SyncSettingsFragment, is CustomSyncServerSettingsFragment -> R.string.pref_sync_screen_key
                 is NotificationsSettingsFragment -> R.string.pref_notifications_screen_key
+                is ScheduleRemindersFragment -> R.string.pref_review_reminders_screen_key
                 is AppearanceSettingsFragment, is CustomButtonsSettingsFragment -> R.string.pref_appearance_screen_key
                 is ControlsSettingsFragment -> R.string.pref_controls_screen_key
                 is AccessibilitySettingsFragment -> R.string.pref_accessibility_screen_key

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -33,7 +33,6 @@ import com.ichi2.anki.common.android.Animations
 import com.ichi2.anki.common.annotations.LegacyNotifications
 import com.ichi2.anki.common.utils.android.getResFromAttr
 import com.ichi2.anki.preferences.HeaderFragment.Companion.getHeaderKeyForFragment
-import com.ichi2.anki.reviewreminders.ReviewReminderScope
 import com.ichi2.anki.reviewreminders.ScheduleRemindersFragment
 import com.ichi2.anki.utils.isWindowCompact
 import com.ichi2.utils.FragmentFactoryUtils
@@ -108,26 +107,30 @@ class PreferencesFragment :
     }
 
     override fun onSearchResultClicked(result: SearchPreferenceResult) {
-        if (result.key == getString(R.string.pref_review_reminders_screen_key)) {
-            Timber.i("Preferences:: edit review reminders button pressed")
-            val intent = ScheduleRemindersFragment.getIntent(requireContext(), ReviewReminderScope.Global)
-            startActivity(intent)
+        if (result.resourceFile == R.xml.preferences_review_reminders) {
+            // This is a special case because the review reminders settings screen is not a
+            // normal SettingsFragment, but is instead a custom fragment.
+            Timber.i("Preferences:: Opening review reminders settings from search result")
+            openPreferencesFragmentFromSearch(ScheduleRemindersFragment())
             return
         }
 
         val fragment = getFragmentFromXmlRes(result.resourceFile) ?: return
-
-        parentFragmentManager.popBackStack() // clear the search fragment from the backstack
-        childFragmentManager.commit {
-            replace(R.id.settings_container, fragment, fragment.javaClass.name)
-            setFadeTransition(this)
-            addToBackStack(fragment.javaClass.name)
-        }
+        openPreferencesFragmentFromSearch(fragment)
 
         if (fragment is ControlsSettingsFragment) {
             fragment.highlightPreference(result)
         } else {
             result.highlight(fragment as PreferenceFragmentCompat)
+        }
+    }
+
+    private fun openPreferencesFragmentFromSearch(fragment: Fragment) {
+        parentFragmentManager.popBackStack() // clear the search fragment from the backstack
+        childFragmentManager.commit {
+            replace(R.id.settings_container, fragment, fragment.javaClass.name)
+            setFadeTransition(this)
+            addToBackStack(fragment.javaClass.name)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
@@ -17,7 +17,6 @@
 package com.ichi2.anki.reviewreminders
 
 import android.app.Dialog
-import android.content.res.Configuration
 import android.os.Bundle
 import android.os.Parcelable
 import android.text.format.DateFormat
@@ -142,6 +141,28 @@ class AddEditReminderDialog : DialogFragment() {
         return dialog
     }
 
+    /**
+     * MaterialTimePicker loses its callbacks when it is redrawn upon device rotation due to a known issue:
+     *
+     * https://github.com/material-components/material-components-android/issues/4310
+     *
+     * Whenever this dialog is hosted inside an activity that does not have `android:configChanges="orientation"`
+     * set in the manifest (ex. PreferencesActivity), the activity will be destroyed and recreated upon rotation,
+     * causing the dialog to be redrawn and lose its callbacks. Hence, we must reattach them via onResume.
+     *
+     * @see onConfigurationChanged
+     */
+    override fun onResume() {
+        super.onResume()
+        val timePickerDialog = parentFragmentManager.findFragmentByTag(TIME_PICKER_TAG) as? MaterialTimePicker
+        timePickerDialog?.let {
+            it.clearOnPositiveButtonClickListeners()
+            it.addOnPositiveButtonClickListener {
+                viewModel.setTime(ReviewReminderTime(timePickerDialog.hour, timePickerDialog.minute))
+            }
+        }
+    }
+
     private fun setUpToolbar() {
         binding.addEditReminderToolbar.title =
             getString(
@@ -251,6 +272,13 @@ class AddEditReminderDialog : DialogFragment() {
     /**
      * Show the time picker dialog for selecting a time with a given hour and minute.
      * Does not automatically dismiss the old dialog.
+     *
+     * We must use `dialog.show` here (thus technically causing the MaterialTimePicker dialog to be rendered
+     * on top of the AddEditReminderDialog, rather than replacing it as is standard) and cannot use the
+     * standard [showDialogFragment] method. This is because there are certain actions that need to be performed
+     * if the screen rotates while the time picker dialog is open. See [onResume]. The standard methods remove the old
+     * dialog before showing the new one, meaning on-rotation actions would not be possible without layering the
+     * MaterialTimePicker dialog on top of the AddEditReminderDialog.
      */
     private fun showTimePickerDialog(
         hour: Int,
@@ -268,20 +296,6 @@ class AddEditReminderDialog : DialogFragment() {
             viewModel.setTime(ReviewReminderTime(dialog.hour, dialog.minute))
         }
         dialog.show(parentFragmentManager, TIME_PICKER_TAG)
-    }
-
-    /**
-     * For some reason, the TimePicker dialog does not automatically redraw itself properly when the device rotates.
-     * Thus, if the TimePicker dialog is active, we manually show a new copy and then dismiss the old one.
-     * We need to show the new one before dismissing the old one to ensure there is no annoying flicker.
-     */
-    override fun onConfigurationChanged(newConfig: Configuration) {
-        super.onConfigurationChanged(newConfig)
-        val previousDialog = parentFragmentManager.findFragmentByTag(TIME_PICKER_TAG) as? MaterialTimePicker
-        previousDialog?.let {
-            showTimePickerDialog(it.hour, it.minute)
-            it.dismiss()
-        }
     }
 
     private fun onSubmit() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
@@ -26,7 +26,6 @@ import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.setFragmentResult
-import androidx.fragment.app.setFragmentResultListener
 import androidx.fragment.app.viewModels
 import com.google.android.material.timepicker.MaterialTimePicker
 import com.google.android.material.timepicker.TimeFormat
@@ -49,6 +48,7 @@ import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.ext.getParcelableCompat
 import com.ichi2.anki.utils.ext.showDialogFragment
+import com.ichi2.anki.utils.showDialogFragment
 import com.ichi2.utils.DisplayUtils.resizeWhenSoftInputShown
 import com.ichi2.utils.Permissions
 import com.ichi2.utils.customView
@@ -346,7 +346,7 @@ class AddEditReminderDialog : DialogFragment() {
             dismiss()
         }
 
-        showDialogFragment(confirmationDialog)
+        parentFragmentManager.showDialogFragment(confirmationDialog)
     }
 
     private fun onDeckSelected(deck: SelectableDeck?) {
@@ -409,7 +409,7 @@ class AddEditReminderDialog : DialogFragment() {
         fun Fragment.registerAddEditReminderHandler(
             action: (newOrModifiedReminder: ReviewReminder?, modeOfFinishedDialog: DialogMode) -> Unit,
         ) {
-            setFragmentResultListener(REQUEST_ADD_EDIT_REMINDER) { _, bundle ->
+            childFragmentManager.setFragmentResultListener(REQUEST_ADD_EDIT_REMINDER, viewLifecycleOwner) { _, bundle ->
                 Timber.i("Received fragment result from add/edit dialog")
                 val modeOfFinishedDialog =
                     bundle.getParcelableCompat<DialogMode>(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
@@ -41,7 +41,9 @@ import com.ichi2.anki.R
 import com.ichi2.anki.common.utils.android.getColorFromAttr
 import com.ichi2.anki.databinding.FragmentReminderTroubleshootingBinding
 import com.ichi2.anki.databinding.ItemTroubleshootingCheckBinding
+import com.ichi2.anki.requireAnkiActivity
 import com.ichi2.anki.settings.Prefs
+import com.ichi2.anki.utils.ext.getParcelableCompat
 import com.ichi2.anki.utils.ext.launchCollectionInLifecycleScope
 import com.ichi2.anki.utils.ext.onWindowFocusChanged
 import com.ichi2.anki.utils.ext.setBackgroundTint
@@ -75,6 +77,20 @@ class ReminderTroubleshootingFragment : Fragment(R.layout.fragment_reminder_trou
 
     private val binding by viewBinding(FragmentReminderTroubleshootingBinding::bind)
 
+    /**
+     * [ScheduleRemindersFragment] can be hosted from multiple activities and must change its UI to accommodate its host
+     * Since this fragment is launched from [ScheduleRemindersFragment], it must also know its host to adjust its UI accordingly.
+     *
+     * @see ScheduleRemindersFragment.FragmentHost
+     */
+    private val host: ScheduleRemindersFragment.FragmentHost by lazy {
+        requireNotNull(
+            requireArguments().getParcelableCompat<ScheduleRemindersFragment.FragmentHost>(ARGS_HOST),
+        ) {
+            "Host cannot be null"
+        }
+    }
+
     internal val notificationPermissionLauncher: ActivityResultLauncher<String> =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) {
             viewModel.refreshChecks()
@@ -86,13 +102,33 @@ class ReminderTroubleshootingFragment : Fragment(R.layout.fragment_reminder_trou
     ) {
         super.onViewCreated(view, savedInstanceState)
 
-        binding.toolbar.setNavigationOnClickListener {
-            requireActivity().onBackPressedDispatcher.onBackPressed()
+        // Set up root layout insets if the host of this fragment does not support edge-to-edge
+        binding.rootLayout.fitsSystemWindows = !host.supportsEdgeToEdge
+        when (host.toolbarType) {
+            ScheduleRemindersFragment.ToolbarType.EXTERNAL -> setupExternalActivityToolbar()
+            ScheduleRemindersFragment.ToolbarType.INTERNAL_COLLAPSIBLE,
+            ScheduleRemindersFragment.ToolbarType.INTERNAL_NON_COLLAPSIBLE,
+            -> setupInternalFragmentToolbar()
         }
 
         setupSummary()
         setupTroubleshootingChecks()
         setupSettingChangeDetector()
+    }
+
+    private fun setupExternalActivityToolbar() {
+        binding.troubleshootingToolbar.isVisible = false
+        requireAnkiActivity().apply {
+            // TODO: Move to string resources
+            setToolbarText(title = "Troubleshooting")
+            invalidateMenu()
+        }
+    }
+
+    private fun setupInternalFragmentToolbar() {
+        binding.troubleshootingToolbar.setNavigationOnClickListener {
+            parentFragmentManager.popBackStack()
+        }
     }
 
     private fun setupSummary() {
@@ -148,6 +184,25 @@ class ReminderTroubleshootingFragment : Fragment(R.layout.fragment_reminder_trou
      */
     private fun setupSettingChangeDetector() {
         onWindowFocusChanged { hasFocus -> if (hasFocus) viewModel.refreshChecks() }
+    }
+
+    companion object {
+        /**
+         * Arguments key for specifying the host of this fragment.
+         */
+        private const val ARGS_HOST = "host"
+
+        fun newInstance(host: ScheduleRemindersFragment.FragmentHost): ReminderTroubleshootingFragment =
+            ReminderTroubleshootingFragment().apply {
+                arguments =
+                    Bundle().apply {
+                        putParcelable(ARGS_HOST, host)
+                    }
+                Timber.i(
+                    "Creating ReminderTroubleshootingFragment with host=%s",
+                    host,
+                )
+            }
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
@@ -19,13 +19,18 @@ package com.ichi2.anki.reviewreminders
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.os.Parcelable
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
+import androidx.annotation.IdRes
 import androidx.core.view.MenuProvider
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat.Type.displayCutout
+import androidx.core.view.WindowInsetsCompat.Type.statusBars
 import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.commit
@@ -36,21 +41,24 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
-import com.ichi2.anki.SingleFragmentActivity
 import com.ichi2.anki.canUserAccessDeck
 import com.ichi2.anki.databinding.FragmentScheduleRemindersBinding
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.DeckId
+import com.ichi2.anki.requireAnkiActivity
 import com.ichi2.anki.reviewreminders.AddEditReminderDialog.Companion.registerAddEditReminderHandler
+import com.ichi2.anki.runCatching
 import com.ichi2.anki.services.AlarmManagerService
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.utils.ConfigAwareSingleFragmentActivity
 import com.ichi2.anki.utils.ext.getParcelableCompat
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.withProgress
 import dev.androidbroadcast.vbpd.viewBinding
 import kotlinx.coroutines.launch
+import kotlinx.parcelize.Parcelize
 import timber.log.Timber
 
 /**
@@ -60,12 +68,108 @@ class ScheduleRemindersFragment :
     Fragment(R.layout.fragment_schedule_reminders),
     BaseSnackbarBuilderProvider {
     /**
+     * Possible toolbar types that can be displayed with this fragment.
+     * @see FragmentHost
+     */
+    @Parcelize
+    enum class ToolbarType : Parcelable {
+        /** For if this fragment is hosted within an external activity which handles its own toolbar. */
+        EXTERNAL,
+
+        /** For if the toolbar should look like the collapsible ones present in the Settings screen. */
+        INTERNAL_COLLAPSIBLE,
+
+        /** For if the toolbar should be simple, fragment-owned, and non-collapsible. */
+        INTERNAL_NON_COLLAPSIBLE,
+    }
+
+    /**
+     * Possible hosts of this fragment. Certain stylistic changes need to be made based on where this
+     * fragment is opened from / nested within.
+     *
+     * TODO: Implement edge-to-edge for Settings, StudyOptionsActivity, and ConfigAwareSingleFragmentActivity.
+     * Then, remove the supportsEdgeToEdge property below and test this fragment's UI behavior 1) on both small and wide screens,
+     * 2) with all app display themes, and 3) from all possible locations this fragment can be opened from. In particular,
+     * make sure there is no weird clipping of the collapsible toolbar content scrim when this fragment is opened from the Settings screen upon scrolling.
+     *
+     * @param containerId The XML ID of the container in which this fragment is hosted.
+     * @param toolbarType The type of toolbar to display for this fragment.
+     * @param supportsEdgeToEdge Whether the host of this fragment currently supports edge-to-edge rendering.
+     * The legacy fitsSystemWindows property is deprecated and should be migrated away from.
+     */
+    @Parcelize
+    enum class FragmentHost(
+        @IdRes val containerId: Int,
+        val toolbarType: ToolbarType,
+        val supportsEdgeToEdge: Boolean,
+    ) : Parcelable {
+        /**
+         * App-wide review reminders editing screen accessed via Settings.
+         * @see com.ichi2.anki.preferences.PreferencesActivity
+         */
+        SETTINGS(
+            containerId = R.id.settings_container,
+            toolbarType = ToolbarType.INTERNAL_COLLAPSIBLE,
+            supportsEdgeToEdge = false,
+        ),
+
+        /**
+         * Side-by-side view of a specific deck's review reminders on large screens.
+         * @see com.ichi2.anki.DeckPicker.tryShowScheduleRemindersPanel
+         */
+        STUDY_OPTIONS_FRAGMENT(
+            containerId = R.id.studyoptions_fragment,
+            toolbarType = ToolbarType.INTERNAL_NON_COLLAPSIBLE,
+            supportsEdgeToEdge = true,
+        ),
+
+        /**
+         * Full-screen view of a specific deck's review reminders on small screens when launched after
+         * viewing the study options screen.
+         * @see com.ichi2.anki.StudyOptionsActivity
+         */
+        STUDY_OPTIONS_FRAME(
+            containerId = R.id.studyoptions_frame,
+            toolbarType = ToolbarType.EXTERNAL,
+            supportsEdgeToEdge = false,
+        ),
+
+        /**
+         * Full-screen view of a specific deck's review reminders on small screens when launched
+         * via long-pressing a deck in the DeckPicker.
+         * @see com.ichi2.anki.deckpicker.DeckPickerViewModel.scheduleReviewReminders
+         */
+        STANDALONE_ACTIVITY(
+            containerId = R.id.fragment_container,
+            toolbarType = ToolbarType.INTERNAL_NON_COLLAPSIBLE,
+            supportsEdgeToEdge = false,
+        ),
+    }
+
+    /**
      * Whether this fragment has been opened to edit all review reminders or just a specific deck's reminders.
+     * If no arguments have been passed to this fragment, defaults to [ReviewReminderScope.Global]. This default is a used
+     * code path, as opening this fragment from the Settings screen is accomplished via a preference_headers android:fragment field
+     * rather than a custom on-click handler for the sake of simplicity.
+     *
      * @see ReviewReminderScope
      */
     private val scheduleRemindersScope: ReviewReminderScope by lazy {
-        requireArguments().getParcelableCompat<ReviewReminderScope>(ARGS_SCOPE)
+        (arguments ?: Bundle()).getParcelableCompat<ReviewReminderScope>(ARGS_SCOPE)
             ?: ReviewReminderScope.Global
+    }
+
+    /**
+     * The [FragmentHost] of this fragment, which determines how certain UI elements are displayed.
+     * If no arguments have been passed to this fragment, defaults to [FragmentHost.SETTINGS]. This default is a used
+     * code path, as opening this fragment from the Settings screen is accomplished via a preference_headers android:fragment field
+     * rather than a custom on-click handler for the sake of simplicity.
+     *
+     * @see FragmentHost
+     */
+    private val host: FragmentHost by lazy {
+        (arguments ?: Bundle()).getParcelableCompat<FragmentHost>(ARGS_HOST)
+            ?: FragmentHost.SETTINGS
     }
 
     private val binding by viewBinding(FragmentScheduleRemindersBinding::bind)
@@ -102,29 +206,24 @@ class ScheduleRemindersFragment :
     ) {
         super.onViewCreated(view, savedInstanceState)
 
-        // Set up toolbar
-        reloadToolbarText()
-        (requireActivity() as AppCompatActivity).setSupportActionBar(binding.toolbar)
-        requireActivity().addMenuProvider(
-            object : MenuProvider {
-                override fun onCreateMenu(
-                    menu: Menu,
-                    menuInflater: MenuInflater,
-                ) {
-                    menuInflater.inflate(R.menu.schedule_reminders, menu)
-                }
+        // Set up root layout insets if the host of this fragment does not support edge-to-edge
+        if (host.supportsEdgeToEdge) {
+            binding.rootLayout.fitsSystemWindows = false // No need for legacy insets behavior
+        } else {
+            binding.rootLayout.fitsSystemWindows = true // Legacy insets behavior to avoid overlapping the status bar
+            if (host.toolbarType == ToolbarType.INTERNAL_NON_COLLAPSIBLE) {
+                // The legacy behavior is broken for the non-collapsible toolbar, also implement a manual workaround for it
+                setNonCollapsibleToolbarInsets()
+            }
+        }
 
-                override fun onMenuItemSelected(menuItem: MenuItem): Boolean =
-                    when (menuItem.itemId) {
-                        R.id.action_troubleshoot -> {
-                            openTroubleshootingScreen()
-                            true
-                        }
-                        else -> false
-                    }
-            },
-            viewLifecycleOwner,
-        )
+        // Set up toolbar
+        when (host.toolbarType) {
+            ToolbarType.EXTERNAL -> setupExternalActivityToolbar()
+            ToolbarType.INTERNAL_COLLAPSIBLE -> setupInternalFragmentToolbar(isCollapsible = true)
+            ToolbarType.INTERNAL_NON_COLLAPSIBLE -> setupInternalFragmentToolbar(isCollapsible = false)
+        }
+
         // Set up add button
         binding.floatingActionButtonAdd.setOnClickListener { addReminder() }
 
@@ -177,17 +276,116 @@ class ScheduleRemindersFragment :
         }
     }
 
-    private fun reloadToolbarText() {
-        Timber.d("Reloading toolbar text")
-        binding.toolbar.title = getString(R.string.schedule_reminders_do_not_translate)
-        when (val scope = scheduleRemindersScope) {
-            is ReviewReminderScope.Global -> {}
-            is ReviewReminderScope.DeckSpecific ->
-                launchCatchingTask {
-                    binding.toolbar.subtitle = scope.getDeckName()
-                }
+    override fun onDestroyView() {
+        troubleshootingSnackbar?.dismiss()
+        super.onDestroyView()
+    }
+
+    private fun setupExternalActivityToolbar() {
+        binding.appbar.isVisible = false
+        requireAnkiActivity().apply {
+            addMenuProvider(
+                menuProvider,
+                viewLifecycleOwner,
+                Lifecycle.State.RESUMED,
+            )
+            retrieveSubtitle { subtitle ->
+                setToolbarText(title = "Review reminders", subtitle = subtitle)
+            }
+            invalidateMenu()
         }
     }
+
+    private fun setupInternalFragmentToolbar(isCollapsible: Boolean) {
+        binding.appbar.isVisible = true
+        val toolbar =
+            if (isCollapsible) {
+                binding.collapsingToolbarLayout.isVisible = true
+                binding.nonCollapsibleToolbar.isVisible = false
+                binding.toolbar // Use collapsible toolbar
+            } else {
+                binding.collapsingToolbarLayout.isVisible = false
+                binding.nonCollapsibleToolbar.isVisible = true
+                binding.nonCollapsibleToolbar // Use non-collapsible toolbar
+            }
+
+        toolbar.apply {
+            addMenuProvider(
+                menuProvider,
+                viewLifecycleOwner,
+                Lifecycle.State.RESUMED,
+            )
+
+            title = "Review reminders"
+            retrieveSubtitle { subtitle = it }
+
+            setNavigationOnClickListener {
+                if (parentFragmentManager.backStackEntryCount > 0) {
+                    parentFragmentManager.popBackStack()
+                } else {
+                    requireActivity().onBackPressedDispatcher.onBackPressed()
+                }
+            }
+        }
+    }
+
+    /**
+     * The collapsible and non-collapsible toolbar are both located within the appbar.
+     * At most one is visible at a time (both are hidden if an external toolbar is being used).
+     * They must be nested within the same appbar because having more than one appbar causes issues with where
+     * the second one is rendered on the screen. If edge-to-edge is not implemented for the [FragmentHost] of this fragment
+     * yet, this fragment's layout and appbar has the fitsSystemWindows attribute set to ensure its
+     * child toolbar is rendered below the status bar.
+     *
+     * However, because the collapsible toolbar is before the non-collapsible toolbar in the layout file,
+     * it consumes the fitsSystemWindows inset first and does not pass any to the non-collapsible toolbar.
+     * Hence, we manually set the insets of the non-collapsible toolbar when it is visible
+     * via the modern setOnApplyWindowInsetsListener API. We cannot use this API for both the
+     * collapsible and non-collapsible toolbars and then omit fitsSystemWindows on the appbar. This is
+     * because doing so causes UI glitches within the status bar when the collapsible toolbar transitions
+     * between its expanded and collapsed states.
+     *
+     * This should only be used for the non-collapsible toolbar if edge-to-edge is not implemented on the host yet.
+     */
+    private fun setNonCollapsibleToolbarInsets() {
+        ViewCompat.setOnApplyWindowInsetsListener(binding.rootLayout) { _, insets ->
+            val bars = insets.getInsets(statusBars() or displayCutout())
+            binding.appbar.updatePadding(left = bars.left, top = bars.top, right = bars.right)
+            insets
+        }
+    }
+
+    private fun retrieveSubtitle(setSubtitle: (String?) -> Unit) {
+        viewLifecycleOwner.lifecycleScope.launch {
+            requireActivity().runCatching {
+                val subtitle =
+                    when (val scope = scheduleRemindersScope) {
+                        is ReviewReminderScope.Global -> null
+                        is ReviewReminderScope.DeckSpecific -> scope.getDeckName()
+                    }
+                setSubtitle(subtitle)
+            }
+        }
+    }
+
+    private val menuProvider: MenuProvider =
+        object : MenuProvider {
+            override fun onCreateMenu(
+                menu: Menu,
+                menuInflater: MenuInflater,
+            ) {
+                menuInflater.inflate(R.menu.schedule_reminders, menu)
+            }
+
+            override fun onMenuItemSelected(menuItem: MenuItem): Boolean =
+                when (menuItem.itemId) {
+                    R.id.action_troubleshoot -> {
+                        openTroubleshootingScreen()
+                        true
+                    }
+                    else -> false
+                }
+        }
 
     /**
      * Fetch all reminders from the database and put them into the RecyclerView.
@@ -371,9 +569,8 @@ class ScheduleRemindersFragment :
         troubleshootingSnackbar?.dismiss()
         parentFragmentManager.commit {
             replace(
-                R.id.fragment_container,
-                ReminderTroubleshootingFragment(),
-                SingleFragmentActivity.FRAGMENT_TAG,
+                host.containerId,
+                ReminderTroubleshootingFragment.newInstance(host),
             )
             addToBackStack(null)
         }
@@ -427,6 +624,11 @@ class ScheduleRemindersFragment :
         private const val ARGS_SCOPE = "scope"
 
         /**
+         * Arguments key for passing information about the [FragmentHost] to this fragment.
+         */
+        private const val ARGS_HOST = "host"
+
+        /**
          * Wrapper for database access in this fragment.
          * Shows an error dialog via [ReviewRemindersDatabase.checkDeserializationErrors] if there are deserialization errors.
          * Shows a progress dialog if database access takes a long time.
@@ -437,7 +639,11 @@ class ScheduleRemindersFragment :
             }
 
         /**
-         * Creates an intent to launch this fragment in a [SingleFragmentActivity].
+         * Creates an intent to launch this fragment in a [ConfigAwareSingleFragmentActivity].
+         * We should not manually handle orientation changes because the dialogs nested within this
+         * fragment are complicated and best handled by the default behavior. Hence, we must use the
+         * config-aware version of SingleFragmentActivity.
+         *
          * @param context
          * @param scope The editing scope of this fragment.
          * @return The new intent.
@@ -446,15 +652,39 @@ class ScheduleRemindersFragment :
             context: Context,
             scope: ReviewReminderScope,
         ): Intent =
-            SingleFragmentActivity
+            ConfigAwareSingleFragmentActivity
                 .getIntent(
                     context,
                     ScheduleRemindersFragment::class,
                     Bundle().apply {
                         putParcelable(ARGS_SCOPE, scope)
+                        putParcelable(ARGS_HOST, FragmentHost.STANDALONE_ACTIVITY)
                     },
                 ).apply {
                     Timber.i("launching ScheduleRemindersFragment for %s scope", scope)
                 }
+
+        /**
+         * Returns an instance of this fragment for a specific [ReviewReminderScope] and [FragmentHost].
+         * @param scope The editing scope of this fragment.
+         * @param host Where this fragment is embedded; determines some UI behaviour.
+         * @return The new fragment instance.
+         */
+        fun newInstance(
+            scope: ReviewReminderScope,
+            host: FragmentHost,
+        ): ScheduleRemindersFragment =
+            ScheduleRemindersFragment().apply {
+                arguments =
+                    Bundle().apply {
+                        putParcelable(ARGS_SCOPE, scope)
+                        putParcelable(ARGS_HOST, host)
+                    }
+                Timber.i(
+                    "Creating ScheduleRemindersFragment for %s scope, host=%s",
+                    scope,
+                    host.name,
+                )
+            }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
@@ -35,7 +35,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.commit
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.snackbar.Snackbar
@@ -54,6 +53,7 @@ import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.utils.ConfigAwareSingleFragmentActivity
 import com.ichi2.anki.utils.ext.getParcelableCompat
+import com.ichi2.anki.utils.ext.launchCollectionInLifecycleScope
 import com.ichi2.anki.utils.showDialogFragment
 import com.ichi2.anki.withProgress
 import dev.androidbroadcast.vbpd.viewBinding
@@ -224,34 +224,8 @@ class ScheduleRemindersFragment :
             ToolbarType.INTERNAL_NON_COLLAPSIBLE -> setupInternalFragmentToolbar(isCollapsible = false)
         }
 
-        // Set up add button
         binding.floatingActionButtonAdd.setOnClickListener { addReminder() }
-
-        // Troubleshoot snackbar: shown persistently when checks find a warning/error.
-        // Tapping "Fix" opens the full troubleshooting screen.
-        lifecycleScope.launch {
-            troubleshootingViewModel.state
-                .flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
-                .collect { state ->
-                    val message =
-                        when (state.summaryStatus) {
-                            SummaryStatus.Ok, SummaryStatus.Warning -> {
-                                troubleshootingSnackbar?.dismiss()
-                                troubleshootingSnackbar = null
-                                return@collect
-                            }
-                            SummaryStatus.Error -> "Reminders are unavailable"
-                        }
-                    if (troubleshootingSnackbar?.isShown == true) {
-                        troubleshootingSnackbar?.setText(message)
-                        return@collect
-                    }
-                    troubleshootingSnackbar =
-                        showSnackbar(text = message, duration = Snackbar.LENGTH_INDEFINITE) {
-                            setAction("Fix") { openTroubleshootingScreen() }
-                        }
-                }
-        }
+        troubleshootingViewModel.state.launchCollectionInLifecycleScope(::setupTroubleshootingSnackbar)
 
         // Set up recycler view
         binding.recyclerView.layoutManager = LinearLayoutManager(requireContext())
@@ -279,6 +253,30 @@ class ScheduleRemindersFragment :
     override fun onDestroyView() {
         troubleshootingSnackbar?.dismiss()
         super.onDestroyView()
+    }
+
+    /**
+     * Sets up the troubleshooting snackbar which is shown persistently when checks find a warning/error.
+     * Tapping "Fix" opens the full troubleshooting screen.
+     */
+    private fun setupTroubleshootingSnackbar(state: ReminderTroubleshootingState) {
+        val message =
+            when (state.summaryStatus) {
+                SummaryStatus.Ok, SummaryStatus.Warning -> {
+                    troubleshootingSnackbar?.dismiss()
+                    troubleshootingSnackbar = null
+                    return
+                }
+                SummaryStatus.Error -> "Reminders are unavailable"
+            }
+        if (troubleshootingSnackbar?.isShown == true) {
+            troubleshootingSnackbar?.setText(message)
+            return
+        }
+        troubleshootingSnackbar =
+            showSnackbar(text = message, duration = Snackbar.LENGTH_INDEFINITE) {
+                setAction("Fix") { openTroubleshootingScreen() }
+            }
     }
 
     private fun setupExternalActivityToolbar() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
@@ -54,7 +54,7 @@ import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.utils.ConfigAwareSingleFragmentActivity
 import com.ichi2.anki.utils.ext.getParcelableCompat
-import com.ichi2.anki.utils.ext.showDialogFragment
+import com.ichi2.anki.utils.showDialogFragment
 import com.ichi2.anki.withProgress
 import dev.androidbroadcast.vbpd.viewBinding
 import kotlinx.coroutines.launch
@@ -584,7 +584,7 @@ class ScheduleRemindersFragment :
         Timber.d("Adding new review reminder")
         val dialogMode = AddEditReminderDialog.DialogMode.Add(scheduleRemindersScope)
         val dialog = AddEditReminderDialog.getInstance(dialogMode)
-        showDialogFragment(dialog)
+        childFragmentManager.showDialogFragment(dialog)
     }
 
     /**
@@ -595,7 +595,7 @@ class ScheduleRemindersFragment :
         Timber.d("Editing review reminder: %s", reminder.id)
         val dialogMode = AddEditReminderDialog.DialogMode.Edit(reminder)
         val dialog = AddEditReminderDialog.getInstance(dialogMode)
-        showDialogFragment(dialog)
+        childFragmentManager.showDialogFragment(dialog)
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
@@ -32,7 +32,6 @@ import androidx.fragment.app.commit
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.CollectionManager.withCol
@@ -156,16 +155,7 @@ class ScheduleRemindersFragment :
         }
 
         // Set up recycler view
-        val layoutManager = LinearLayoutManager(requireContext())
-        binding.recyclerView.layoutManager = layoutManager
-        binding.recyclerView.addItemDecoration(
-            DividerItemDecoration(
-                requireContext(),
-                layoutManager.orientation,
-            ),
-        )
-
-        // Set up adapter, pass functionality to it
+        binding.recyclerView.layoutManager = LinearLayoutManager(requireContext())
         adapter =
             ScheduleRemindersAdapter(
                 ::retrieveDeckNameFromID,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/Dialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/Dialog.kt
@@ -45,3 +45,10 @@ fun showDialogFragmentImpl(
     newFragment.show(ft, DIALOG_FRAGMENT_TAG)
     manager.executePendingTransactions()
 }
+
+/**
+ * Convenience function for calling [showDialogFragmentImpl] with a certain [FragmentManager],
+ * as opposed to [com.ichi2.anki.utils.ext.showDialogFragment], which always calls it with the activity-level
+ * support fragment manager. This is useful when you want a dialog to be scoped to a fragment's lifecycle.
+ */
+fun FragmentManager.showDialogFragment(newFragment: DialogFragment) = showDialogFragmentImpl(this, newFragment)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Flow.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Flow.kt
@@ -53,7 +53,7 @@ fun <T> Flow<T>.launchCollectionInLifecycleScope(block: suspend (T) -> Unit) {
         fragment.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
             this@launchCollectionInLifecycleScope.collect {
                 if (isRobolectric) {
-                    HandlerUtils.postOnNewHandler { runBlocking { block(it) } }
+                    fragment.lifecycle.postOnNewHandlerIfAlive { block(it) }
                 } else {
                     block(it)
                 }
@@ -78,10 +78,7 @@ fun <T> Flow<T>.launchCollectionInLifecycleScope(
         activity.lifecycle.repeatOnLifecycle(state) {
             this@launchCollectionInLifecycleScope.collect {
                 if (isRobolectric) {
-                    // hack: lifecycleScope/runOnUiThread do not handle our
-                    // test dispatcher overriding both IO and Main
-                    // in tests, waitForAsyncTasksToComplete may be required.
-                    HandlerUtils.postOnNewHandler { runBlocking { block(it) } }
+                    activity.lifecycle.postOnNewHandlerIfAlive { block(it) }
                 } else {
                     block(it)
                 }
@@ -100,11 +97,24 @@ fun <T> StateFlow<T>.launchCollectionInLifecycleScope(block: suspend (T) -> Unit
                 if (lastValue == it) return@collect
                 lastValue = it
                 if (isRobolectric) {
-                    HandlerUtils.postOnNewHandler { runBlocking { block(it) } }
+                    activity.lifecycle.postOnNewHandlerIfAlive { block(it) }
                 } else {
                     block(it)
                 }
             }
+        }
+    }
+}
+
+/**
+ * Hack: lifecycleScope/runOnUiThread do not handle our test dispatcher overriding both IO and Main.
+ * In tests, waitForAsyncTasksToComplete may be required.
+ */
+private fun Lifecycle.postOnNewHandlerIfAlive(block: suspend () -> Unit) {
+    val lifecycle = this
+    HandlerUtils.postOnNewHandler {
+        if (lifecycle.currentState != Lifecycle.State.DESTROYED) {
+            runBlocking { block() }
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Fragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Fragment.kt
@@ -68,12 +68,14 @@ val Fragment.isCompactWidth: Boolean
  */
 fun Fragment.onWindowFocusChanged(action: (hasFocus: Boolean) -> Unit) {
     val listener = OnWindowFocusChangeListener(action)
-    val viewTreeObserver = requireView().viewTreeObserver
-    viewTreeObserver.addOnWindowFocusChangeListener(listener)
+    requireView().viewTreeObserver.addOnWindowFocusChangeListener(listener)
     viewLifecycleOwner.lifecycle.addObserver(
         object : DefaultLifecycleObserver {
             override fun onDestroy(owner: LifecycleOwner) {
-                viewTreeObserver.removeOnWindowFocusChangeListener(listener)
+                view
+                    ?.viewTreeObserver
+                    ?.takeIf { it.isAlive }
+                    ?.removeOnWindowFocusChangeListener(listener)
             }
         },
     )

--- a/AnkiDroid/src/main/res/layout/activity_study_options.xml
+++ b/AnkiDroid/src/main/res/layout/activity_study_options.xml
@@ -2,6 +2,7 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout android:id="@+id/root_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     xmlns:android="http://schemas.android.com/apk/res/android">
             <LinearLayout
                 android:layout_width="match_parent"

--- a/AnkiDroid/src/main/res/layout/fragment_reminder_troubleshooting.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_reminder_troubleshooting.xml
@@ -15,10 +15,6 @@
         app:navigationContentDescription="@string/abc_action_bar_up_description"
         app:title="Troubleshooting" />
 
-    <com.google.android.material.divider.MaterialDivider
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
-
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent">

--- a/AnkiDroid/src/main/res/layout/fragment_reminder_troubleshooting.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_reminder_troubleshooting.xml
@@ -2,13 +2,14 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?android:attr/colorBackground"
     android:orientation="vertical">
 
     <com.google.android.material.appbar.MaterialToolbar
-        android:id="@+id/toolbar"
+        android:id="@+id/troubleshooting_toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:navigationIcon="?attr/homeAsUpIndicator"

--- a/AnkiDroid/src/main/res/layout/fragment_schedule_reminders.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_schedule_reminders.xml
@@ -7,63 +7,81 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <LinearLayout
-        android:id="@+id/root_linear_layout"
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true">
+
+        <!-- Collapsible toolbar - Whether the toolbar is collapsible is decided programmatically -->
+        <com.google.android.material.appbar.CollapsingToolbarLayout
+            android:id="@+id/collapsingToolbarLayout"
+            style="?collapsingToolbarLayoutMediumStyle"
+            android:layout_width="match_parent"
+            android:layout_height="?collapsingToolbarLayoutMediumSize"
+            app:expandedTitleMarginTop="80dp"
+            app:expandedSubtitleTextAppearance="@style/TextAppearance.AnkiDroid.TopAppBar.Subtitle"
+            app:layout_scrollFlags="scroll|exitUntilCollapsed|snap"
+            app:toolbarId="@id/toolbar">
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                app:layout_collapseMode="pin"
+                app:navigationContentDescription="@string/abc_action_bar_up_description"
+                app:navigationIcon="?attr/homeAsUpIndicator"
+                tools:title="Review reminders"/>
+
+        </com.google.android.material.appbar.CollapsingToolbarLayout>
+
+        <!-- Non-collapsible toolbar - Whether the toolbar is collapsible is decided programmatically -->
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/non_collapsible_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:navigationContentDescription="@string/abc_action_bar_up_description"
+            app:navigationIcon="?attr/homeAsUpIndicator"
+            tools:title="Review reminders"/>
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="?android:attr/colorBackground"
+        android:overScrollFooter="@color/transparent"
+        android:clipToPadding="false"
+        android:drawSelectorOnTop="true"
+        android:paddingBottom="84dp"
+        android:scrollbars="vertical"
+        android:contentDescription="List of scheduled review reminders"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:listitem="@layout/item_schedule_reminders"
+        tools:ignore="HardcodedText" />
+
+    <LinearLayout
+        android:id="@+id/no_reminders_placeholder"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center_vertical"
         android:orientation="vertical">
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
+        <ImageView
+            android:layout_width="96dp"
+            android:layout_height="96dp"
+            android:layout_marginBottom="24dp"
+            android:layout_gravity="center_horizontal"
+            app:srcCompat="@drawable/outline_notifications_off_24" />
+
+        <com.google.android.material.textview.MaterialTextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:navigationContentDescription="@string/abc_action_bar_up_description"
-            android:background="@drawable/browser_heading_bottom_divider"
-            app:navigationIcon="?attr/homeAsUpIndicator" />
-
-        <FrameLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/recycler_view"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:background="?android:attr/colorBackground"
-                android:overScrollFooter="@color/transparent"
-                android:clipToPadding="false"
-                android:drawSelectorOnTop="true"
-                android:paddingBottom="84dp"
-                android:scrollbars="vertical"
-                android:contentDescription="List of scheduled review reminders"
-                tools:listitem="@layout/item_schedule_reminders"
-                tools:ignore="HardcodedText" />
-
-            <LinearLayout
-                android:id="@+id/no_reminders_placeholder"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:gravity="center_vertical"
-                android:orientation="vertical">
-
-                <ImageView
-                    android:layout_width="96dp"
-                    android:layout_height="96dp"
-                    android:layout_marginBottom="24dp"
-                    android:layout_gravity="center_horizontal"
-                    app:srcCompat="@drawable/outline_notifications_off_24" />
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="8dp"
-                    android:gravity="center"
-                    android:text="@string/you_have_no_review_reminders"
-                    style="@style/TextAppearance.AppCompat.Medium" />
-
-            </LinearLayout>
-
-        </FrameLayout>
+            android:layout_marginBottom="8dp"
+            android:gravity="center"
+            android:text="@string/you_have_no_review_reminders"
+            style="@style/TextAppearance.AppCompat.Medium" />
 
     </LinearLayout>
 

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -233,6 +233,8 @@
 
     <style name="TextAppearance.AnkiDroid.TopAppBar.Title" parent="TextAppearance.Material3.TitleMedium" />
 
+    <style name="TextAppearance.AnkiDroid.TopAppBar.Subtitle" parent="TextAppearance.Material3.ActionBar.Subtitle" />
+
     <style name="AnkiDroid.AlertDialog.Body.Text" parent="MaterialAlertDialog.Material3.Body.Text">
         <!-- The default style uses onSurfaceVariant, which isn't defined yet -->
         <item name="android:textColor">?android:attr/textColor</item>

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -74,6 +74,7 @@
 
     <!-- Review Reminders -->
     <com.ichi2.preferences.HeaderPreference
+        android:fragment="com.ichi2.anki.reviewreminders.ScheduleRemindersFragment"
         android:key="@string/pref_review_reminders_screen_key"
         android:title="Review reminders"
         android:icon="@drawable/ic_notifications"

--- a/AnkiDroid/src/main/res/xml/preferences_review_reminders.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_review_reminders.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ The search functionality in the settings screen (HeaderFragment, getFragmentFromXmlRes) requires
+  ~ @XmlRes resource IDs as a key when the user is performing searches. However, ScheduleRemindersFragment
+  ~ is not a PreferenceFragmentCompat due to having a lot of custom logic and UI, so it does not have one. This file serves as a workaround
+  ~ so that searching for review reminder settings will work while still allowing ScheduleRemindersFragment
+  ~ to be a custom standalone fragment rather than a rigid PreferenceFragmentCompat. The preference screen
+  ~ defined here is never actually displayed to the user and is only for searching and indexing purposes.
+  -->
+<PreferenceScreen />

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -468,7 +468,7 @@ class DeckPickerTest : RobolectricTest() {
 
             Prefs.newReviewRemindersEnabled = true
             val scheduleReminders = selectContextMenuOptionForActivity(DeckPickerContextMenuOption.SCHEDULE_REMINDERS, didA)
-            assertEquals("com.ichi2.anki.SingleFragmentActivity", scheduleReminders.component!!.className)
+            assertEquals("com.ichi2.anki.utils.ConfigAwareSingleFragmentActivity", scheduleReminders.component!!.className)
             onBackPressedDispatcher.onBackPressed()
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/AddEditReminderDialogScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/AddEditReminderDialogScreenshotTest.kt
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Eric Li <ericli3690@gmail.com>
+
+package com.ichi2.anki.reviewreminders
+
+import android.view.View
+import androidx.fragment.app.FragmentActivity
+import com.ichi2.anki.R
+import com.ichi2.anki.ScreenshotTest
+import com.ichi2.anki.reviewreminders.AddEditReminderDialog.DialogMode
+import org.junit.Test
+import org.robolectric.Robolectric.buildActivity
+
+class AddEditReminderDialogScreenshotTest : ScreenshotTest() {
+    @Test
+    fun `add mode`() {
+        val activity = buildActivity(FragmentActivity::class.java).setup().get()
+        AddEditReminderDialog
+            .getInstance(DialogMode.Add(ReviewReminderScope.Global))
+            .show(activity.supportFragmentManager, "dialog")
+        advanceRobolectricLooper()
+        captureScreen("add_mode")
+
+        val dialogFragment =
+            activity.supportFragmentManager.findFragmentByTag("dialog") as AddEditReminderDialog
+        dialogFragment.dialog?.findViewById<View>(R.id.add_edit_reminder_advanced_dropdown)?.performClick()
+        advanceRobolectricLooper()
+        captureScreen("add_mode_advanced_open")
+    }
+
+    @Test
+    fun `edit mode`() {
+        val deckId = addDeck("Test Deck")
+        val reminder =
+            ReviewReminder.createReviewReminder(
+                time = ReviewReminderTime(9, 0),
+                scope = ReviewReminderScope.DeckSpecific(deckId),
+                onlyNotifyIfNoReviews = true,
+            )
+        val activity = buildActivity(FragmentActivity::class.java).setup().get()
+        AddEditReminderDialog
+            .getInstance(DialogMode.Edit(reminder))
+            .show(activity.supportFragmentManager, "dialog")
+        advanceRobolectricLooper()
+        captureScreen("edit_mode")
+
+        val dialogFragment =
+            activity.supportFragmentManager.findFragmentByTag("dialog") as AddEditReminderDialog
+        dialogFragment.dialog?.findViewById<View>(R.id.add_edit_reminder_advanced_dropdown)?.performClick()
+        advanceRobolectricLooper()
+        captureScreen("edit_mode_advanced_open")
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersScreenshotTest.kt
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Eric Li <ericli3690@gmail.com>
+
+package com.ichi2.anki.reviewreminders
+
+import android.content.Intent
+import androidx.annotation.IdRes
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.commit
+import androidx.test.core.app.ActivityScenario
+import com.google.android.material.appbar.AppBarLayout
+import com.ichi2.anki.R
+import com.ichi2.anki.ScreenshotTest
+import com.ichi2.anki.StudyOptionsActivity
+import com.ichi2.anki.preferences.PreferencesActivity
+import com.ichi2.anki.preferences.PreferencesFragment
+import com.ichi2.anki.reviewreminders.ScheduleRemindersFragment.FragmentHost
+import com.ichi2.anki.utils.ConfigAwareSingleFragmentActivity
+import com.ichi2.anki.withDeckPicker
+import com.ichi2.testutils.BackupManagerTestUtilities
+import org.junit.Test
+
+/**
+ * Covers all [FragmentHost] configurations of the fragment.
+ */
+class ReviewRemindersScreenshotTest : ScreenshotTest() {
+    @Test
+    fun `settings host`() {
+        captureSettingsHost("settingsHost")
+    }
+
+    @Test
+    fun `settings host tablet`() {
+        setTabletQualifiers()
+        // The toolbar is not collapsible on wide screens
+        captureSettingsHost("settingsHostTablet", captureScrolled = false)
+    }
+
+    private fun captureSettingsHost(
+        prefix: String,
+        captureScrolled: Boolean = true,
+    ) {
+        ActivityScenario.launch<PreferencesActivity>(PreferencesActivity.getIntent(targetContext)).use { scenario ->
+            scenario.onActivity { activity ->
+                val fm = (activity.fragment as PreferencesFragment).childFragmentManager
+                commitScheduleRemindersAndCapture(
+                    fragmentManager = fm,
+                    containerId = R.id.settings_container,
+                    host = FragmentHost.SETTINGS,
+                    scope = ReviewReminderScope.Global,
+                    prefix = prefix,
+                )
+                if (captureScrolled) {
+                    fm
+                        .findFragmentById(R.id.settings_container)
+                        ?.view
+                        ?.findViewById<AppBarLayout>(R.id.appbar)
+                        ?.setExpanded(false, false)
+                    advanceRobolectricLooper()
+                    captureScreen("${prefix}_scheduleReminders_scrolled")
+                }
+                commitTroubleshootingAndCapture(
+                    fragmentManager = fm,
+                    containerId = R.id.settings_container,
+                    host = FragmentHost.SETTINGS,
+                    prefix = prefix,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `study options fragment host`() {
+        setTabletQualifiers()
+        withDeckPicker(deckCount = 1, withCards = true) { deckPicker ->
+            val deckId = addDeck("Test Deck")
+            commitScheduleRemindersAndCapture(
+                fragmentManager = deckPicker.supportFragmentManager,
+                containerId = R.id.studyoptions_fragment,
+                host = FragmentHost.STUDY_OPTIONS_FRAGMENT,
+                scope = ReviewReminderScope.DeckSpecific(deckId),
+                prefix = "studyOptionsFragmentHost",
+            )
+            commitTroubleshootingAndCapture(
+                fragmentManager = deckPicker.supportFragmentManager,
+                containerId = R.id.studyoptions_fragment,
+                host = FragmentHost.STUDY_OPTIONS_FRAGMENT,
+                prefix = "studyOptionsFragmentHost",
+            )
+        }
+        BackupManagerTestUtilities.reset()
+    }
+
+    @Test
+    fun `study options frame host`() {
+        val deckId = addDeck("Test Deck")
+        ActivityScenario
+            .launch<StudyOptionsActivity>(
+                Intent(targetContext, StudyOptionsActivity::class.java),
+            ).use { scenario ->
+                scenario.onActivity { activity ->
+                    commitScheduleRemindersAndCapture(
+                        fragmentManager = activity.supportFragmentManager,
+                        containerId = R.id.studyoptions_frame,
+                        host = FragmentHost.STUDY_OPTIONS_FRAME,
+                        scope = ReviewReminderScope.DeckSpecific(deckId),
+                        prefix = "studyOptionsFrameHost",
+                    )
+                    commitTroubleshootingAndCapture(
+                        fragmentManager = activity.supportFragmentManager,
+                        containerId = R.id.studyoptions_frame,
+                        host = FragmentHost.STUDY_OPTIONS_FRAME,
+                        prefix = "studyOptionsFrameHost",
+                    )
+                }
+            }
+    }
+
+    @Test
+    fun `standalone activity host`() {
+        val intent = ScheduleRemindersFragment.getIntent(targetContext, ReviewReminderScope.Global)
+        ActivityScenario.launch<ConfigAwareSingleFragmentActivity>(intent).use { scenario ->
+            advanceRobolectricLooper()
+            scenario.onActivity { activity ->
+                captureScreen("standaloneActivityHost_scheduleReminders")
+                commitTroubleshootingAndCapture(
+                    fragmentManager = activity.supportFragmentManager,
+                    containerId = R.id.fragment_container,
+                    host = FragmentHost.STANDALONE_ACTIVITY,
+                    prefix = "standaloneActivityHost",
+                )
+            }
+        }
+    }
+
+    private fun commitScheduleRemindersAndCapture(
+        fragmentManager: FragmentManager,
+        @IdRes containerId: Int,
+        host: FragmentHost,
+        scope: ReviewReminderScope,
+        prefix: String,
+    ) {
+        fragmentManager.commit {
+            replace(containerId, ScheduleRemindersFragment.newInstance(scope, host))
+        }
+        advanceRobolectricLooper()
+        captureScreen("${prefix}_scheduleReminders")
+    }
+
+    private fun commitTroubleshootingAndCapture(
+        fragmentManager: FragmentManager,
+        @IdRes containerId: Int,
+        host: FragmentHost,
+        prefix: String,
+    ) {
+        fragmentManager.commit {
+            replace(containerId, ReminderTroubleshootingFragment.newInstance(host))
+            addToBackStack(null)
+        }
+        advanceRobolectricLooper()
+        captureScreen("${prefix}_troubleshooting")
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Sonnet 4.5, Composer 2.5 (initial rough drafts for tests)

## Purpose / Description
This change was originally proposed by @BrayanDSO. Thanks Brayan!

> Also, after https://github.com/ankidroid/Anki-Android/pull/18734 got in, you probably are capable to stop using a separate Activity for the ScheduleReminders fragment

- https://discord.com/channels/368267295601983490/1370606512598155404/1393544381528674305

This took a long time to get right and required a lot of iteration. I had to scrap a lot of approaches. I also ran into a lot of issues that I consider out of scope with regards to this PR. I've added TODO comments and might create some issues.

---

ScheduleReminders can be hosted in multiple places, each of which presents their own unique UI challenges:

1. Long-pressing a deck from DeckPicker: On small screens, there is no suitable activity currently available, and so we should launch one to host ScheduleRemindersFragment in the form of SingleFragmentActivity. On large screens, there MAY be a right-side panel available (it is hidden in the edge case where the collection is empty); the UI looks cleanest if it is used.
2. Clicking on the "bell" icon from StudyOptionsFragment: On small screens, StudyOptionsActivity is currently active, and so it should be used as the host rather than launching a new activity. However, it manages an external toolbar and so using an internal toolbar would not work. We need to latch onto the external support action bar and modify it. On large screens, the right-side panel is available similar to option 1 if the collection is non-empty.
3. The screen may be launched from Settings, in which case the user is inspecting all reminders across all decks. Here, it should match the style of the other Settings Preferences screens, i.e. a collapsing toolbar, and should align whether on a small screen or large screen.

https://github.com/user-attachments/assets/28326281-3fdd-4cfc-be8d-f6c54de2caec

https://github.com/user-attachments/assets/c433a382-f2c8-4c48-8af3-4749c6f08eb5

## Fixes
* Fixes long-standing UI inconsistencies for review reminders.

## Approach
Previously:
- The ScheduleRemindersFragment was always launched in a SingleFragmentActivity.
- This made it stylistically stick out like a sore thumb inside the Settings menu, particularly on wide screens.
- It unnecessarily creates new activities all over the place when it could use pre-existing activities, like StudyOptionsActivity, that are already active.

Now:
- The ScheduleRemindersFragment renders using the current available activity if possible, modifying its styling and toolbar as necessary.
- Logic for doing so is encapsulated in FragmentHost and ToolbarType. In my opinion, this is the cleanest way to handle the various ways ScheduleRemindersFragment can be launched, keeping all logic centralized within the file and maintaining a single source of truth.

## How Has This Been Tested?
- Permission requesting dialog works as before.
- The permission requesting Snackbar auto-dismisses upon navigating away from the fragment.
- Searching for "Notifications" or "Review Reminders" in settings locates the setting.
- Rotation of all screens works.
- Visuals on all screens have no visual glitches.
- Creating, updating, viewing, and deleting reminders works.
- All four app themes work.
- When the collection is empty and the right-hand study options fragment panel is hidden on a tablet, long-clicking to open schedule reminders opens it in SingleFragmentActivity.

- Tested on a emulated Google Pixel, API 25.
- Tested on a physical Lenovo Tab M11, API 35.
- Tested on a physical Samsung S23, API 36.

## Learning
- See the TODO comments.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)