### PR TITLE
feat: Compose setup for project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,3 +27,9 @@ ktlint_standard_when-entry-bracing = disabled
 # https://pinterest.github.io/ktlint/latest/rules/standard/#blank-line-between-when-conditions
 ktlint_standard_blank-line-between-when-conditions = disabled
 
+# Jetpack Compose convention: @Composable functions are named in PascalCase
+# (they return Unit and behave like UI declarations rather than regular functions).
+# Tell ktlint's function-naming rule to skip any function annotated @Composable.
+# https://pinterest.github.io/ktlint/latest/rules/standard/#function-naming
+ktlint_function_naming_ignore_when_annotated_with = Composable
+

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -2,28 +2,6 @@
   <code_scheme name="Project" version="173">
     <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
     <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
-    <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
-      <value />
-    </option>
-    <option name="IMPORT_LAYOUT_TABLE">
-      <value>
-        <package name="android" withSubpackages="true" static="false" />
-        <emptyLine />
-        <package name=" com" withSubpackages="true" static="false" />
-        <emptyLine />
-        <package name=" junit" withSubpackages="true" static="false" />
-        <emptyLine />
-        <package name=" net" withSubpackages="true" static="false" />
-        <emptyLine />
-        <package name=" org" withSubpackages="true" static="false" />
-        <emptyLine />
-        <package name=" java" withSubpackages="true" static="false" />
-        <emptyLine />
-        <package name=" javax" withSubpackages="true" static="false" />
-        <emptyLine />
-        <package name="" withSubpackages="true" static="true" />
-      </value>
-    </option>
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="BLANK_LINES_AROUND_INITIALIZER" value="2" />

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'org.jetbrains.kotlin.plugin.parcelize'
     alias(libs.plugins.androidx.baselineprofile)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.keeper)
     alias(libs.plugins.roborazzi)
     id 'idea'
@@ -70,6 +71,7 @@ android {
         aidl = true
         viewBinding = true
         resValues = true
+        compose = true
     }
 
     if (rootProject.testReleaseBuild) {
@@ -462,6 +464,17 @@ dependencies {
     implementation(libs.google.analytics.kt)
 
     implementation libs.androidx.activity
+    // TODO: hoist the Compose enablement (kotlin.compose plugin, buildFeatures.compose,
+    // and the dependencies below) into a convention plugin under `buildSrc/` once the
+    // Kotlin-DSL migration of this build script lands
+    implementation libs.androidx.activity.compose
+    implementation platform(libs.androidx.compose.bom)
+    implementation libs.androidx.compose.ui
+    implementation libs.androidx.compose.ui.tooling.preview
+    implementation libs.androidx.compose.material3
+    implementation libs.androidx.lifecycle.viewmodel.compose
+    implementation libs.androidx.lifecycle.runtime.compose
+    debugImplementation libs.androidx.compose.ui.tooling
     implementation libs.androidx.annotation
     implementation libs.androidx.appcompat
     implementation libs.androidx.browser
@@ -592,5 +605,11 @@ dependencies {
     // Required so the ExperimentalCoroutinesApi opt-in (applied globally) doesn't cause
     // an "unresolved" warning, which is treated as an error due to allWarningsAsErrors
     testFixturesImplementation libs.kotlinx.coroutines.core
+    // The Kotlin Compose Compiler plugin attaches to every Kotlin compilation in the
+    // module including testFixtures, which has no @Composable code and refuses to
+    // run unless the Compose Runtime is on the classpath. compileOnly satisfies the
+    // plugin's version check without shipping the runtime in the testFixtures output.
+    testFixturesCompileOnly platform(libs.androidx.compose.bom)
+    testFixturesCompileOnly libs.androidx.compose.runtime
 
 }

--- a/AnkiDroid/src/main/java/com/ichi2/compose/theme/Dimensions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compose/theme/Dimensions.kt
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Ashish Yadav <mailtoashish693@gmail.com>
+
+package com.ichi2.compose.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Spacing scale for Compose screens, read the same way as the Material 3 slots
+ * (`MaterialTheme.dimensions.space200`) Material 3 ships no spacing tokens of
+ * its own, so this fills that gap.
+ *
+ * [screenEdge] and [sectionGap] are semantic aliases for the two steps used most
+ * often at screen level; reach for the `spaceNNN` tokens elsewhere.
+ */
+@Immutable
+data class Dimensions(
+    val space25: Dp = 2.dp,
+    val space50: Dp = 4.dp,
+    val space100: Dp = 8.dp,
+    val space150: Dp = 12.dp,
+    val space200: Dp = 16.dp,
+    val space300: Dp = 24.dp,
+    val space400: Dp = 32.dp,
+    val space800: Dp = 64.dp,
+    val screenEdge: Dp = 24.dp,
+    val sectionGap: Dp = 16.dp,
+)
+
+/**
+ * Provides the active [Dimensions] down the Compose tree. Prefer reading via
+ * [MaterialTheme.dimensions]; use this directly only to override tokens in a
+ * `CompositionLocalProvider` (previews, tests).
+ */
+val LocalDimensions = staticCompositionLocalOf { Dimensions() }
+
+/**
+ * Access the spacing scale the same way as [MaterialTheme.colorScheme] or
+ * [MaterialTheme.typography].
+ */
+val MaterialTheme.dimensions: Dimensions
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalDimensions.current

--- a/AnkiDroid/src/main/java/com/ichi2/compose/theme/Theme.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compose/theme/Theme.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
@@ -36,7 +37,9 @@ import com.ichi2.anki.R
 fun AnkiDroidTheme(content: @Composable () -> Unit) {
     val context = LocalContext.current
     val colorScheme = remember(context) { context.toMaterial3ColorScheme() }
-    MaterialTheme(colorScheme = colorScheme, content = content)
+    CompositionLocalProvider(LocalDimensions provides Dimensions()) {
+        MaterialTheme(colorScheme = colorScheme, content = content)
+    }
 }
 
 @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/compose/theme/Theme.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compose/theme/Theme.kt
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Ashish Yadav <mailtoashish693@gmail.com>
+
+package com.ichi2.compose.theme
+
+import android.content.Context
+import android.content.res.TypedArray
+import androidx.annotation.StyleableRes
+import androidx.annotation.VisibleForTesting
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.withStyledAttributes
+import com.ichi2.anki.R
+
+/**
+ * Wraps [content] in a Material3 [MaterialTheme] populated from the currently
+ * applied AnkiDroid XML theme (light, plain, dark or black).
+ *
+ * Color attributes are read from the host Activity's theme via the
+ * [R.styleable.ComposeTheme] styleable, so a theme change in app settings
+ * (which already triggers Activity.recreate()) flows through automatically.
+ *
+ * For any color slot not defined by the active theme, the Material3 default is used.
+ *
+ * Wrap all top-level Compose content in this composable so screens pick up the
+ * same colors as the rest of the app.
+ */
+@Composable
+fun AnkiDroidTheme(content: @Composable () -> Unit) {
+    val context = LocalContext.current
+    val colorScheme = remember(context) { context.toMaterial3ColorScheme() }
+    MaterialTheme(colorScheme = colorScheme, content = content)
+}
+
+@VisibleForTesting
+internal fun Context.toMaterial3ColorScheme(): ColorScheme {
+    var scheme: ColorScheme = lightColorScheme()
+    withStyledAttributes(attrs = R.styleable.ComposeTheme) {
+        val isLight = getBoolean(R.styleable.ComposeTheme_isLightTheme, true)
+        val base = if (isLight) lightColorScheme() else darkColorScheme()
+        scheme =
+            base.copy(
+                primary = color(R.styleable.ComposeTheme_colorPrimary, base.primary),
+                onPrimary = color(R.styleable.ComposeTheme_colorOnPrimary, base.onPrimary),
+                // primaryContainer / onPrimaryContainer are intentionally NOT read from
+                // the AnkiDroid XML themes. Those XML values were chosen for legacy
+                // Material Components purposes (switch thumb, old-style FAB icon tint)
+                // and conflict with Material3's semantic (a real container background
+                // for FABs and similar). Falling back to the Material3 base colorScheme
+                // gives the right behavior for Compose components.
+                secondary = color(R.styleable.ComposeTheme_colorSecondary, base.secondary),
+                onSecondary = color(R.styleable.ComposeTheme_colorOnSecondary, base.onSecondary),
+                secondaryContainer = color(R.styleable.ComposeTheme_colorSecondaryContainer, base.secondaryContainer),
+                onSecondaryContainer = color(R.styleable.ComposeTheme_colorOnSecondaryContainer, base.onSecondaryContainer),
+                tertiary = color(R.styleable.ComposeTheme_colorTertiary, base.tertiary),
+                onTertiary = color(R.styleable.ComposeTheme_colorOnTertiary, base.onTertiary),
+                tertiaryContainer = color(R.styleable.ComposeTheme_colorTertiaryContainer, base.tertiaryContainer),
+                onTertiaryContainer = color(R.styleable.ComposeTheme_colorOnTertiaryContainer, base.onTertiaryContainer),
+                error = color(R.styleable.ComposeTheme_colorError, base.error),
+                onError = color(R.styleable.ComposeTheme_colorOnError, base.onError),
+                errorContainer = color(R.styleable.ComposeTheme_colorErrorContainer, base.errorContainer),
+                onErrorContainer = color(R.styleable.ComposeTheme_colorOnErrorContainer, base.onErrorContainer),
+                surface = color(R.styleable.ComposeTheme_colorSurface, base.surface),
+                onSurface = color(R.styleable.ComposeTheme_colorOnSurface, base.onSurface),
+                surfaceVariant = color(R.styleable.ComposeTheme_colorSurfaceVariant, base.surfaceVariant),
+                onSurfaceVariant = color(R.styleable.ComposeTheme_colorOnSurfaceVariant, base.onSurfaceVariant),
+                outline = color(R.styleable.ComposeTheme_colorOutline, base.outline),
+                outlineVariant = color(R.styleable.ComposeTheme_colorOutlineVariant, base.outlineVariant),
+                surfaceContainer = color(R.styleable.ComposeTheme_colorSurfaceContainer, base.surfaceContainer),
+                surfaceContainerHigh = color(R.styleable.ComposeTheme_colorSurfaceContainerHigh, base.surfaceContainerHigh),
+                surfaceContainerHighest = color(R.styleable.ComposeTheme_colorSurfaceContainerHighest, base.surfaceContainerHighest),
+                surfaceContainerLow = color(R.styleable.ComposeTheme_colorSurfaceContainerLow, base.surfaceContainerLow),
+                surfaceContainerLowest = color(R.styleable.ComposeTheme_colorSurfaceContainerLowest, base.surfaceContainerLowest),
+                background = color(R.styleable.ComposeTheme_android_colorBackground, base.background),
+            )
+    }
+    return scheme
+}
+
+private fun TypedArray.color(
+    @StyleableRes index: Int,
+    fallback: Color,
+): Color = if (hasValue(index)) Color(getColor(index, fallback.toArgb())) else fallback

--- a/AnkiDroid/src/main/java/com/ichi2/compose/ui/preview/ThemePreviews.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compose/ui/preview/ThemePreviews.kt
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Ashish Yadav <mailtoashish693@gmail.com>
+
+package com.ichi2.compose.ui.preview
+
+import android.content.res.Configuration
+import androidx.compose.ui.tooling.preview.Preview
+
+// TODO: see if we can do better, all 4 themes should be made available for preview
+
+/**
+ * Multi-preview annotation that renders the annotated composable in both
+ * light and dark system UI modes.
+ *
+ * Apply to any private `*Preview` function in a composable file so the IDE
+ * shows both variants side-by-side without duplicating @Preview blocks.
+ */
+@Preview(
+    name = "Light",
+    group = "theme",
+    uiMode = Configuration.UI_MODE_NIGHT_NO,
+    showBackground = true,
+)
+annotation class ThemePreviews

--- a/AnkiDroid/src/main/res/values/compose_theme_attrs.xml
+++ b/AnkiDroid/src/main/res/values/compose_theme_attrs.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="ComposeTheme">
+        <attr name="isLightTheme" />
+        <attr name="colorPrimary" />
+        <attr name="colorOnPrimary" />
+        <attr name="colorPrimaryContainer" />
+        <attr name="colorOnPrimaryContainer" />
+        <attr name="colorSecondary" />
+        <attr name="colorOnSecondary" />
+        <attr name="colorSecondaryContainer" />
+        <attr name="colorOnSecondaryContainer" />
+        <attr name="colorTertiary" />
+        <attr name="colorOnTertiary" />
+        <attr name="colorTertiaryContainer" />
+        <attr name="colorOnTertiaryContainer" />
+        <attr name="colorError" />
+        <attr name="colorOnError" />
+        <attr name="colorErrorContainer" />
+        <attr name="colorOnErrorContainer" />
+        <attr name="colorSurface" />
+        <attr name="colorOnSurface" />
+        <attr name="colorSurfaceVariant" />
+        <attr name="colorOnSurfaceVariant" />
+        <attr name="colorOutline" />
+        <attr name="colorOutlineVariant" />
+        <attr name="colorSurfaceContainer" />
+        <attr name="colorSurfaceContainerHigh" />
+        <attr name="colorSurfaceContainerHighest" />
+        <attr name="colorSurfaceContainerLow" />
+        <attr name="colorSurfaceContainerLowest" />
+        <attr name="android:colorBackground" />
+    </declare-styleable>
+</resources>

--- a/AnkiDroid/src/test/java/com/ichi2/compose/theme/DimensionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compose/theme/DimensionsTest.kt
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Ashish Yadav <mailtoashish693@gmail.com>
+
+package com.ichi2.compose.theme
+
+import androidx.compose.ui.unit.dp
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pins the [Dimensions] spacing scale: the `spaceNNN` numeric tokens and the
+ * semantic aliases that point at specific steps.
+ */
+class DimensionsTest {
+    private val dimensions = Dimensions()
+
+    @Test
+    fun `numeric scale follows the 8dp-base convention`() {
+        // spaceNNN == (NNN / 100) * 8dp
+        assertEquals(2.dp, dimensions.space25)
+        assertEquals(4.dp, dimensions.space50)
+        assertEquals(8.dp, dimensions.space100)
+        assertEquals(12.dp, dimensions.space150)
+        assertEquals(16.dp, dimensions.space200)
+        assertEquals(24.dp, dimensions.space300)
+        assertEquals(32.dp, dimensions.space400)
+        assertEquals(64.dp, dimensions.space800)
+    }
+
+    @Test
+    fun `scale increases monotonically`() {
+        val scale =
+            listOf(
+                dimensions.space25,
+                dimensions.space50,
+                dimensions.space100,
+                dimensions.space150,
+                dimensions.space200,
+                dimensions.space300,
+                dimensions.space400,
+                dimensions.space800,
+            )
+        scale.zipWithNext { smaller, larger ->
+            assertTrue(smaller < larger, "$smaller should be < $larger")
+        }
+    }
+
+    @Test
+    fun `semantic aliases map to their scale step`() {
+        // Documented intent: screenEdge is the space300 step, sectionGap is space200.
+        assertEquals(dimensions.space300, dimensions.screenEdge)
+        assertEquals(dimensions.space200, dimensions.sectionGap)
+    }
+
+    @Test
+    fun `copy overrides a single token and leaves the rest`() {
+        // Used by previews / tests to provide a custom scale.
+        val custom = dimensions.copy(screenEdge = 8.dp)
+        assertEquals(8.dp, custom.screenEdge)
+        assertEquals(16.dp, custom.sectionGap, "non-overridden tokens are unchanged")
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/compose/theme/ThemeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compose/theme/ThemeTest.kt
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Ashish Yadav <mailtoashish693@gmail.com>
+
+package com.ichi2.compose.theme
+
+import android.content.Context
+import android.view.ContextThemeWrapper
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.toArgb
+import androidx.core.content.ContextCompat
+import androidx.test.core.app.ApplicationProvider
+import com.ichi2.anki.R
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import com.ichi2.anki.common.android.R as CommonR
+
+/**
+ * Verifies that the four AnkiDroid XML themes (light, plain, dark, black) are
+ * correctly bridged into a Material3 [androidx.compose.material3.ColorScheme]
+ * by [toMaterial3ColorScheme].
+ *
+ * The colors expected here are pinned to the values declared in the matching
+ * theme XML under res/values/theme_*.xml. If a theme's primary color is
+ * intentionally changed, the matching assertion here should be updated.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ThemeTest {
+    private val appContext: Context get() = ApplicationProvider.getApplicationContext()
+
+    private fun themed(themeRes: Int) = ContextThemeWrapper(appContext, themeRes)
+
+    @Test
+    fun `light theme bridges colorPrimary to scheme primary`() {
+        val scheme = themed(R.style.Theme_Light).toMaterial3ColorScheme()
+        val expected = ContextCompat.getColor(appContext, CommonR.color.material_light_blue_500)
+        assertEquals(expected, scheme.primary.toArgb())
+    }
+
+    @Test
+    fun `dark theme bridges colorPrimary to scheme primary`() {
+        val scheme = themed(R.style.Theme_Dark).toMaterial3ColorScheme()
+        val expected = ContextCompat.getColor(appContext, CommonR.color.material_blue_400)
+        assertEquals(expected, scheme.primary.toArgb())
+    }
+
+    @Test
+    fun `plain theme produces a different primary than light theme`() {
+        val light = themed(R.style.Theme_Light).toMaterial3ColorScheme()
+        val plain = themed(R.style.Theme_Light_Plain).toMaterial3ColorScheme()
+        assertNotEquals(
+            light.primary.toArgb(),
+            plain.primary.toArgb(),
+            "Plain theme should have its own brand color distinct from Light theme",
+        )
+    }
+
+    @Test
+    fun `black theme produces a different surface than dark theme`() {
+        val dark = themed(R.style.Theme_Dark).toMaterial3ColorScheme()
+        val black = themed(R.style.Theme_Dark_Black).toMaterial3ColorScheme()
+        assertNotEquals(
+            dark.surface.toArgb(),
+            black.surface.toArgb(),
+            "Black theme should be visually distinct from Dark theme on surface color",
+        )
+    }
+
+    @Test
+    fun `light theme uses lightColorScheme as base for unspecified slots`() {
+        val scheme = themed(R.style.Theme_Light).toMaterial3ColorScheme()
+        val lightDefaults = lightColorScheme()
+        // inverseSurface is not overridden by Theme_Light, so it should come from the base
+        assertEquals(lightDefaults.inverseSurface.toArgb(), scheme.inverseSurface.toArgb())
+    }
+
+    @Test
+    fun `dark theme uses darkColorScheme as base for unspecified slots`() {
+        val scheme = themed(R.style.Theme_Dark).toMaterial3ColorScheme()
+        val darkDefaults = darkColorScheme()
+        // inverseSurface is not overridden by Theme_Dark, so it should come from the base
+        assertEquals(darkDefaults.inverseSurface.toArgb(), scheme.inverseSurface.toArgb())
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,8 @@ plugins {
     alias(libs.plugins.androidx.baselineprofile) apply false
     // Serialization is a separate artifact, not pinned transitively by AGP.
     alias(libs.plugins.kotlin.serialization) apply false
+    // Compose Compiler plugin (required since Kotlin 2.0); applied per-module that opts in.
+    alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.ktlint.gradle.plugin) apply false
     alias(libs.plugins.keeper) apply false
 }
@@ -121,6 +123,7 @@ subprojects {
             // This workaround safely feeds the unsafe flag *only* to the IDE during Gradle sync,
             // while passing the standard, crash-free flag to the compiler during the actual build.
             val isInIdeaSync = System.getProperty("idea.sync.active").toBoolean()
+            val taskName = name
 
             compilerOptions {
                 allWarningsAsErrors = fatalWarnings
@@ -140,6 +143,14 @@ subprojects {
                 }
                 if (project.path != ":api") {
                     compilerArgs += "-Xcontext-parameters"
+                }
+                // Opt in to Material3 APIs marked experimental once at the module level
+                // (currently only :AnkiDroid uses Compose Material3). Avoids littering
+                // composables with @OptIn(ExperimentalMaterial3Api::class).
+                // Skipped for testFixtures since that source set only carries
+                // compose-runtime on compileOnly, not material3.
+                if (project.path == ":AnkiDroid" && !taskName.contains("TestFixtures")) {
+                    compilerArgs += "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api"
                 }
                 freeCompilerArgs = compilerArgs
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,8 @@ androidxAppCompat = "1.7.1"
 androidxBenchmark = "1.4.1"
 # https://developer.android.com/jetpack/androidx/releases/browser
 androidxBrowser = "1.10.0"
+# https://developer.android.com/jetpack/compose/bom/bom-mapping
+androidxComposeBillOfMaterials = "2026.06.00"
 # https://developer.android.com/jetpack/androidx/releases/constraintlayout
 androidxConstraintlayout = "2.2.1"
 # https://developer.android.com/jetpack/androidx/releases/core
@@ -148,6 +150,19 @@ androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "a
 androidx-benchmark-macro-junit4 = { module = "androidx.benchmark:benchmark-macro-junit4", version.ref = "androidxBenchmark" }
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidxAnnotation" }
 androidx-activity = { module = "androidx.activity:activity", version.ref = "androidxActivity" }
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidxActivity" }
+# The Compose libraries below intentionally omit `version.ref`: their versions are
+# pinned by `androidx-compose-bom` (a Bill of Materials), so the BoM resolves them
+# to a mutually-compatible set. Bump `androidxComposeBillOfMaterials` to upgrade
+# them all in lock-step.
+androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "androidxComposeBillOfMaterials" }
+androidx-compose-ui = { module = "androidx.compose.ui:ui" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
+androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
+androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
+androidx-compose-runtime = { module = "androidx.compose.runtime:runtime" }
+androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidxLifecycleProcess" }
+androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidxLifecycleProcess" }
 androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "androidxLifecycleProcess" }
 androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "androidxMedia3" }
 androidx-media3-exoplayer-dash = { module = "androidx.media3:media3-exoplayer-dash", version.ref = "androidxMedia3" }
@@ -240,6 +255,7 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 
 
 ktlint-gradle-plugin = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintGradlePlugin" }


### PR DESCRIPTION


<!--- Please fill the necessary details below -->
## Purpose / Description
Enable Jetpack Compose on the :AnkiDroid module so future screens can be built or migrated incrementally. This follows Google's I/O 2026 "Compose-First" direction. This PR is foundational it does not convert any existing user-facing screen.

## Fixes
* Related to  #21138


## Approach
See commit 1 and then:
Added `com.ichi2.compose.theme.Theme` that reads colors from the host Activity's XML theme via R.styleable.ComposeTheme and bridges each of the four AnkiDroid themes (Light, Plain, Dark, Black) into a Material 3 ColorScheme. Slots not declared by the XML fall back to Material 3 defaults; isLightTheme (inherited from Theme.Material3.{Light,Dark}) decides the base scheme.

- Add ktlint config: ktlint_function_naming_ignore_when_annotated_with = Composable so @Composable fun MySomeScreen() isn't flagged.



## How Has This Been Tested?
Local build passed 


## Learning (optional, can help others)
Themes and Preview is a mess to handle for custom themes and it took me whole night to enable compose for Shared Deck screen

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->