### PR TITLE
fix: memory leaks [DeckPicker + CardBrowser]

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -170,6 +170,7 @@ import com.ichi2.anki.ui.windows.permissions.PermissionsActivity
 import com.ichi2.anki.utils.Destination
 import com.ichi2.anki.utils.ShortcutUtils
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
+import com.ichi2.anki.utils.ext.doOnScrolled
 import com.ichi2.anki.utils.ext.launchCollectionInLifecycleScope
 import com.ichi2.anki.utils.ext.positionIsVisible
 import com.ichi2.anki.utils.ext.setFragmentResultListener
@@ -600,11 +601,11 @@ open class DeckPicker :
                     pullToSyncWrapper.isRefreshing = false
                     sync()
                 }
-                viewTreeObserver.addOnScrollChangedListener {
-                    pullToSyncWrapper.isEnabled =
-                        decksLayoutManager.findFirstCompletelyVisibleItemPosition() == 0
-                }
             }
+        // Only allow pull-to-sync when the deck list is scrolled to the top.
+        deckPickerBinding.decks.doOnScrolled { _, _ ->
+            pullToSyncWrapper.isEnabled = decksLayoutManager.findFirstCompletelyVisibleItemPosition() == 0
+        }
     }
 
     @Suppress("UNUSED_PARAMETER")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -72,7 +72,6 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import anki.collection.OpChanges
-import anki.decks.deckId
 import anki.sync.SyncStatusResponse
 import com.google.android.material.progressindicator.LinearProgressIndicator
 import com.google.android.material.snackbar.BaseTransientBottomBar
@@ -529,18 +528,7 @@ open class DeckPicker :
 
         lifecycleScope.launch { applyDeckPickerBackground() }
 
-        pullToSyncWrapper =
-            deckPickerBinding.pullToSyncWrapper.apply {
-                setDistanceToTriggerSync(SWIPE_TO_SYNC_TRIGGER_DISTANCE)
-                setOnRefreshListener {
-                    Timber.i("Pull to Sync: Syncing")
-                    pullToSyncWrapper.isRefreshing = false
-                    sync()
-                }
-                viewTreeObserver.addOnScrollChangedListener {
-                    pullToSyncWrapper.isEnabled = decksLayoutManager.findFirstCompletelyVisibleItemPosition() == 0
-                }
-            }
+        setupPullToSync()
         // Setup the FloatingActionButtons
         floatingActionMenu =
             DeckPickerFloatingActionMenu(this, binding, this).apply {
@@ -601,6 +589,22 @@ open class DeckPicker :
         onBackPressedDispatcher.addCallback(this, exitViaDoubleTapBackCallback())
         onBackPressedDispatcher.addCallback(this, closeFloatingActionBarBackPressCallback)
         super.setupBackPressedCallbacks()
+    }
+
+    private fun setupPullToSync() {
+        pullToSyncWrapper =
+            deckPickerBinding.pullToSyncWrapper.apply {
+                setDistanceToTriggerSync(SWIPE_TO_SYNC_TRIGGER_DISTANCE)
+                setOnRefreshListener {
+                    Timber.i("Pull to Sync: Syncing")
+                    pullToSyncWrapper.isRefreshing = false
+                    sync()
+                }
+                viewTreeObserver.addOnScrollChangedListener {
+                    pullToSyncWrapper.isEnabled =
+                        decksLayoutManager.findFirstCompletelyVisibleItemPosition() == 0
+                }
+            }
     }
 
     @Suppress("UNUSED_PARAMETER")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -17,7 +17,6 @@
 package com.ichi2.anki.browser
 
 import android.content.Context
-import android.content.DialogInterface
 import android.graphics.Color
 import android.os.Bundle
 import android.text.Spannable
@@ -122,7 +121,6 @@ import com.ichi2.anki.libanki.undoAvailable
 import com.ichi2.anki.libanki.undoLabel
 import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.model.CardsOrNotes.CARDS
-import com.ichi2.anki.model.LegacySortType
 import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.observability.undoableOp
@@ -134,7 +132,6 @@ import com.ichi2.anki.scheduling.SetDueDateDialog
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.attachFastScroller
 import com.ichi2.anki.ui.internationalization.sentenceCase
-import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.undoAndShowSnackbar
 import com.ichi2.anki.utils.ext.addPrepareMenuProvider
 import com.ichi2.anki.utils.ext.getParcelableCompat
@@ -142,7 +139,6 @@ import com.ichi2.anki.utils.ext.hasCheckedBackground
 import com.ichi2.anki.utils.ext.ifNotZero
 import com.ichi2.anki.utils.ext.launchCollectionInLifecycleScope
 import com.ichi2.anki.utils.ext.setFragmentResultListener
-import com.ichi2.anki.utils.ext.sharedPrefs
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.utils.ext.visibleItemPositions
 import com.ichi2.anki.utils.hideKeyboard
@@ -1446,13 +1442,7 @@ class CardBrowserFragment :
         }
 
     fun changeDisplayOrder() {
-        showDialogFragment(
-            // TODO: move this into the ViewModel
-            CardBrowserOrderDialog.newInstance { dialog: DialogInterface, which: Int ->
-                dialog.dismiss()
-                activityViewModel.changeCardOrder(LegacySortType.fromCardBrowserLabelIndex(which))
-            },
-        )
+        showDialogFragment(CardBrowserOrderDialog())
     }
 
     fun updateFlagForSelectedRows(flag: Flag) =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserOrderDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserOrderDialog.kt
@@ -17,7 +17,6 @@
 package com.ichi2.anki.dialogs
 
 import android.app.Dialog
-import android.content.DialogInterface
 import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.activityViewModels
@@ -50,19 +49,14 @@ class CardBrowserOrderDialog : AnalyticsDialogFragment() {
         return AlertDialog
             .Builder(requireContext())
             .setTitle(R.string.card_browser_change_display_order_title)
-            .setSingleChoiceItems(items, viewModel.order.cardBrowserLabelIndex, orderSingleChoiceDialogListener)
-            .create()
+            .setSingleChoiceItems(items, viewModel.order.cardBrowserLabelIndex) { dialog, which ->
+                dialog.dismiss()
+                viewModel.changeCardOrder(LegacySortType.fromCardBrowserLabelIndex(which))
+            }.create()
     }
 
     companion object {
-        private var orderSingleChoiceDialogListener: DialogInterface.OnClickListener? = null
-
         // SortType.NO_SORTING.cardBrowserLabelIndex
         private const val CARD_ORDER_NONE = 0
-
-        fun newInstance(orderSingleChoiceDialogListener: DialogInterface.OnClickListener): CardBrowserOrderDialog {
-            this.orderSingleChoiceDialogListener = orderSingleChoiceDialogListener
-            return CardBrowserOrderDialog()
-        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/RecyclerView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/RecyclerView.kt
@@ -24,3 +24,23 @@ import androidx.recyclerview.widget.RecyclerView
 fun <T : View> RecyclerView.ViewHolder.findViewById(
     @IdRes id: Int,
 ) = itemView.findViewById<T>(id)
+
+/**
+ * Adds a listener invoked whenever the [RecyclerView] has completed scrolling.
+ *
+ * - `dx` - The amount of horizontal scroll.
+ * - `dy` - The amount of vertical scroll.
+ *
+ * @see RecyclerView.OnScrollListener.onScrolled
+ */
+inline fun RecyclerView.doOnScrolled(crossinline action: (dx: Int, dy: Int) -> Unit) {
+    addOnScrollListener(
+        object : RecyclerView.OnScrollListener() {
+            override fun onScrolled(
+                recyclerView: RecyclerView,
+                dx: Int,
+                dy: Int,
+            ) = action(dx, dy)
+        },
+    )
+}


### PR DESCRIPTION
## Fixes
* Fixes #21148

## Approach

* move from a `viewTreeObserver` to a `OnScrollListener` for detecting if the scrollview is scrolled to the top
* fix a TODO and move an operation to the ViewModel [CardBrowser]
  * technically also removed in https://github.com/ankidroid/Anki-Android/pull/20240 

## How Has This Been Tested?
* Enable leak canary
* Open the deck picker + 'change order' dialogs, then change screens

## Learning (optional, can help others)
`viewTreeObserver` internals: if called before the attach phase, a 'floating' tree observer is attached, and copied out when the real tree observer is added, this means `onDestroy()` isn't an ideal location.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)