### PR TITLE
Decouple consumer and producer in ChangeManager

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/observability/ChangeManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/observability/ChangeManager.kt
@@ -139,7 +139,7 @@ object ChangeManager {
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun clearSubscribers() {
+    fun resetForTesting() {
         subscribers.size.ifNotZero { size -> Timber.d("clearing %d subscribers", size) }
         subscribers.clear()
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/observability/ChangeManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/observability/ChangeManager.kt
@@ -39,6 +39,8 @@ import anki.collection.OpChangesWithId
 import anki.collection.opChanges
 import anki.import_export.ImportResponse
 import com.ichi2.anki.common.crashreporting.CrashReportService
+import com.ichi2.anki.observability.ChangeManager.publish
+import com.ichi2.anki.observability.ChangeManager.toOpChanges
 import com.ichi2.anki.utils.ext.ifNotZero
 import org.jetbrains.annotations.Contract
 import timber.log.Timber
@@ -68,6 +70,30 @@ object ChangeManager {
     private val subscribers = CopyOnWriteArrayList(mutableListOf<WeakReference<Subscriber>>())
 
     val subscriberCount get() = subscribers.size
+
+    /**
+     * Delivers changes to [subscribers][ChangeManager.subscribers] off the caller's thread.
+     *
+     * @see publish
+     */
+    private val publisher = OpChangesPublisher { changes, handler -> notifySubscribers(changes, handler) }
+
+    /**
+     * Notifies `subscribers` of `changes` without blocking the caller.
+     *
+     * Unlike `notifySubscribers`, the caller **does not** wait for subscribers to complete.
+     *
+     * This may be called from any thread.
+     *
+     * @param changes a raw/wrapped backend [OpChanges] response (see [ChangeManager.toOpChanges])
+     * @param handler the initiator of the change, or `null`. See [Subscriber.opExecuted]
+     */
+    fun <T : Any> publish(
+        changes: T,
+        handler: Any? = null,
+    ) {
+        publisher.publish(changes.toOpChanges(), handler)
+    }
 
     /**
      * Subscribes to changes.
@@ -143,7 +169,9 @@ object ChangeManager {
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @Synchronized
     fun resetForTesting() {
+        publisher.reset()
         subscribers.size.ifNotZero { size -> Timber.d("clearing %d subscribers", size) }
         subscribers.clear()
     }
@@ -152,18 +180,25 @@ object ChangeManager {
         changes: T,
         initiator: Any?,
     ) {
-        val opChanges =
-            when (changes) {
-                is OpChanges -> changes
-                is OpChangesWithCount -> changes.changes
-                is OpChangesWithId -> changes.changes
-                is OpChangesAfterUndo -> changes.changes
-                is OpChangesOnly -> changes.changes
-                is ImportResponse -> changes.changes
-                else -> TODO("unhandled change type of class '${changes::class}'")
-            }
-        notifySubscribers(opChanges, initiator)
+        notifySubscribers(changes.toOpChanges(), initiator)
     }
+
+    /**
+     * Extracts an [OpChanges] from a backend response.
+     *
+     * @throws NotImplementedError if the receiver is not a backend OpChanges type.
+     */
+    // TODO: See if we can add a marker interface
+    private fun <T : Any> T.toOpChanges(): OpChanges =
+        when (this) {
+            is OpChanges -> this
+            is OpChangesWithCount -> changes
+            is OpChangesWithId -> changes
+            is OpChangesAfterUndo -> changes
+            is OpChangesOnly -> changes
+            is ImportResponse -> changes
+            else -> TODO("unhandled change type of class '${this::class}'")
+        }
 
     fun notifySubscribersAllValuesChanged(handler: Any? = null) {
         notifySubscribers(ALL, handler)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/observability/ChangeManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/observability/ChangeManager.kt
@@ -53,6 +53,10 @@ object ChangeManager {
          * Called after a backend method invoked via col.op() or col.opWithProgress()
          * has modified the collection. Subscriber should inspect the changes, and update
          * the UI if necessary.
+         *
+         * @param changes see [OpChanges].
+         * @param handler the initiator of the change. A subscriber may compare this against itself
+         * to detect changes it caused, and skip its default handling in favour of more specific updates.
          */
         fun opExecuted(
             changes: OpChanges,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/observability/OpChangesPublisher.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/observability/OpChangesPublisher.kt
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.observability
+
+import anki.collection.OpChanges
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+
+/**
+ * Provides non-blocking delivery of [OpChanges] to the [ChangeManager] subscriber registry.
+ *
+ * Use this when `suspend` is not feasible (e.g. `ContentProvider`).
+ *
+ * [publish] queues a change onto [changeChannel] and returns immediately.
+ *
+ * @param deliver forwards a change to subscribers; invoked on [Dispatchers.Main].
+ */
+internal class OpChangesPublisher(
+    private val deliver: (changes: OpChanges, handler: Any?) -> Unit,
+) {
+    private data class ChangeEvent(
+        val changes: OpChanges,
+        val handler: Any?,
+    )
+
+    /** CoroutineScope which handles the coroutine consuming [changeChannel]. */
+    private var scope: CoroutineScope? = null
+    private val changeChannel =
+        Channel<ChangeEvent>(
+            capacity = Channel.UNLIMITED,
+        )
+
+    /** Ensures that [changeChannel] is being processed. */
+    @Synchronized
+    private fun ensureCollector() {
+        if (scope != null) return
+        scope =
+            CoroutineScope(Dispatchers.Main + SupervisorJob()).also { s ->
+                s.launch {
+                    for (event in changeChannel) {
+                        deliver(event.changes, event.handler)
+                    }
+                }
+            }
+    }
+
+    /**
+     * Queues [changes] for non-blocking delivery to subscribers.
+     *
+     * May be called on any thread.
+     *
+     * @see ChangeManager.publish
+     */
+    fun publish(
+        changes: OpChanges,
+        handler: Any?,
+    ) {
+        ensureCollector()
+        changeChannel.trySend(ChangeEvent(changes, handler))
+    }
+
+    /** Cancels the collector and discards any queued, undelivered changes. */
+    @Synchronized
+    fun reset() {
+        scope?.cancel()
+        scope = null
+        changeChannel.drain()
+    }
+}
+
+private fun <T> Channel<T>.drain() {
+    while (this.tryReceive().isSuccess) { /* intentionally empty */ }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -148,7 +148,7 @@ open class RobolectricTest :
                 // W/ShadowLegacyPath: android.graphics.Path#op() not supported yet.
                 .filter("^(?!(W/ShadowLegacyPath|D/LifecycleMonitor)).*$")
 
-        ChangeManager.clearSubscribers()
+        ChangeManager.resetForTesting()
 
         validateRunWithAnnotationPresent()
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/observability/ChangeManagerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/observability/ChangeManagerTest.kt
@@ -15,21 +15,29 @@
  */
 package com.ichi2.anki.observability
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import anki.collection.OpChanges
+import com.ichi2.testutils.EmptyApplication
 import com.ichi2.testutils.JvmTest
+import com.ichi2.testutils.subscriberChangeCounter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.setMain
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.greaterThan
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
-import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.javaType
 import kotlin.reflect.jvm.isAccessible
 
-@RunWith(RobolectricTestRunner::class)
+// this cannot yet use `EmptyApplication` - `CrashReportService` dependency
+@RunWith(AndroidJUnit4::class)
 class ChangeManagerExceptionHandlingTest : JvmTest() {
     @Test
     fun `all subscribers notified even if one throws exception`() {
@@ -99,4 +107,27 @@ class ChangeManagerTest {
             }
         }
     }
+}
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = EmptyApplication::class)
+class ChangeManagerPublishTest : JvmTest() {
+    @Test
+    fun `publish notifies multiple subscribers asynchronously`() =
+        runTest {
+            // queue coroutine execution on Dispatchers.Main, to test 'not notified synchronously'
+            Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+
+            val counter1 = subscriberChangeCounter()
+            val counter2 = subscriberChangeCounter()
+
+            ChangeManager.publish(ChangeManager.ALL)
+
+            assertThat("not notified synchronously by publish", counter1.hasChanges, equalTo(false))
+
+            advanceUntilIdle()
+
+            assertThat("First subscriber should be notified", counter1.hasChanges, equalTo(true))
+            assertThat("Second subscriber should be notified", counter2.hasChanges, equalTo(true))
+        }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/observability/ChangeManagerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/observability/ChangeManagerTest.kt
@@ -20,7 +20,6 @@ import com.ichi2.testutils.JvmTest
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.greaterThan
-import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -32,12 +31,6 @@ import kotlin.reflect.jvm.isAccessible
 
 @RunWith(RobolectricTestRunner::class)
 class ChangeManagerExceptionHandlingTest : JvmTest() {
-    @After
-    override fun tearDown() {
-        super.tearDown()
-        ChangeManager.clearSubscribers()
-    }
-
     @Test
     fun `all subscribers notified even if one throws exception`() {
         var firstCalled = false

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/JvmTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/JvmTest.kt
@@ -34,7 +34,7 @@ open class JvmTest : InMemoryAnkiTest() {
     @CallSuper
     override fun setUp() {
         super.setUp()
-        ChangeManager.clearSubscribers()
+        ChangeManager.resetForTesting()
     }
 
     override fun setupTestDispatcher(dispatcher: TestDispatcher) {

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestChangeSubscriber.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestChangeSubscriber.kt
@@ -60,7 +60,7 @@ suspend fun ensureOpWithHandler(
 }
 
 // used to ensure a strong reference to the subscription is held
-private class ChangeCounter : ChangeManager.Subscriber {
+internal class ChangeCounter : ChangeManager.Subscriber {
     private var changes = 0
     val changeCount get() = changes
     val hasChanges get() = changes > 0
@@ -84,4 +84,15 @@ private class ExtractOpHandler : ChangeManager.Subscriber {
     ) {
         this.handler = handler
     }
+}
+
+/**
+ * Produces a [ChangeCounter] which is subscribed to [ChangeManager].
+ *
+ * Query the result via [.changeCount][ChangeCounter.changeCount] or [.hasChanges][ChangeCounter.hasChanges]
+ */
+internal fun subscriberChangeCounter(): ChangeCounter {
+    val counter = ChangeCounter()
+    ChangeManager.subscribe(counter)
+    return counter
 }

--- a/libanki/src/testFixtures/java/com/ichi2/anki/libanki/testutils/AnkiTest.kt
+++ b/libanki/src/testFixtures/java/com/ichi2/anki/libanki/testutils/AnkiTest.kt
@@ -38,12 +38,14 @@ import com.ichi2.anki.libanki.getNotetype
 import com.ichi2.anki.libanki.testutils.ext.addNote
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.setMain
 import net.ankiweb.rsdroid.exceptions.BackendDeckIsFilteredException
 import timber.log.Timber
+import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.time.Duration
@@ -396,12 +398,18 @@ interface AnkiTest {
         times: Int = 1,
         testBody: suspend TestScope.() -> Unit,
     ) {
-        val dispatcher = UnconfinedTestDispatcher()
+        // Use a unified scheduler on `Dispatchers.Main` and runTest uses, so
+        // advanceUntilIdle()/runCurrent() handle coroutines launched on `Main`.
+        val scheduler =
+            (context[ContinuationInterceptor] as? TestDispatcher)?.scheduler
+                ?: TestCoroutineScheduler()
+        val dispatcher = UnconfinedTestDispatcher(scheduler)
         Dispatchers.setMain(dispatcher)
         setupTestDispatcher(dispatcher)
+
         repeat(times) {
             if (times != 1) Timber.d("------ Executing test $it/$times ------")
-            kotlinx.coroutines.test.runTest(context, dispatchTimeout) {
+            kotlinx.coroutines.test.runTest(context + scheduler, dispatchTimeout) {
                 runTestInner(testBody)
             }
         }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
I introduced a non-blocking notification mechanism to `ChangeManager` to support background producers without causing UI thread crashes or blocking background execution

## Fixes
* Fixes #21102 
* Part of #20907

## Approach

- I added ~~`MutableShareFlow`~~ `Channel` as a thread-safe buffer 
- I added non-blocking `publish` function that allows producer to deliver changes without waiting for UI updates
- Initialized a `CoroutineScope` with `Dispatchers.Main` to ensure UI safe notification

## How Has This Been Tested?
I have added unit test to verify asynchronous notification for multiple subscribers

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
