### PR TITLE
fix(card-browser): refresh column headers on resume

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -725,6 +725,7 @@ open class CardBrowser :
         searchView?.post {
             hideKeyboard()
         }
+        viewModel.refreshColumnsFromPrefs()
     }
 
     override fun onNavigationPressed() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -643,6 +643,18 @@ class CardBrowserViewModel(
         flowOfActiveColumns.update { columns }
     }
 
+    /**
+     * Reloads active columns from SharedPreferences if they differ from the in-memory copy.
+     */
+    fun refreshColumnsFromPrefs() =
+        viewModelScope.launch {
+            if (!initCompleted) return@launch
+            val stored = BrowserColumnCollection.load(sharedPrefs(), cardsOrNotes)
+            if (stored.columns == activeColumns) return@launch
+            Timber.d("refreshColumnsFromPrefs: columns changed externally, reloading")
+            updateActiveColumns(stored)
+        }
+
     @VisibleForTesting
     fun manualInit() {
         require(manualInit) { "'manualInit' should be true" }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -652,6 +652,40 @@ class CardBrowserViewModelTest : JvmTest() {
     }
 
     @Test
+    fun `refreshColumnsFromPrefs - reloads when SharedPreferences changed externally`() =
+        runViewModelTest {
+            flowOfActiveColumns.test {
+                ignoreEventsDuringViewModelInit()
+
+                // simulate another CardBrowser instance (e.g. one launched via the
+                // system PROCESS_TEXT context menu) saving a different column set
+                val externalColumns = listOf(QUESTION, ANSWER, DECK)
+                BrowserColumnCollection.save(
+                    sharedPrefs(),
+                    cardsOrNotes,
+                    BrowserColumnCollection(externalColumns),
+                )
+
+                refreshColumnsFromPrefs().join()
+
+                assertThat("flowOfActiveColumns emits external columns", awaitItem().columns, equalTo(externalColumns))
+                assertThat("activeColumns matches", activeColumns, equalTo(externalColumns))
+            }
+        }
+
+    @Test
+    fun `refreshColumnsFromPrefs - no event when SharedPreferences unchanged`() =
+        runViewModelTest {
+            flowOfActiveColumns.test {
+                ignoreEventsDuringViewModelInit()
+
+                refreshColumnsFromPrefs().join()
+
+                expectNoEvents()
+            }
+        }
+
+    @Test
     fun `change card order to NO_SORTING is a no-op if done twice`() =
         runViewModelTest {
             flowOfSearchState.test {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
> [!NOTE]
> Assisted-by: Claude Opus 4.7 for writing test (reviewed by me)

## Purpose / Description
Refresh the header when user is changing the header via context menu then opening card browser so this pr fixes that behaviour 

## Fixes
* Fixes #21153

## Approach
See commit

## How Has This Been Tested?
Pixel 10 and tests added

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->