### PR TITLE
Preserve reviewer state during fold/unfold configuration changes

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -374,7 +374,7 @@
             android:name="com.ichi2.anki.Reviewer"
             android:exported="true"
             android:theme="@style/Theme_Dark.Launcher"
-            android:configChanges="keyboardHidden|orientation|screenSize"
+            android:configChanges="keyboardHidden|orientation|screenSize|screenLayout|smallestScreenSize"
             android:windowSoftInputMode="adjustResize"
             android:parentActivityName=".DeckPicker">
             <intent-filter>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
On foldable devices, folding/unfolding the device while reviewing a card caused the Reviewer to reset back to the question side after the answer was already shown.

This happened because fold/unfold transitions trigger additional configuration changes (screenLayout and smallestScreenSize) which were not handled in the Reviewer's configChanges.

## Fixes
* Fixes #21155

## Approach
Added the following configuration changes to the Reviewer activity:

android:configChanges="keyboardHidden|orientation|screenSize|screenLayout|smallestScreenSize"

Specifically:

screenLayout
smallestScreenSize

These additional flags ensure fold/unfold posture changes are handled without resetting the current reviewer state.

## How Has This Been Tested?

AnkiDroid Version = 2.24.0-debug (7594d0d08d0b97fb4f7d2d96a2eb08cfc771a9ae)  
Backend Version = 0.1.64-anki25.09.2 (25.09.2 3890e12c9e48c028c3f12aa58cb64bd9f8895e30)  
Android Version = 17 (SDK 37)  
ProductFlavor = play  
Device Info = Google | google | emu64xa16k | sdk_gphone16k_x86_64 | sdk_gphone16k_x86_64 | ranchu  
WebView Info = [com.google.android.webview | 763221809]: Mozilla/5.0 (Linux; Android 17; sdk_gphone16k_x86_64 Build/CP21.260330.005; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/145.0.7632.218 Mobile Safari/537.36  
ACRA UUID = f681826e-4753-4ebf-96c5-8a4a647175b3  
FSRS = 5.1.0 (Enabled: false)  
Crash Reports Enabled = false

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->