### PR TITLE
refactor: decouple CardBrowserFragment from CardBrowser activity

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -28,11 +28,8 @@ import android.view.WindowManager
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
-import androidx.activity.result.ActivityResult
-import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.annotation.LayoutRes
 import androidx.annotation.MainThread
-import androidx.annotation.VisibleForTesting
 import androidx.core.view.MenuHost
 import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
@@ -101,13 +98,6 @@ open class CardBrowser :
     NavigationDrawerActivity(),
     ChangeManager.Subscriber,
     MenuHost {
-    /**
-     * Provides an instance of NoteEditorLauncher for adding a note
-     */
-    @get:VisibleForTesting
-    val addNoteLauncher: NoteEditorLauncher
-        get() = createAddNoteLauncher(viewModel)
-
     fun onDeckSelected(deck: SelectableDeck?) {
         deck?.let { deck -> viewModel.setSelectedDeck(deck) }
     }
@@ -151,14 +141,6 @@ open class CardBrowser :
     @get:LayoutRes
     private val layout: Int
         get() = if (useSearchView) R.layout.activity_card_browser_searchview else R.layout.activity_card_browser
-
-    private var onAddNoteActivityResult =
-        registerForActivityResult(StartActivityForResult()) { result: ActivityResult ->
-            Timber.d("onAddNoteActivityResult: resultCode=%d", result.resultCode)
-            if (result.resultCode == RESULT_OK) {
-                forceRefreshSearch(useSearchTextValue = true)
-            }
-        }
 
     init {
         ChangeManager.subscribe(this)
@@ -561,13 +543,6 @@ open class CardBrowser :
         // So we must ensure that all shortcuts uses a modifier.
         // A shortcut without modifier would be triggered while the user types, which is not what we want.
         when (keyCode) {
-            KeyEvent.KEYCODE_E -> {
-                if (event.isCtrlPressed) {
-                    Timber.i("Ctrl+E: Add Note")
-                    launchCatchingTask { addNoteFromCardBrowser() }
-                    return true
-                }
-            }
             KeyEvent.KEYCODE_F -> {
                 if (event.isCtrlPressed) {
                     Timber.i("Ctrl+F - Find notes")
@@ -600,10 +575,6 @@ open class CardBrowser :
         } else {
             super.onNavigationPressed()
         }
-    }
-
-    fun addNoteFromCardBrowser() {
-        onAddNoteActivityResult.launch(addNoteLauncher.toIntent(this))
     }
 
     public override fun onSaveInstanceState(outState: Bundle) {
@@ -755,10 +726,6 @@ open class CardBrowser :
 
         // Values related to persistent state data
         fun clearLastDeckId() = SharedPreferencesLastDeckIdRepository.clearLastDeckId()
-
-        @VisibleForTesting
-        fun createAddNoteLauncher(viewModel: CardBrowserViewModel): NoteEditorLauncher =
-            NoteEditorLauncher.AddNoteFromCardBrowser(viewModel)
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -72,12 +72,9 @@ import com.ichi2.anki.dialogs.registerDeckSelectedHandler
 import com.ichi2.anki.dialogs.registerSaveSearchHandler
 import com.ichi2.anki.dialogs.registerSavedSearchActionHandler
 import com.ichi2.anki.dialogs.startDeckSelection
-import com.ichi2.anki.dialogs.tags.TagsDialogFactory
-import com.ichi2.anki.dialogs.tags.TagsDialogListener
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.SortOrder
-import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.model.CardsOrNotes
 import com.ichi2.anki.model.CardsOrNotes.CARDS
 import com.ichi2.anki.model.CardsOrNotes.NOTES
@@ -102,7 +99,6 @@ import timber.log.Timber
 @KotlinCleanup("scan through this class and add attributes - in process")
 open class CardBrowser :
     NavigationDrawerActivity(),
-    TagsDialogListener,
     ChangeManager.Subscriber,
     MenuHost {
     /**
@@ -133,7 +129,6 @@ open class CardBrowser :
     private val searchView: CardBrowserSearchView?
         get() = cardBrowserFragment.legacySearchView
 
-    lateinit var tagsDialogFactory: TagsDialogFactory
     private val searchItem: MenuItem? get() = cardBrowserFragment.searchItem
     private val mySearchesItem: MenuItem? get() = cardBrowserFragment.mySearchesItem
 
@@ -212,7 +207,6 @@ open class CardBrowser :
         if (showedActivityFailedScreen(savedInstanceState)) {
             return
         }
-        tagsDialogFactory = TagsDialogFactory(this).attachToActivity<TagsDialogFactory>(this)
         super.onCreate(savedInstanceState)
         binding = ActivityCardBrowserBinding.inflate(layoutInflater)
         if (!ensureStoragePermissions()) {
@@ -633,15 +627,6 @@ open class CardBrowser :
         } else {
             viewModel.launchSearchForCards()
         }
-    }
-
-    @RustCleanup("this isn't how Desktop Anki does it")
-    override fun onSelectedTags(
-        selectedTags: List<String>,
-        indeterminateTags: List<String>,
-        stateFilter: CardStateFilter,
-    ) {
-        cardBrowserFragment.onSelectedTags(selectedTags, indeterminateTags, stateFilter)
     }
 
     private fun refreshBrowserUI() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -608,27 +608,6 @@ open class CardBrowser :
         invalidateOptionsMenu() // maybe the availability of undo changed
     }
 
-    // all we need to do is select all decks
-    fun searchAllDecks() = viewModel.setSelectedDeck(SelectableDeck.AllDecks)
-
-    /**
-     * Returns the current deck name, "All Decks" if all decks are selected, or "Unknown"
-     * Do not use this for any business logic, as this will return inconsistent data
-     * with the collection.
-     */
-    val selectedDeckNameForUi: String
-        get() =
-            try {
-                when (val deckId = viewModel.lastDeckId) {
-                    null -> getString(R.string.card_browser_unknown_deck_name)
-                    ALL_DECKS_ID -> getString(R.string.card_browser_all_decks)
-                    else -> getColUnsafe.decks.name(deckId)
-                }
-            } catch (e: Exception) {
-                Timber.w(e, "Unable to get selected deck name")
-                getString(R.string.card_browser_unknown_deck_name)
-            }
-
     /**
      * Implementation of `by viewModels()` for use in [onCreate]
      *

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -134,6 +134,7 @@ import com.ichi2.anki.requireAnkiActivity
 import com.ichi2.anki.requireNavigationDrawerActivity
 import com.ichi2.anki.scheduling.ForgetCardsDialog
 import com.ichi2.anki.scheduling.SetDueDateDialog
+import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.attachFastScroller
 import com.ichi2.anki.ui.internationalization.sentenceCase
@@ -204,7 +205,7 @@ class CardBrowserFragment :
 
     // Dev option for Issue 18709
     private val useSearchView: Boolean
-        get() = requireCardBrowserActivity().useSearchView
+        get() = Prefs.devUsingCardBrowserSearchView
 
     // only usable if 'useSearchView' is set
     override var searchBar: SearchBar? = null
@@ -235,6 +236,13 @@ class CardBrowserFragment :
     @get:LayoutRes
     private val layout: Int
         get() = if (useSearchView) R.layout.fragment_card_browser_searchview else R.layout.fragment_card_browser
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        if (!useSearchView) {
+            require(context is MenuHost) { "Host activity must implement MenuHost when useSearchView is disabled" }
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -397,7 +405,7 @@ class CardBrowserFragment :
     }
 
     private fun setupMenu() {
-        val menuHost: MenuHost = requireCardBrowserActivity()
+        val menuHost: MenuHost = if (useSearchView) this else (requireActivity() as MenuHost)
 
         fun MenuItem.setupUndo() {
             isVisible = getColUnsafe().undoAvailable()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -221,6 +221,18 @@ class CardBrowserFragment :
     private val useSearchView: Boolean
         get() = Prefs.devUsingCardBrowserSearchView
 
+    /**
+     * Returns the current deck name, "All Decks" if all decks are selected, or "Unknown"
+     * Do not use this for any business logic, as this will return inconsistent data
+     * with the collection.
+     */
+    private val selectedDeckNameForUi: String
+        get() =
+            activityViewModel.searchRequestFlow.value.filters.decks
+                .firstOrNull()
+                ?.name
+                ?: getString(R.string.card_browser_all_decks)
+
     // only usable if 'useSearchView' is set
     override var searchBar: SearchBar? = null
 
@@ -889,8 +901,6 @@ class CardBrowserFragment :
         }
 
         fun onSearchCompleted(state: SearchState.Completed) {
-            val activity = requireCardBrowserActivity()
-
             // #3592: show the number of cards found the number of cards is not visible in the menu
             val isMenuSubtitleVisible = legacySearchView != null && legacySearchView!!.isIconified
 
@@ -904,7 +914,9 @@ class CardBrowserFragment :
 
                 showSnackbar(message, Snackbar.LENGTH_SHORT) {
                     if (!searchAllDecks) return@showSnackbar
-                    setAction(R.string.card_browser_search_all_decks) { activity.searchAllDecks() }
+                    setAction(R.string.card_browser_search_all_decks) {
+                        activityViewModel.setSelectedDeck(SelectableDeck.AllDecks)
+                    }
                 }
             }
 
@@ -916,7 +928,7 @@ class CardBrowserFragment :
                     )
                 SearchResultMessage.NoCardsInSelectedDeck ->
                     showSnackbar(
-                        getString(R.string.card_browser_no_cards_in_deck, activity.selectedDeckNameForUi),
+                        getString(R.string.card_browser_no_cards_in_deck, selectedDeckNameForUi),
                         searchAllDecks = true,
                     )
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -68,8 +68,8 @@ import com.google.android.material.progressindicator.LinearProgressIndicator
 import com.google.android.material.search.SearchBar
 import com.google.android.material.search.SearchView
 import com.google.android.material.snackbar.Snackbar
+import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.AnkiActivityProvider
-import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.getColUnsafe
 import com.ichi2.anki.CollectionManager.withCol
@@ -178,8 +178,9 @@ class CardBrowserFragment :
     val viewModel: CardBrowserFragmentViewModel by viewModels()
     val searchViewModel: CardBrowserSearchViewModel by activityViewModels()
 
-    override val ankiActivity: CardBrowser
-        get() = requireAnkiActivity() as CardBrowser
+    // TODO: remove AnkiActivityProvider, use context parameters instead
+    override val ankiActivity: AnkiActivity
+        get() = requireAnkiActivity()
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     lateinit var cardsAdapter: BrowserMultiColumnAdapter
@@ -1762,8 +1763,6 @@ class CardBrowserFragment :
     private fun addNote() {
         onAddNoteActivityResult.launch(addNoteLauncher.toIntent(requireContext()))
     }
-
-    private fun requireCardBrowserActivity(): CardBrowser = requireActivity() as CardBrowser
 
     /**
      * Updates the tags of selected/checked notes and saves them to the disk

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.anki.browser
 
+import android.app.Activity
 import android.content.Context
 import android.graphics.Color
 import android.os.Bundle
@@ -35,6 +36,8 @@ import android.view.inputmethod.EditorInfo
 import android.widget.Button
 import android.widget.ImageButton
 import android.widget.TextView
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.annotation.CheckResult
 import androidx.annotation.LayoutRes
 import androidx.annotation.VisibleForTesting
@@ -127,6 +130,7 @@ import com.ichi2.anki.libanki.undoLabel
 import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.model.CardsOrNotes.CARDS
 import com.ichi2.anki.model.SelectableDeck
+import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.previewer.PreviewerFragment
@@ -199,6 +203,16 @@ class CardBrowserFragment :
     private lateinit var tagsDialogFactory: TagsDialogFactory
 
     private var undoSnackbar: Snackbar? = null
+
+    private val onAddNoteActivityResult =
+        registerForActivityResult(StartActivityForResult()) { result: ActivityResult ->
+            Timber.d("onAddNoteActivityResult: resultCode=%d", result.resultCode)
+            if (result.resultCode == Activity.RESULT_OK) {
+                // The old forceRefreshSearch called setQuery(searchView.text) before searching,
+                // but the ViewModel already holds the submitted query, so we just re-run the search directly.
+                activityViewModel.launchSearchForCards()
+            }
+        }
 
     /** The focused row, should only be used for efficient `notifyItemChanged` calls */
     private var focusedRow: CardOrNoteId? = null
@@ -548,7 +562,7 @@ class CardBrowserFragment :
 
                     when (menuItem.itemId) {
                         R.id.action_add_note_from_card_browser -> {
-                            requireCardBrowserActivity().addNoteFromCardBrowser()
+                            addNote()
                             return true
                         }
                         R.id.action_save_search -> {
@@ -1180,10 +1194,13 @@ class CardBrowserFragment :
                 }
             }
             KeyEvent.KEYCODE_E -> {
-                // NOTE: Ctrl+E is 'Add Note', set in the Activity
                 if (event.isCtrlPressed && event.isShiftPressed) {
                     Timber.i("Ctrl+Shift+E: Export selected cards")
                     exportSelected()
+                    return true
+                } else if (event.isCtrlPressed) {
+                    Timber.i("Ctrl+E: Add Note")
+                    addNote()
                     return true
                 } else if (!event.isCtrlPressed) {
                     if (legacySearchView?.isIconified == true) {
@@ -1725,6 +1742,14 @@ class CardBrowserFragment :
 
     private fun CardOrNoteId.toRowSelection() =
         RowSelection(rowId = this, topOffset = calculateTopOffset(activityViewModel.getPositionOfId(this)!!))
+
+    @VisibleForTesting
+    val addNoteLauncher: NoteEditorLauncher
+        get() = NoteEditorLauncher.AddNoteFromCardBrowser(activityViewModel)
+
+    private fun addNote() {
+        onAddNoteActivityResult.launch(addNoteLauncher.toIntent(requireContext()))
+    }
 
     private fun requireCardBrowserActivity(): CardBrowser = requireActivity() as CardBrowser
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -156,6 +156,7 @@ import com.ichi2.utils.replaceText
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
+import net.ankiweb.rsdroid.RustCleanup
 import net.ankiweb.rsdroid.Translations
 import timber.log.Timber
 
@@ -194,8 +195,7 @@ class CardBrowserFragment :
 
     // DEFECT: Doesn't need to be a local
     private var tagsDialogListenerAction: TagsDialogListenerAction? = null
-    private val tagsDialogFactory: TagsDialogFactory
-        get() = ankiActivity.tagsDialogFactory
+    private lateinit var tagsDialogFactory: TagsDialogFactory
 
     private var undoSnackbar: Snackbar? = null
 
@@ -235,6 +235,11 @@ class CardBrowserFragment :
     @get:LayoutRes
     private val layout: Int
         get() = if (useSearchView) R.layout.fragment_card_browser_searchview else R.layout.fragment_card_browser
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        tagsDialogFactory = TagsDialogFactory(listener = this).attachToActivity<TagsDialogFactory>(requireActivity())
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -1632,6 +1637,7 @@ class CardBrowserFragment :
         }
     }
 
+    @RustCleanup("this isn't how Desktop Anki does it")
     override fun onSelectedTags(
         selectedTags: List<String>,
         indeterminateTags: List<String>,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -553,7 +553,7 @@ class CardBrowserTest : RobolectricTest() {
 
             assertThat("The target deck should be selected", b.lastDeckId, equalTo(targetDid))
 
-            val addIntent = b.addNoteLauncher.toIntent(targetContext)
+            val addIntent = b.cardBrowserFragment.addNoteLauncher.toIntent(targetContext)
             IntentAssert.hasExtra(addIntent.extras, NoteEditorFragment.EXTRA_DID, targetDid)
         }
 
@@ -566,7 +566,7 @@ class CardBrowserTest : RobolectricTest() {
 
         assertThat("The initial deck should be selected", b.lastDeckId, equalTo(initialDid))
 
-        val addIntent = b.addNoteLauncher.toIntent(targetContext)
+        val addIntent = b.cardBrowserFragment.addNoteLauncher.toIntent(targetContext)
         IntentAssert.hasExtra(addIntent.extras, NoteEditorFragment.EXTRA_DID, initialDid)
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -50,6 +50,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import anki.search.BrowserRow
 import anki.search.BrowserRow.Color
+import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.IntentHandler.Companion.grantedStoragePermissions
@@ -879,7 +880,7 @@ class CardBrowserTest : RobolectricTest() {
             assertThat("Result should be empty", cardBrowser.viewModel.rowCount, equalTo(0))
 
             advanceRobolectricLooper()
-            cardBrowser.searchAllDecks()
+            cardBrowser.viewModel.setSelectedDeck(SelectableDeck.AllDecks)
             advanceRobolectricLooper()
             assertThat("Result should contain one card", cardBrowser.viewModel.rowCount, equalTo(1))
         }
@@ -892,7 +893,7 @@ class CardBrowserTest : RobolectricTest() {
             addBasicAndReversedNote("Hello", "Anki")
 
             browserWithNoNewCards.apply {
-                searchAllDecks()
+                viewModel.setSelectedDeck(SelectableDeck.AllDecks)
                 advanceRobolectricLooper()
                 with(viewModel) {
                     assertThat("Result should contain 4 cards", rowCount, equalTo(4))
@@ -2130,3 +2131,6 @@ suspend fun CardBrowser.selectAll() {
 
 val CardBrowser.menu: Menu
     get() = if (this.useSearchView) cardBrowserFragment.searchBar!!.menu else shadowOf(this).optionsMenu!!
+
+val CardBrowser.selectedDeckNameForUi: String
+    get() = CollectionManager.getColUnsafe().decks.name(viewModel.lastDeckId!!)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -22,7 +22,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.TurbineTestContext
 import app.cash.turbine.test
 import com.ichi2.anki.AnkiDroidApp
-import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.Flag
 import com.ichi2.anki.NoteEditorFragment
@@ -79,6 +78,7 @@ import com.ichi2.anki.model.LegacySortType.NO_SORTING
 import com.ichi2.anki.model.LegacySortType.SORT_FIELD
 import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.model.SortType
+import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.servicelayer.NoteService
 import com.ichi2.anki.setFlagFilterSync
 import com.ichi2.anki.settings.Prefs
@@ -286,7 +286,7 @@ class CardBrowserViewModelTest : JvmTest() {
 
             assertThat("All decks should be selected", hasSelectedAllDecks())
 
-            val addIntent = CardBrowser.createAddNoteLauncher(this).toIntent(mockIt())
+            val addIntent = NoteEditorLauncher.AddNoteFromCardBrowser(this).toIntent(mockIt())
             IntentAssert.doesNotHaveExtra(addIntent.extras, NoteEditorFragment.EXTRA_DID)
         }
 


### PR DESCRIPTION
## Purpose / Description
Finishes the decoupling for card browser fragment so it can be used outside of card browser activity.

## Fixes
* For GSoC 2026: Redesign Deck Picker

## Approach
Moves the remaining dependent parts into the fragment itself:
- TagsDialogFactory is created during onCreate
- useSearchView reads from prefs directly
- selectedDeckNameForUi / searchAllDecks() were moved inline and use viewModel calls
- addNoteFromCardBrowser registers it's own launcher

## How Has This Been Tested?
Compiles and builds successfully.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->