### PR TITLE
build(deps): adopt Anki 26.05

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt
@@ -128,8 +128,8 @@ val collectionMethods =
         "getIgnoredBeforeCount" to { bytes -> getIgnoredBeforeCountRaw(bytes) },
         "getRetentionWorkload" to { bytes -> getRetentionWorkloadRaw(bytes) },
         "simulateFsrsWorkload" to { bytes -> simulateFsrsWorkloadRaw(bytes) },
-        // https://github.com/ankitects/anki/pull/4326 -> saveCustomColours should be no-op in mobile clients
-        "saveCustomColours" to { bytes -> backendIdentity(bytes) },
+        "saveCustomColours" to { bytes -> saveCustomColoursRaw(bytes) },
+        "getCustomColours" to { bytes -> getCustomColoursRaw(bytes) },
     )
 
 suspend fun handleCollectionPostRequest(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt
@@ -130,6 +130,7 @@ val collectionMethods =
         "simulateFsrsWorkload" to { bytes -> simulateFsrsWorkloadRaw(bytes) },
         // https://github.com/ankitects/anki/pull/4326 -> saveCustomColours should be no-op in mobile clients
         "saveCustomColours" to { bytes -> backendIdentity(bytes) },
+        "getCustomColours" to { bytes -> getCustomColoursRaw(bytes) },
     )
 
 suspend fun handleCollectionPostRequest(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/Fsrs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/Fsrs.kt
@@ -43,7 +43,7 @@ value class FsrsVersion(
         when (libraryVersion) {
             "0.6.4" -> "FSRS 4.5"
             "1.4.3", "2.0.3" -> "FSRS 5"
-            "4.1.1", "5.1.0" -> "FSRS 6"
+            "4.1.1", "5.1.0", "5.2.0" -> "FSRS 6"
             else -> null
         }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
@@ -39,7 +39,9 @@ class TranslationTest : RobolectricTest() {
     @Test
     fun `translatable strings do not duplicate GeneratedTranslations`() =
         runTest {
-            val backendStrings = getBackendNonArgStrings()
+            val backendStrings =
+                getBackendNonArgStrings()
+                    .filterNot { it.methodName in IGNORED_BACKEND_TRANSLATIONS }
             val backendByText = backendStrings.groupBy { it.text }
             val backendByTextLower = backendStrings.groupBy { it.text.lowercase() }
             val xmlStrings = getTranslatableXmlStrings()
@@ -362,6 +364,17 @@ class TranslationTest : RobolectricTest() {
                 "Show answer", // R.string.show_answer
                 // TR.studyingShowAnswer()
                 // TR.deckConfigQuestionActionShowAnswer()
+            )
+
+        /**
+         * Backend translation method names (e.g. `TR.xx()`) excluded from the
+         * duplicate check as the strings are unrelated conceptually.
+         *
+         * Do not remove this set when empty.
+         */
+        private val IGNORED_BACKEND_TRANSLATIONS =
+            setOf(
+                "launcherOff", // "Off" - unrelated to R.string.full_screen_off
             )
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
@@ -26,7 +26,9 @@ class TranslationTest : RobolectricTest() {
     @Test
     fun `translatable strings do not duplicate GeneratedTranslations`() =
         runTest {
-            val backendStrings = getBackendNonArgStrings()
+            val backendStrings =
+                getBackendNonArgStrings()
+                    .filterNot { it.methodName in IGNORED_BACKEND_TRANSLATIONS }
             val backendByText = backendStrings.groupBy { it.text }
             val backendByTextLower = backendStrings.groupBy { it.text.lowercase() }
             val xmlStrings = getTranslatableXmlStrings()
@@ -355,6 +357,17 @@ class TranslationTest : RobolectricTest() {
                 "Manage note types", // R.string.model_browser_label
                 // TR.browsingManageNoteTypes()
                 // TR.qtMiscManageNoteTypes()
+            )
+
+        /**
+         * Backend translation method names (e.g. `TR.xx()`) excluded from the
+         * duplicate check as the strings are unrelated conceptually.
+         *
+         * Do not remove this set when empty.
+         */
+        private val IGNORED_BACKEND_TRANSLATIONS =
+            setOf(
+                "launcherOff", // "Off" - unrelated to R.string.full_screen_off
             )
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/pages/PostRequestHandlerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/pages/PostRequestHandlerTest.kt
@@ -26,6 +26,7 @@ import org.hamcrest.Matchers.not
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.InputStreamReader
+import kotlin.test.assertNotNull
 
 @RunWith(AndroidJUnit4::class)
 class PostRequestHandlerTest : RobolectricTest() {
@@ -38,6 +39,13 @@ class PostRequestHandlerTest : RobolectricTest() {
             containsInAnyOrder((collectionMethods + uiMethods).keys),
         )
     }
+
+    @Test
+    fun `saveCustomColours does not throw`() =
+        runTest {
+            // saveCustomColours is a FrontendService which is not implemented, but should not throw
+            assertNotNull(handleCollectionPostRequest("saveCustomColours", byteArrayOf()))
+        }
 
     /**
      * Auto-generated list of all typescript funcs created & packaged during backend build

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,7 +70,7 @@ androidxWebkit = "1.16.0"
 # https://developer.android.com/jetpack/androidx/releases/work
 androidxWork = "2.11.2"
 # https://github.com/ankidroid/Anki-Android-Backend/
-ankiBackend = '0.1.64-anki25.09.2'
+ankiBackend = '0.1.66-anki26.05'
 autoService = "1.1.1"
 autoServiceAnnotations = "1.1.1"
 # https://github.com/skydoves/ColorPickerView/releases

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,7 +64,7 @@ androidxWebkit = "1.15.0"
 # https://developer.android.com/jetpack/androidx/releases/work
 androidxWork = "2.11.2"
 # https://github.com/ankidroid/Anki-Android-Backend/
-ankiBackend = '0.1.64-anki25.09.2'
+ankiBackend = '0.1.66-anki26.05'
 autoService = "1.1.1"
 autoServiceAnnotations = "1.1.1"
 # https://github.com/skydoves/ColorPickerView/releases

--- a/libanki/src/main/java/com/ichi2/anki/libanki/Collection.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Collection.kt
@@ -1493,6 +1493,12 @@ class Collection(
 
     @NotInPyLib
     fun evaluateParamsLegacyRaw(input: ByteArray): ByteArray = backend.evaluateParamsLegacyRaw(input = input)
+
+    @NotInPyLib
+    fun saveCustomColoursRaw(input: ByteArray): ByteArray = backend.saveCustomColoursRaw(input = input)
+
+    @NotInPyLib
+    fun getCustomColoursRaw(input: ByteArray): ByteArray = backend.getCustomColoursRaw(input = input)
 }
 
 @NotInPyLib

--- a/libanki/src/main/java/com/ichi2/anki/libanki/Collection.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Collection.kt
@@ -1493,6 +1493,9 @@ class Collection(
 
     @NotInPyLib
     fun evaluateParamsLegacyRaw(input: ByteArray): ByteArray = backend.evaluateParamsLegacyRaw(input = input)
+
+    @NotInPyLib
+    fun getCustomColoursRaw(input: ByteArray): ByteArray = backend.getCustomColoursRaw(input = input)
 }
 
 @NotInPyLib

--- a/libanki/src/main/java/com/ichi2/anki/libanki/Deck.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Deck.kt
@@ -135,6 +135,7 @@ fun Order.toDisplayString(translations: Translations) =
         Order.REVERSE_ADDED -> translations.decksLatestAddedFirst()
         Order.RETRIEVABILITY_ASCENDING -> translations.deckConfigSortOrderRetrievabilityAscending()
         Order.RETRIEVABILITY_DESCENDING -> translations.deckConfigSortOrderRetrievabilityDescending()
+        Order.RELATIVE_OVERDUENESS -> translations.decksRelativeOverdueness()
         Order.UNRECOGNIZED -> throw IllegalArgumentException("Can't display an unknown enum value.")
     }
 


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.8 - ignoring translations
> Assisted-by: Claude Fable 5 - dependency bump

----

## Purpose / Description

This updates the backend to pull in https://github.com/ankitects/anki/releases/tag/26.05

## Fixes
* Part of https://github.com/ankidroid/Anki-Android/issues/21016
* See https://github.com/ankidroid/Anki-Android-Backend/pull/699

## Approach
* https://github.com/ankidroid/Anki-Android-Backend/pull/699 - bump the backend
* Pull in the dependency, and fix the failures

## How Has This Been Tested?
⚠️ Only unit tested, this should be soaked in alpha

## Learning
* last change: https://github.com/ankidroid/Anki-Android/pull/19194
* `saveCustomColors` is a `FrontendService` method and not implemented by mobile clients

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)