### PR TITLE
refactor: extract `AnkiDroidApp.instance` to `:common:android`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -36,6 +36,8 @@ import anki.collection.OpChanges
 import com.ichi2.anki.AnkiDroidApp.Companion.sharedPreferencesTestingOverride
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
+import com.ichi2.anki.common.android.ApplicationContextInitializer
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.annotations.LegacyNotifications
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.coroutines.applicationScope
@@ -141,6 +143,7 @@ open class AnkiDroidApp :
             }
         }
         instance = this
+        ApplicationContextInitializer.setInstance(this)
 
         // Get preferences
         val preferences = this.sharedPrefs()
@@ -467,6 +470,9 @@ open class AnkiDroidApp :
                 isAccessible = true
                 set(field, null)
             }
+            // Mirror reality: when AnkiDroidApp.onCreate doesn't run (the bmgr-restore
+            // scenario), appContext is also uninitialized.
+            ApplicationContextInitializer.clearForTesting()
         }
 
         @VisibleForTesting(otherwise = VisibleForTesting.NONE)
@@ -477,6 +483,10 @@ open class AnkiDroidApp :
                 isAccessible = true
                 set(field, value)
             }
+            // Production code (AnkiDroidApp.onCreate) sets appContext
+            // right after AnkiDroidApp.instance. Mirror that in tests so callers using the
+            // common-side accessor see the same mock.
+            ApplicationContextInitializer.setInstance(value)
         }
 
         /** Load the libraries to allow access to Anki-Android-Backend */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -676,7 +676,7 @@ open class CardBrowser :
     /**
      * Implementation of `by viewModels()` for use in [onCreate]
      *
-     * @see showedActivityFailedScreen - we may not have AnkiDroidApp.instance and therefore can't
+     * @see showedActivityFailedScreen - we may not have appContext and therefore can't
      * create the ViewModel
      *
      * @param fragmented True if `noteEditorFrame` is non-null (x-large displays)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -63,6 +63,7 @@ import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.shortcut
 import com.ichi2.anki.cardviewer.SingleCardSide
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.utils.android.showThemedToast
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
@@ -1277,7 +1278,7 @@ open class CardTemplateEditor : AnkiActivity(R.layout.activity_card_template_edi
             }
 
         private fun launchCardBrowserAppearance(currentTemplate: BackendCardTemplate) {
-            val context = AnkiDroidApp.instance.baseContext
+            val context = appContext
             val browserAppearanceIntent = CardTemplateBrowserAppearanceEditor.getIntentFromTemplate(context, currentTemplate)
             onCardBrowserAppearanceActivityResult.launch(browserAppearanceIntent)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateNotetype.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateNotetype.kt
@@ -22,6 +22,7 @@ import android.os.Parcel
 import android.os.Parcelable
 import androidx.core.os.bundleOf
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.compat.CompatHelper.Companion.compat
 import com.ichi2.anki.compat.CompatHelper.Companion.getSerializableCompat
@@ -55,7 +56,7 @@ class CardTemplateNotetype(
 
     fun toBundle(): Bundle =
         bundleOf(
-            INTENT_MODEL_FILENAME to saveTempNoteType(AnkiDroidApp.instance.applicationContext, notetype),
+            INTENT_MODEL_FILENAME to saveTempNoteType(appContext, notetype),
             "mTemplateChanges" to templateChanges,
         )
 
@@ -406,7 +407,7 @@ class CardTemplateNotetype(
         /** Clear any temp note type files saved into internal cache directory  */
         fun clearTempNoteTypeFiles(): Int {
             var deleteCount = 0
-            for (c in AnkiDroidApp.instance.cacheDir.listFiles() ?: arrayOf()) {
+            for (c in appContext.cacheDir.listFiles() ?: arrayOf()) {
                 val absolutePath = c.absolutePath
                 if (absolutePath.contains("editedTemplate") && absolutePath.endsWith("json")) {
                     if (!c.delete()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -288,7 +288,7 @@ object CollectionHelper {
      *
      * @return the absolute path to the AnkiDroid directory.
      */
-    // This uses a lambda as we typically depends on the `lateinit` AnkiDroidApp.instance
+    // This uses a lambda as we typically depends on the `lateinit` appContext
     // If we remove all Android references, we get a significant unit test speedup
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     internal fun getCurrentAnkiDroidDirectoryOptionalContext(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
@@ -31,6 +31,7 @@ import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.CollectionManager.withOpenColOrNull
 import com.ichi2.anki.CollectionManager.withQueue
 import com.ichi2.anki.backend.createDatabaseUsingRustBackend
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.utils.android.isRobolectric
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.CollectionFiles
@@ -288,8 +289,8 @@ object CollectionManager {
     }
 
     fun getCollectionDirectory() =
-        // Allow execution if AnkiDroidApp.instance is not initialized
-        CollectionHelper.getCurrentAnkiDroidDirectoryOptionalContext(AnkiDroidApp.sharedPrefs()) { AnkiDroidApp.instance }
+        // Allow execution if appContext is not initialized
+        CollectionHelper.getCurrentAnkiDroidDirectoryOptionalContext(AnkiDroidApp.sharedPrefs()) { appContext }
 
     /** Ensures the AnkiDroid directory is created, then returns the path to the
      * folder and the name of the collection file inside it. */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DayRolloverHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DayRolloverHandler.kt
@@ -35,6 +35,7 @@ import anki.collection.OpChanges
 import anki.collection.opChanges
 import com.ichi2.anki.CollectionManager.withOpenColOrNull
 import com.ichi2.anki.android.AnkiBroadcastReceiver
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.exception.ManuallyReportedException
@@ -110,7 +111,7 @@ object DayRolloverHandler : AnkiBroadcastReceiver() {
 
         Timber.i("day cutoff changed %d -> %d", lastCutoff, currentCutoff)
         // Re-arm the wall-clock alarm whenever the cutoff changes
-        DayRolloverAlarm.scheduleNext(AnkiDroidApp.instance)
+        DayRolloverAlarm.scheduleNext(appContext)
         // we do not want to send a "study queues changes" message initially
         if (lastCutoff != null) {
             handleDayRollover()
@@ -126,7 +127,7 @@ object DayRolloverHandler : AnkiBroadcastReceiver() {
 
         Timber.i("day rollover: updating widgets")
         try {
-            WidgetStatus.updateInBackground(AnkiDroidApp.instance)
+            WidgetStatus.updateInBackground(appContext)
         } catch (e: Exception) {
             Timber.w(e, "failed to update widgets")
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -102,6 +102,7 @@ import com.ichi2.anki.android.back.exitViaDoubleTapBackCallback
 import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.shortcut
 import com.ichi2.anki.android.view.locationInWindow
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.destinations.navigate
@@ -989,7 +990,7 @@ open class DeckPicker :
      * @see DeckPickerViewModel.handleStartup
      */
     private fun handleStartup() {
-        val context = AnkiDroidApp.instance
+        val context = appContext
 
         val environment: AnkiDroidEnvironment =
             object : AnkiDroidEnvironment {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/JavaScriptTTS.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/JavaScriptTTS.kt
@@ -20,6 +20,7 @@ import android.os.Bundle
 import android.speech.tts.TextToSpeech
 import android.speech.tts.TextToSpeech.OnInitListener
 import androidx.annotation.IntDef
+import com.ichi2.anki.common.android.appContext
 
 /**
  * Since it is assumed that only advanced users will use the JavaScript api,
@@ -136,7 +137,7 @@ class JavaScriptTTS internal constructor() : OnInitListener {
     }
 
     init {
-        val context = AnkiDroidApp.instance.applicationContext
+        val context = appContext
         tts = TextToSpeech(context, this)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -89,6 +89,7 @@ import com.ichi2.anki.OnContextAndLongClickListener.Companion.setOnContextAndLon
 import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.ShortcutGroupProvider
 import com.ichi2.anki.android.input.shortcut
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.utils.HashUtil
@@ -130,7 +131,6 @@ import com.ichi2.anki.multimedia.MultimediaResult
 import com.ichi2.anki.multimedia.MultimediaResultContract
 import com.ichi2.anki.multimedia.MultimediaUtils.createImageFile
 import com.ichi2.anki.multimedia.MultimediaViewModel
-import com.ichi2.anki.multimediacard.IMultimediaEditableNote
 import com.ichi2.anki.multimediacard.impl.MultimediaEditableNote
 import com.ichi2.anki.noteeditor.CustomToolbarButton
 import com.ichi2.anki.noteeditor.FieldState
@@ -2730,7 +2730,7 @@ class NoteEditorFragment :
         fun addNoteArgs(): Bundle = Bundle().apply { putInt(EXTRA_CALLER, NoteEditorCaller.DECKPICKER.value) }
 
         fun shouldReplaceNewlines(): Boolean =
-            AnkiDroidApp.instance
+            appContext
                 .sharedPrefs()
                 .getBoolean(PREF_NOTE_EDITOR_NEWLINE_REPLACE, true)
 
@@ -2743,7 +2743,7 @@ class NoteEditorFragment :
         }
 
         private fun shouldHideToolbar(): Boolean =
-            !AnkiDroidApp.instance
+            !appContext
                 .sharedPrefs()
                 .getBoolean(PREF_NOTE_EDITOR_SHOW_TOOLBAR, true)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/TtsVoices.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/TtsVoices.kt
@@ -24,6 +24,7 @@ package com.ichi2.anki
 
 import android.speech.tts.TextToSpeech
 import android.speech.tts.Voice
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.i18n.normalize
 import com.ichi2.anki.i18n.toAnkiTwoLetterCode
@@ -202,7 +203,7 @@ object TtsVoices {
                 // TextToSpeech retains the context. So we can't give it any context that
                 // may be expected to disappear, as it would cause a memory leak. Hence
                 // we pass it the application as context.
-                TextToSpeech(AnkiDroidApp.instance) { status ->
+                TextToSpeech(appContext) { status ->
                     if (status == TextToSpeech.SUCCESS) {
                         Timber.v("TTS creation success")
                         ttsEngine = textToSpeech?.defaultEngine

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
@@ -40,6 +40,7 @@ import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
 import androidx.core.graphics.scale
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.time.Time
 import com.ichi2.anki.common.time.getTimestamp
@@ -585,7 +586,7 @@ class Whiteboard(
         }
 
         private val displayDimensions: Point
-            get() = getDisplayDimensions(AnkiDroidApp.instance.applicationContext)
+            get() = getDisplayDimensions(appContext)
     }
 
     init {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidUsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidUsageAnalytics.kt
@@ -7,9 +7,9 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.criticalay.GoogleAnalytics
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.BuildConfig
 import com.ichi2.anki.R
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.utils.ext.getRootCause
 import com.ichi2.anki.preferences.sharedPrefs
@@ -49,7 +49,7 @@ object AnkiDroidUsageAnalytics {
 
     /**
      * Application context captured during [initialize]. Held here so we don't
-     * rely on [AnkiDroidApp.instance] from background paths the singleton can
+     * rely on [appContext] from background paths the singleton can
      * be uninitialized in rare Android scenarios (e.g. BackupManager) and
      * analytics is a startup concern that must not crash.
      */
@@ -223,7 +223,7 @@ object AnkiDroidUsageAnalytics {
         get() = optIn
         set(value) {
             optIn = value
-            AnkiDroidApp.instance.sharedPrefs().edit {
+            appContext.sharedPrefs().edit {
                 putBoolean(ANALYTICS_OPTIN_KEY, value)
             }
             // Rebuild the underlying client so its own `enabled` flag picks

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
@@ -26,10 +26,10 @@ import com.brsanthu.googleanalytics.GoogleAnalytics
 import com.brsanthu.googleanalytics.GoogleAnalyticsConfig
 import com.brsanthu.googleanalytics.httpclient.OkHttpClientImpl
 import com.brsanthu.googleanalytics.request.DefaultRequest
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.BuildConfig
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsConstants.reportablePrefKeys
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.utils.DisplayUtils
@@ -190,7 +190,7 @@ object UsageAnalytics {
         sAnalytics!!.flush()
         sAnalytics = null
         unInstallDefaultExceptionHandler()
-        initialize(AnkiDroidApp.instance.applicationContext)
+        initialize(appContext)
     }
 
     /**
@@ -306,12 +306,12 @@ object UsageAnalytics {
     // A listener on this preference handles the rest
     var isEnabled: Boolean
         get() {
-            val userPrefs = AnkiDroidApp.instance.sharedPrefs()
+            val userPrefs = appContext.sharedPrefs()
             return userPrefs.getBoolean(ANALYTICS_OPTIN_KEY, false)
         }
         set(value) {
             // A listener on this preference handles the rest
-            AnkiDroidApp.instance.sharedPrefs().edit {
+            appContext.sharedPrefs().edit {
                 putBoolean(ANALYTICS_OPTIN_KEY, value)
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/android/back/ExitViaDoubleTapBackBackPressCallback.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/android/back/ExitViaDoubleTapBackBackPressCallback.kt
@@ -21,8 +21,8 @@ import androidx.activity.OnBackPressedCallback
 import androidx.preference.PreferenceManager
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.AnkiActivity
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.utils.android.HandlerUtils
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
@@ -91,6 +91,6 @@ fun AnkiActivity.exitViaDoubleTapBackCallback(): OnBackPressedCallback =
             }
 
         PreferenceManager
-            .getDefaultSharedPreferences(AnkiDroidApp.instance)
+            .getDefaultSharedPreferences(appContext)
             .registerOnSharedPreferenceChangeListener(callback.strongListenerReference)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/LastDeckIdRepository.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/LastDeckIdRepository.kt
@@ -18,7 +18,7 @@ package com.ichi2.anki.browser
 
 import android.content.Context
 import androidx.core.content.edit
-import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.Decks
 
@@ -37,7 +37,7 @@ interface LastDeckIdRepository {
 class SharedPreferencesLastDeckIdRepository : LastDeckIdRepository {
     override var lastDeckId: DeckId?
         get() =
-            AnkiDroidApp.instance
+            appContext
                 .getSharedPreferences(PERSISTENT_STATE_FILE, 0)
                 .getLong(LAST_DECK_ID_KEY, Decks.NOT_FOUND_DECK_ID)
                 .takeUnless { it == Decks.NOT_FOUND_DECK_ID }
@@ -45,14 +45,14 @@ class SharedPreferencesLastDeckIdRepository : LastDeckIdRepository {
             if (value == null) {
                 clearLastDeckId()
             } else {
-                AnkiDroidApp.instance.getSharedPreferences(PERSISTENT_STATE_FILE, 0).edit {
+                appContext.getSharedPreferences(PERSISTENT_STATE_FILE, 0).edit {
                     putLong(LAST_DECK_ID_KEY, value)
                 }
             }
 
     companion object {
         fun clearLastDeckId() {
-            val context: Context = AnkiDroidApp.instance
+            val context: Context = appContext
             context.getSharedPreferences(PERSISTENT_STATE_FILE, 0).edit {
                 remove(LAST_DECK_ID_KEY)
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
@@ -23,12 +23,12 @@ import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.AbstractFlashcardViewer.Companion.getMediaBaseUrl
 import com.ichi2.anki.AndroidTtsError
 import com.ichi2.anki.AndroidTtsPlayer
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionHelper.getMediaDirectory
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.cardviewer.MediaErrorBehavior.CONTINUE_MEDIA
 import com.ichi2.anki.cardviewer.MediaErrorBehavior.RETRY_MEDIA
 import com.ichi2.anki.cardviewer.MediaErrorBehavior.STOP_MEDIA
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.libanki.AvTag
 import com.ichi2.anki.libanki.Card
@@ -98,7 +98,7 @@ class CardMediaPlayer : Closeable {
         this.mediaErrorListener = mediaErrorListener
         this.soundTagPlayer =
             SoundTagPlayer(
-                soundUriBase = getMediaBaseUrl(getMediaDirectory(AnkiDroidApp.instance)),
+                soundUriBase = getMediaBaseUrl(getMediaDirectory(appContext)),
                 videoPlayer = VideoPlayer(javascriptEvaluator),
             )
         this.ttsPlayer = scope.async { AndroidTtsPlayer.createInstance(scope) }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
@@ -29,8 +29,8 @@ import androidx.media3.common.C.AUDIO_CONTENT_TYPE_MUSIC
 import androidx.media3.common.audio.AudioFocusRequestCompat
 import androidx.media3.common.audio.AudioManagerCompat
 import androidx.media3.common.util.UnstableApi
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.ensureActive
 import com.ichi2.anki.libanki.SoundOrVideoTag
@@ -60,7 +60,7 @@ class SoundTagPlayer(
      * AudioManager to request/release audio focus
      */
     private var audioManager: AudioManager =
-        AnkiDroidApp.instance.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        appContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
 
     // the same instance of an AudioFocusRequestCompat must be used to cancel focus
     private val audioFocusRequest: AudioFocusRequestCompat by lazy {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AsyncDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AsyncDialogFragment.kt
@@ -19,6 +19,7 @@ import android.content.Context
 import android.content.res.Resources
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
+import com.ichi2.anki.common.android.appContext
 import timber.log.Timber
 
 abstract class AsyncDialogFragment : AnalyticsDialogFragment() {
@@ -46,13 +47,13 @@ abstract class AsyncDialogFragment : AnalyticsDialogFragment() {
 
     /**
      * Return the {@link Context} this fragment is currently associated with.
-     * Uses [AnkiDroidApp.instance] if [requireContext] fails
+     * Uses [appContext] if [requireContext] fails
      */
     protected fun getSafeContext(): Context =
         try {
             requireContext()
         } catch (e: Exception) {
             Timber.w(e, "Error getting context; using AnkiDroidApp")
-            AnkiDroidApp.instance
+            appContext
         }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/viewmodel/TtsVoicesViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/viewmodel/TtsVoicesViewModel.kt
@@ -20,8 +20,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ichi2.anki.AndroidTtsPlayer
 import com.ichi2.anki.AndroidTtsVoice
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.TtsVoices
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.dialogs.tryDisplayLocalizedName
 import com.ichi2.anki.libanki.TTSTag
 import com.ichi2.anki.libanki.TtsPlayer
@@ -197,7 +197,7 @@ class TtsVoicesViewModel : ViewModel() {
     fun copyToClipboard(voice: TtsVoice) {
         // At least in API 33, we do not need to display a snackbar, as the Android OS already
         // displays the copied text
-        AnkiDroidApp.instance.copyToClipboard(
+        appContext.copyToClipboard(
             text = voice.toString(),
         )
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -47,9 +47,9 @@ import androidx.core.graphics.drawable.toDrawable
 import androidx.core.view.children
 import androidx.core.view.isVisible
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.NoteEditorFragment
 import com.ichi2.anki.R
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.compat.CompatHelper
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.utils.AndroidUiUtils.showSoftInput
@@ -224,7 +224,7 @@ class Toolbar : FrameLayout {
         button.setPaddingRelative(twoDp, twoDp, twoDp, twoDp)
         // end apply style
         val shouldScroll =
-            AnkiDroidApp.instance
+            appContext
                 .sharedPrefs()
                 .getBoolean(NoteEditorFragment.PREF_NOTE_EDITOR_SCROLL_TOOLBAR, true)
         if (shouldScroll) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerHelpers.kt
@@ -21,8 +21,8 @@ import androidx.appcompat.widget.ThemeUtils
 import androidx.core.view.updateLayoutParams
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.shape.ShapeAppearanceModel
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.LanguageUtils
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.libanki.CardOrdinal
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.settings.enums.FrameStyle
@@ -41,7 +41,7 @@ import org.intellij.lang.annotations.Language
  */
 @Language("HTML")
 fun stdHtml(
-    context: Context = AnkiDroidApp.instance,
+    context: Context = appContext,
     extraJsAssets: List<String> = emptyList(),
     nightMode: Boolean = false,
 ): String {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/GestureMapper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/GestureMapper.kt
@@ -17,10 +17,10 @@ package com.ichi2.anki.reviewer
 
 import android.content.SharedPreferences
 import android.view.ViewConfiguration
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.TapGestureMode
 import com.ichi2.anki.cardviewer.TapGestureMode.Companion.fromPreference
+import com.ichi2.anki.common.android.appContext
 import timber.log.Timber
 import kotlin.math.abs
 import kotlin.math.floor
@@ -39,7 +39,7 @@ class GestureMapper {
         // Else, when Robolectric executes in the CI it accesses AnkiDroidApp.getInstance before it exists #9173
         if (VIEW_CONFIGURATION == null) {
             // Set good default values for swipe detection
-            VIEW_CONFIGURATION = ViewConfiguration.get(AnkiDroidApp.instance)
+            VIEW_CONFIGURATION = ViewConfiguration.get(appContext)
             DEFAULT_SWIPE_MIN_DISTANCE = VIEW_CONFIGURATION!!.scaledPagingTouchSlop
             DEFAULT_SWIPE_THRESHOLD_VELOCITY = VIEW_CONFIGURATION!!.scaledMinimumFlingVelocity
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewRemindersDatabase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewRemindersDatabase.kt
@@ -20,7 +20,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
-import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.settings.Prefs
@@ -62,7 +62,7 @@ object ReviewRemindersDatabase {
      */
     @VisibleForTesting
     val remindersSharedPrefs: SharedPreferences =
-        AnkiDroidApp.instance.getSharedPreferences(
+        appContext.getSharedPreferences(
             SHARED_PREFS_FILE_KEY,
             Context.MODE_PRIVATE,
         )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SensibleSwipeDismissBehavior.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SensibleSwipeDismissBehavior.kt
@@ -24,7 +24,7 @@ import androidx.core.view.marginRight
 import androidx.customview.widget.ViewDragHelper
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
-import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.utils.dp
 import kotlin.math.absoluteValue
 import kotlin.math.sign
@@ -210,6 +210,6 @@ open class SensibleSwipeDismissBehavior : BaseTransientBottomBar.Behavior() {
 
 @VisibleForTesting enum class Dismiss { DoNotDismiss, ToTheLeft, ToTheRight }
 
-private val FLING_TO_DISMISS_SPEED_THRESHOLD = 1000.dp.toPx(AnkiDroidApp.instance.applicationContext)
+private val FLING_TO_DISMISS_SPEED_THRESHOLD = 1000.dp.toPx(appContext)
 
 private const val DRAG_TO_DISMISS_DISTANCE_RATIO = .5f

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/audiorecord/CheckPronunciationViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/audiorecord/CheckPronunciationViewModel.kt
@@ -17,7 +17,7 @@ package com.ichi2.anki.ui.windows.reviewer.audiorecord
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.recorder.AudioRecorder
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -26,7 +26,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 
 class CheckPronunciationViewModel(
-    private val audioRecorder: AudioRecorder = AudioRecorder(AnkiDroidApp.instance),
+    private val audioRecorder: AudioRecorder = AudioRecorder(appContext),
     private val audioPlayer: AudioPlayer = AudioPlayer(),
 ) : ViewModel() {
     init {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/AndroidUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/AndroidUtils.kt
@@ -30,8 +30,8 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.utils.android.showThemedToast
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.utils.AdaptionUtil
@@ -53,7 +53,7 @@ inline fun <T> withWakeLock(
     tag: String,
     block: () -> T,
 ): T {
-    val context = AnkiDroidApp.instance
+    val context = appContext
     val wakeLock =
         ContextCompat
             .getSystemService(context, PowerManager::class.java)!!

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt
@@ -27,7 +27,7 @@ import android.content.pm.ResolveInfo
 import android.os.Build
 import android.provider.Settings
 import androidx.core.net.toUri
-import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.compat.CompatHelper.Companion.getPackageInfoCompat
 import com.ichi2.anki.compat.CompatHelper.Companion.queryIntentActivitiesCompat
 import com.ichi2.anki.compat.MATCH_DEFAULT_ONLY_L
@@ -61,7 +61,7 @@ object AdaptionUtil {
     private val isRunningUnderFirebaseTestLab: Boolean
         get() =
             try {
-                isRunningUnderFirebaseTestLab(AnkiDroidApp.instance.contentResolver)
+                isRunningUnderFirebaseTestLab(appContext.contentResolver)
             } catch (e: Exception) {
                 Timber.w(e)
                 false
@@ -143,7 +143,7 @@ object AdaptionUtil {
         }
 
     val isMiui: Boolean by lazy {
-        val ctx: Context = AnkiDroidApp.instance
+        val ctx: Context = appContext
 
         // https://stackoverflow.com/questions/47610456/how-to-detect-miui-rom-programmatically-in-android
         fun isIntentResolved(intent: Intent): Boolean =

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
@@ -30,6 +30,7 @@ import androidx.core.os.bundleOf
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.crashreporting.CrashReportService
@@ -336,7 +337,7 @@ object ImportUtils {
                             appendLine(DebugInfoService.getDebugInfo(activity))
                         }
 
-                    AnkiDroidApp.instance.copyToClipboard(stringToCopy)
+                    appContext.copyToClipboard(stringToCopy)
                 }
 
             Timber.d("showImportUnsuccessfulDialog() message %s", failure.humanReadableMessage)

--- a/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.kt
@@ -22,8 +22,8 @@ import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.ConfigurationCompat
 import androidx.fragment.app.Fragment
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.compat.CompatHelper
 import com.ichi2.anki.preferences.sharedPrefs
 import net.ankiweb.rsdroid.BackendFactory
@@ -331,7 +331,7 @@ object LanguageUtil {
     /** If locale is not provided, the current locale will be used. */
     fun setDefaultBackendLanguages(languageTag: String? = null) {
         val langCode =
-            languageTag ?: AnkiDroidApp.instance
+            languageTag ?: appContext
                 .sharedPrefs()
                 .getString("language", SYSTEM_LANGUAGE_TAG)!!
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/NetworkUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/NetworkUtils.kt
@@ -19,15 +19,11 @@ import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
 import androidx.core.content.getSystemService
-import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.common.android.appContext
 
 object NetworkUtils {
     private val connectivityManager: ConnectivityManager?
-        get() =
-            AnkiDroidApp
-                .instance
-                .applicationContext
-                .getSystemService()
+        get() = appContext.getSystemService()
 
     /**
      * @return whether the active network is metered

--- a/AnkiDroid/src/main/java/com/ichi2/utils/VersionUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/VersionUtils.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import androidx.core.content.pm.PackageInfoCompat
 import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.common.android.ApplicationContextInitializer
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.compat.CompatHelper.Companion.getPackageInfoCompat
 import com.ichi2.anki.compat.PackageInfoFlagsCompat
@@ -98,12 +99,11 @@ object VersionUtils {
 
     private val applicationInstance: Context?
         get() =
-            if (AnkiDroidApp.isInitialized) {
-                AnkiDroidApp.instance
-            } else {
-                Timber.w("AnkiDroid instance not set")
-                null
-            }
+            ApplicationContextInitializer.instanceOrNull
+                ?: run {
+                    Timber.w("AnkiDroid instance not set")
+                    null
+                }
 
     /**
      * Return whether the package version code is set to that for release version

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
@@ -32,10 +32,10 @@ import androidx.annotation.LayoutRes
 import androidx.core.app.PendingIntentCompat
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.IntentHandler
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.UsageAnalytics
+import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.utils.android.SdCard
 import com.ichi2.anki.compat.CompatHelper.Companion.registerReceiverCompat
 import com.ichi2.anki.preferences.sharedPrefs
@@ -130,10 +130,10 @@ class AnkiDroidWidgetSmall : AnalyticsWidgetProvider() {
                                 if (action != null && action == Intent.ACTION_MEDIA_MOUNTED) {
                                     Timber.d("mountReceiver - Action = Media Mounted")
                                     if (remounted) {
-                                        WidgetStatus.updateInBackground(AnkiDroidApp.instance)
+                                        WidgetStatus.updateInBackground(appContext)
                                         remounted = false
                                         if (mountReceiver != null) {
-                                            AnkiDroidApp.instance.unregisterReceiver(mountReceiver)
+                                            appContext.unregisterReceiver(mountReceiver)
                                         }
                                     } else {
                                         remounted = true
@@ -144,7 +144,7 @@ class AnkiDroidWidgetSmall : AnalyticsWidgetProvider() {
                     val iFilter = IntentFilter()
                     iFilter.addAction(Intent.ACTION_MEDIA_MOUNTED)
                     iFilter.addDataScheme("file")
-                    AnkiDroidApp.instance.registerReceiverCompat(mountReceiver, iFilter, ContextCompat.RECEIVER_EXPORTED)
+                    appContext.registerReceiverCompat(mountReceiver, iFilter, ContextCompat.RECEIVER_EXPORTED)
                 }
             } else {
                 // Compute the total number of cards due.

--- a/common/android/src/main/java/com/ichi2/anki/common/android/ApplicationContextInitializer.kt
+++ b/common/android/src/main/java/com/ichi2/anki/common/android/ApplicationContextInitializer.kt
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Ashish Yadav <mailtoashish693@gmail.com>
+
+package com.ichi2.anki.common.android
+
+import android.app.Application
+import android.content.Context
+import androidx.annotation.VisibleForTesting
+
+/**
+ * The AnkiDroid [Application] context. Set once during `AnkiDroidApp.onCreate()`
+ * via [ApplicationContextInitializer.setInstance].
+ *
+ * Typed as [Context] since most callers only need that level of API. The setter
+ * accepts [Application] to make the lifetime guarantee explicit.
+ *
+ * Holding the Application statically is safe: it lives for the entire process.
+ * The lint warning about static `Context` fields targets Activity/View/Service
+ * contexts that have shorter lifecycles.
+ */
+lateinit var appContext: Context
+    private set
+
+object ApplicationContextInitializer {
+    /**
+     * Sets the [appContext]. Called once from `AnkiDroidApp.onCreate()`.
+     */
+    fun setInstance(app: Application) {
+        appContext = app
+    }
+
+    /**
+     * The [appContext] if it has been initialized, or `null` if not.
+     *
+     * Prefer this over checking initialization state explicitly it returns the
+     * context (or null) in one read.
+     */
+    val instanceOrNull: Context?
+        get() = if (::appContext.isInitialized) appContext else null
+
+    /**
+     * Clears [appContext]. Tests use this to simulate the `bmgr restore` scenario
+     * where `AnkiDroidApp.onCreate()` does not run.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    fun clearForTesting() {
+        // Top-level `lateinit var appContext` compiles to a static field on the
+        // ApplicationContextInitializerKt file class. Clear it via plain Java
+        // reflection so this module doesn't need to depend on kotlin-reflect at runtime.
+        val cls = Class.forName("com.ichi2.anki.common.android.ApplicationContextInitializerKt")
+        val field = cls.getDeclaredField("appContext")
+        field.isAccessible = true
+        field.set(null, null)
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Extract application context to :common:android, a step towards clean code and one more step closer to widget extraction

## Fixes
* Part of #20737

## Approach
See commit

## How Has This Been Tested?
Local build and ran on Emualtor works smooth 

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->