### PR TITLE
fix(lint): rules file location

### DIFF
--- a/lint.gradle
+++ b/lint.gradle
@@ -7,7 +7,7 @@ android {
         checkReleaseBuilds = true
         checkTestSources = true
         explainIssues = false
-        lintConfig = file('../lint-release.xml')
+        lintConfig = file("${rootDir}/lint-release.xml")
         showAll = true
         // To output the lint report to stdout set textReport=true, and leave textOutput unset.
         textReport = true


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.8 - verification

`../lint-release.xml` returned the wrong path if in a subdirectory

Fixes :common:android lint

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)