### PR TITLE
refactor: rename pre-existing 'appContext' members to avoid shadowing

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidUsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidUsageAnalytics.kt
@@ -53,10 +53,10 @@ object AnkiDroidUsageAnalytics {
      * be uninitialized in rare Android scenarios (e.g. BackupManager) and
      * analytics is a startup concern that must not crash.
      */
-    private lateinit var appContext: Context
+    private lateinit var analyticsContext: Context
 
     private val serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-    private val clientId: String by lazy { getOrCreateClientId(appContext) }
+    private val clientId: String by lazy { getOrCreateClientId(analyticsContext) }
 
     private val sharedPrefsListener =
         SharedPreferences.OnSharedPreferenceChangeListener { prefs, key ->
@@ -87,28 +87,28 @@ object AnkiDroidUsageAnalytics {
         private set
 
     fun initialize(context: Context) {
-        appContext = context.applicationContext
+        analyticsContext = context.applicationContext
 
         Timber.i("AnkiDroidUsageAnalytics:: initialize()")
 
         // Read opt-in before building the client so `enabled` reflects the
         // user's choice rather than the default.
-        handlePreferences(appContext)
+        handlePreferences(analyticsContext)
 
         if (analytics == null) {
             analytics =
                 GoogleAnalytics.builder {
-                    measurementId = appContext.getString(R.string.ga_trackingId)
+                    measurementId = analyticsContext.getString(R.string.ga_trackingId)
                     apiSecret = BuildConfig.ANALYTICS_API_KEY
-                    appName = appContext.getString(R.string.app_name)
+                    appName = analyticsContext.getString(R.string.app_name)
                     appVersion = BuildConfig.VERSION_NAME
                     enabled = optIn
-                    samplePercentage = getAnalyticsSamplePercentage(appContext)
+                    samplePercentage = getAnalyticsSamplePercentage(analyticsContext)
                     debug = false
                 }
         }
 
-        initializePrefKeys(appContext)
+        initializePrefKeys(analyticsContext)
 
         AnalyticsExceptionHandler.install(this::sendAnalyticsException)
     }
@@ -228,8 +228,8 @@ object AnkiDroidUsageAnalytics {
             }
             // Rebuild the underlying client so its own `enabled` flag picks
             // up the new opt-in state without waiting for the next launch.
-            if (::appContext.isInitialized) {
-                reinitialize(appContext)
+            if (::analyticsContext.isInitialized) {
+                reinitialize(analyticsContext)
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileManager.kt
@@ -43,7 +43,7 @@ import java.io.File
 class ProfileManager private constructor(
     context: Context,
 ) {
-    private val appContext = context.applicationContext
+    private val profileContext = context.applicationContext
 
     lateinit var activeProfileContext: Context
         private set
@@ -53,7 +53,7 @@ class ProfileManager private constructor(
      * ID of the currently active profile.
      */
     private val globalProfilePrefs by lazy {
-        appContext.getSharedPreferences(PROFILE_REGISTRY_FILENAME, Context.MODE_PRIVATE)
+        profileContext.getSharedPreferences(PROFILE_REGISTRY_FILENAME, Context.MODE_PRIVATE)
     }
 
     private val profileRegistry by lazy { ProfileRegistry(globalProfilePrefs) }
@@ -171,7 +171,7 @@ class ProfileManager private constructor(
         try {
             val wrapper =
                 ProfileContextWrapper.create(
-                    context = appContext,
+                    context = profileContext,
                     profileId = profileId,
                     profileBaseDir = profileBaseDir.file,
                 )
@@ -208,7 +208,7 @@ class ProfileManager private constructor(
         if (prefs.getString(PREF_COLLECTION_PATH, null) != null) return
 
         val profileCollectionDir =
-            getDefaultAnkiDroidDirectory(appContext, directoryName = profileId.value).apply { mkdirs() }
+            getDefaultAnkiDroidDirectory(profileContext, directoryName = profileId.value).apply { mkdirs() }
 
         prefs.edit { putString(PREF_COLLECTION_PATH, profileCollectionDir.absolutePath) }
     }
@@ -243,8 +243,8 @@ class ProfileManager private constructor(
      */
     private fun resolveProfileDirectory(profileId: ProfileId): ProfileRestrictedDirectory {
         val appDataRoot =
-            ContextCompat.getDataDir(appContext)
-                ?: appContext.filesDir.parentFile
+            ContextCompat.getDataDir(profileContext)
+                ?: profileContext.filesDir.parentFile
 
         if (appDataRoot == null) {
             val e = IllegalStateException("Cannot resolve Application Data Directory")
@@ -333,7 +333,7 @@ class ProfileManager private constructor(
 
         Timber.i("deleteProfile: starting deletion of %s", profileId)
 
-        val appDataRoot = ContextCompat.getDataDir(appContext)
+        val appDataRoot = ContextCompat.getDataDir(profileContext)
 
         if (profileId.isDefault()) {
             Timber.d("deleteProfile: wiping legacy default-profile data under %s", appDataRoot)
@@ -405,13 +405,13 @@ class ProfileManager private constructor(
      * The default-location fallback used when the profile has never written `PREF_COLLECTION_PATH`.
      *
      * TODO: consolidate with the profile-creation path this should delegate to
-     * `CollectionHelper.getDefaultAnkiDroidDirectory(appContext, directoryName = ...)`
+     * `CollectionHelper.getDefaultAnkiDroidDirectory(profileContext, directoryName = ...)`
      * that gives us legacy-storage handling and `SystemStorageException`-on-null for free, and keeps
      * the "where does a profile collection live" decision in a single place shared with
      * `ensureProfileCollectionPath`.
      */
     private fun defaultCollectionDirFor(profileId: ProfileId): File? {
-        val externalFilesDir = appContext.getExternalFilesDir(null) ?: return null
+        val externalFilesDir = profileContext.getExternalFilesDir(null) ?: return null
         return if (profileId.isDefault()) {
             File(externalFilesDir, "AnkiDroid")
         } else {
@@ -430,10 +430,10 @@ class ProfileManager private constructor(
      * TODO: extract a `ProfilePreferences` accessor (e.g. `prefsForProfile(profileId).collectionPath`)
      */
     private fun readStoredCollectionPath(profileId: ProfileId): String? {
-        val defaultPrefsName = "${appContext.packageName}_preferences"
+        val defaultPrefsName = "${profileContext.packageName}_preferences"
         val prefsName =
             if (profileId.isDefault()) defaultPrefsName else "profile_${profileId.value}_$defaultPrefsName"
-        return appContext
+        return profileContext
             .getSharedPreferences(prefsName, Context.MODE_PRIVATE)
             .getString(PREF_COLLECTION_PATH, null)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/navigation/AnkiDroidNavigator.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/navigation/AnkiDroidNavigator.kt
@@ -12,15 +12,15 @@ import com.ichi2.anki.common.destinations.Navigator
 
 /** AnkiDroid's [Navigator] implementation. */
 object AnkiDroidNavigator : Navigator {
-    private lateinit var appContext: Context
+    private lateinit var navContext: Context
 
     fun initialize(application: Application) {
-        appContext = application
+        navContext = application
     }
 
     override fun toIntent(destination: Destination): Intent =
         when (destination) {
-            is BrowserDestination -> destination.toIntent(appContext)
+            is BrowserDestination -> destination.toIntent(navContext)
         }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
@@ -158,14 +158,12 @@ class ReminderTroubleshootingFragment : Fragment(R.layout.fragment_reminder_trou
  * [ScheduleRemindersFragment] and [ReminderTroubleshootingFragment] use this with
  * `by activityViewModels { … }` so they observe a single VM + repository instance.
  */
-internal fun reminderTroubleshootingViewModelFactory(context: Context): ViewModelProvider.Factory {
-    val appContext = context.applicationContext
-    return viewModelFactory {
+internal fun reminderTroubleshootingViewModelFactory(context: Context): ViewModelProvider.Factory =
+    viewModelFactory {
         initializer {
-            ReminderTroubleshootingViewModel(ReminderTroubleshootingRepository(appContext))
+            ReminderTroubleshootingViewModel(ReminderTroubleshootingRepository(context))
         }
     }
-}
 
 private class TroubleshootingChecksAdapter(
     private val getResolveAction: (TroubleshootingCheck) -> ResolveCheckAction?,


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Getting the app context extraction ready via renaming the existing vars to avoid shadowing

## Fixes
* Related to #20737 

## Approach
Renames four private 'appContext' members/locals so the upcoming globalaccessor (com.ichi2.anki.common.android.appContext) lands cleanly without shadowing inside their containing classes

## How Has This Been Tested?
No behavior change. Preparatory step for the AnkiDroidApplication accessor extraction in a follow-up PR.


## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->