### PR TITLE
tests: fix memory leaks

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
@@ -485,6 +485,7 @@ class CardTemplateEditorTest : RobolectricTest() {
                     .start()
                     .resume()
                     .visible()
+            saveControllerForCleanup(templateEditorController)
             testEditor = templateEditorController.get()
             shadowTestEditor = shadowOf(testEditor)
             assertFalse("Note type should not have changed yet", testEditor.noteTypeHasChanged())

--- a/AnkiDroid/src/test/java/com/ichi2/anki/MyAccountTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/MyAccountTest.kt
@@ -39,43 +39,43 @@ class MyAccountTest : RobolectricTest() {
 
     @Test
     fun testLoginEmailPasswordProvided() {
-        val scenario = launchFragmentInContainer<LoginFragment>()
+        launchFragmentInContainer<LoginFragment>().use { scenario ->
+            scenario.onFragment { fragment ->
+                val testPassword = "randomStrongPassword"
+                val testEmail = "random.email@example.com"
 
-        scenario.onFragment { fragment ->
-            val testPassword = "randomStrongPassword"
-            val testEmail = "random.email@example.com"
+                fragment.view?.findViewById<TextInputEditText>(R.id.username)?.setText(testEmail)
+                fragment.view?.findViewById<TextInputEditText>(R.id.password)?.setText(testPassword)
 
-            fragment.view?.findViewById<TextInputEditText>(R.id.username)?.setText(testEmail)
-            fragment.view?.findViewById<TextInputEditText>(R.id.password)?.setText(testPassword)
-
-            val loginButton = fragment.view?.findViewById<Button>(R.id.login_button)
-            assertEquals(loginButton?.isEnabled, true)
+                val loginButton = fragment.view?.findViewById<Button>(R.id.login_button)
+                assertEquals(loginButton?.isEnabled, true)
+            }
         }
     }
 
     @Test
     fun testLoginFailsNoEmailProvided() {
-        val scenario = launchFragmentInContainer<LoginFragment>()
+        launchFragmentInContainer<LoginFragment>().use { scenario ->
+            scenario.onFragment { fragment ->
+                val testPassword = "randomStrongPassword"
 
-        scenario.onFragment { fragment ->
-            val testPassword = "randomStrongPassword"
-
-            fragment.view?.findViewById<TextInputEditText>(R.id.password)?.setText(testPassword)
-            val loginButton = fragment.view?.findViewById<Button>(R.id.login_button)
-            assertFalse(loginButton?.isEnabled == true)
+                fragment.view?.findViewById<TextInputEditText>(R.id.password)?.setText(testPassword)
+                val loginButton = fragment.view?.findViewById<Button>(R.id.login_button)
+                assertFalse(loginButton?.isEnabled == true)
+            }
         }
     }
 
     @Test
     fun testLoginFailsNoPasswordProvided() {
-        val scenario = launchFragmentInContainer<LoginFragment>()
+        launchFragmentInContainer<LoginFragment>().use { scenario ->
+            scenario.onFragment { fragment ->
+                val testEmail = "random.email@example.com"
 
-        scenario.onFragment { fragment ->
-            val testEmail = "random.email@example.com"
-
-            fragment.view?.findViewById<TextInputEditText>(R.id.username)?.setText(testEmail)
-            val loginButton = fragment.view?.findViewById<Button>(R.id.login_button)
-            assertFalse(loginButton?.isEnabled == true)
+                fragment.view?.findViewById<TextInputEditText>(R.id.username)?.setText(testEmail)
+                val loginButton = fragment.view?.findViewById<Button>(R.id.login_button)
+                assertFalse(loginButton?.isEnabled == true)
+            }
         }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/FindAndReplaceDialogFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/FindAndReplaceDialogFragmentTest.kt
@@ -89,38 +89,39 @@ class FindAndReplaceDialogFragmentTest : RobolectricTest() {
         runTest {
             val note = createFindReplaceTestNote("A", "kart", "kilogram")
             val file = IdsFile(targetContext.cacheDir, listOf(note.id))
-            val scenario =
-                FragmentScenario.launch(
+            FragmentScenario
+                .launch(
                     fragmentClass = FindAndReplaceDialogFragment::class.java,
                     fragmentArgs = bundleOf(FindAndReplaceDialogFragment.ARG_IDS to file),
                     themeResId = R.style.Theme_Light,
-                )
-            scenario.onFragment { fragment ->
-                advanceUntilIdle()
-                onView(withId(R.id.only_selected_notes_check_box))
-                    .inRoot(isDialog())
-                    .check(matches(isEnabled()))
-                onView(withId(R.id.only_selected_notes_check_box))
-                    .inRoot(isDialog())
-                    .check(matches(isChecked()))
-                // 2 default field options + 2 fields from the only note selected
-                val allTargets =
-                    targetContext.getDefaultTargets() + listOf("Afield0", "Afield1")
-                assertThat(fragment.adapter.items, equalTo(allTargets))
-            }
-            scenario.recreate()
-            scenario.onFragment { fragment ->
-                advanceUntilIdle()
-                onView(withId(R.id.only_selected_notes_check_box))
-                    .inRoot(isDialog())
-                    .check(matches(isEnabled()))
-                onView(withId(R.id.only_selected_notes_check_box))
-                    .inRoot(isDialog())
-                    .check(matches(isChecked()))
-                // check that the target list from before the recreate call wasn't reset
-                val allTargets = targetContext.getDefaultTargets() + listOf("Afield0", "Afield1")
-                assertThat(fragment.adapter.items, equalTo(allTargets))
-            }
+                ).use { scenario ->
+                    scenario.onFragment { fragment ->
+                        advanceUntilIdle()
+                        onView(withId(R.id.only_selected_notes_check_box))
+                            .inRoot(isDialog())
+                            .check(matches(isEnabled()))
+                        onView(withId(R.id.only_selected_notes_check_box))
+                            .inRoot(isDialog())
+                            .check(matches(isChecked()))
+                        // 2 default field options + 2 fields from the only note selected
+                        val allTargets =
+                            targetContext.getDefaultTargets() + listOf("Afield0", "Afield1")
+                        assertThat(fragment.adapter.items, equalTo(allTargets))
+                    }
+                    scenario.recreate()
+                    scenario.onFragment { fragment ->
+                        advanceUntilIdle()
+                        onView(withId(R.id.only_selected_notes_check_box))
+                            .inRoot(isDialog())
+                            .check(matches(isEnabled()))
+                        onView(withId(R.id.only_selected_notes_check_box))
+                            .inRoot(isDialog())
+                            .check(matches(isChecked()))
+                        // check that the target list from before the recreate call wasn't reset
+                        val allTargets = targetContext.getDefaultTargets() + listOf("Afield0", "Afield1")
+                        assertThat(fragment.adapter.items, equalTo(allTargets))
+                    }
+                }
         }
 
     private fun onFindReplaceFragment(
@@ -133,7 +134,7 @@ class FindAndReplaceDialogFragmentTest : RobolectricTest() {
                 fragmentClass = FindAndReplaceDialogFragment::class.java,
                 fragmentArgs = bundleOf(FindAndReplaceDialogFragment.ARG_IDS to file),
                 themeResId = R.style.Theme_Light,
-            ).onFragment { fragment -> fragment.action() }
+            ).use { scenario -> scenario.onFragment { fragment -> fragment.action() } }
     }
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/export/ExportDialogFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/export/ExportDialogFragmentTest.kt
@@ -36,9 +36,7 @@ import org.junit.runner.RunWith
 class ExportDialogFragmentTest : RobolectricTest() {
     @Test
     fun `collection export options are initialized correctly`() {
-        launchFragment<ExportDialogFragment>(
-            themeResId = R.style.Theme_Light,
-        ).onFragment {
+        onExportDialog {
             // Select export type as anki collection package.
             onView(withId(R.id.export_type_selector)).inRoot(isDialog()).perform(click())
             onData(containsString(TR.exportingAnkiCollectionPackage()))
@@ -62,9 +60,7 @@ class ExportDialogFragmentTest : RobolectricTest() {
 
     @Test
     fun `apkg export options are initialized correctly`() {
-        launchFragment<ExportDialogFragment>(
-            themeResId = R.style.Theme_Light,
-        ).onFragment {
+        onExportDialog {
             // Select export type as anki deck package.
             onView(withId(R.id.export_type_selector)).inRoot(isDialog()).perform(click())
             onData(containsString(TR.exportingAnkiDeckPackage()))
@@ -100,9 +96,7 @@ class ExportDialogFragmentTest : RobolectricTest() {
 
     @Test
     fun `Legacy export checkbox(default false) is shown only for collection and apkg`() {
-        launchFragment<ExportDialogFragment>(
-            themeResId = R.style.Theme_Light,
-        ).onFragment {
+        onExportDialog {
             // check legacy checkboxes status for collection export
             onView(withId(R.id.export_type_selector)).inRoot(isDialog()).perform(click())
             onData(containsString(TR.exportingAnkiCollectionPackage()))
@@ -158,4 +152,10 @@ class ExportDialogFragmentTest : RobolectricTest() {
                 .check(matches(not(isDisplayed())))
         }
     }
+
+    /** Launches [ExportDialogFragment] and executes [action] on the fragment. */
+    private fun onExportDialog(action: ExportDialogFragment.() -> Unit) =
+        launchFragment<ExportDialogFragment>(
+            themeResId = R.style.Theme_Light,
+        ).use { scenario -> scenario.onFragment { action(it) } }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/pages/StatisticsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/pages/StatisticsTest.kt
@@ -42,13 +42,15 @@ class StatisticsTest : RobolectricTest() {
     @Test
     fun `shows 'Default' deck when collection is empty`() =
         runTest {
-            ActivityScenario.launch<SingleFragmentActivity>(
-                StatisticsDestination().toIntent(
-                    targetContext,
-                ),
-            )
-            advanceUntilIdle()
-            onView(withText("Default")).check(matches(isDisplayed()))
+            ActivityScenario
+                .launch<SingleFragmentActivity>(
+                    StatisticsDestination().toIntent(
+                        targetContext,
+                    ),
+                ).use {
+                    advanceUntilIdle()
+                    onView(withText("Default")).check(matches(isDisplayed()))
+                }
         }
 
     @Test
@@ -59,19 +61,21 @@ class StatisticsTest : RobolectricTest() {
             val testDeck1 = addDeck(testDeckName1)
             withCol { decks.select(testDeck1) }
             addDeck(testDeckName2)
-            ActivityScenario.launch<SingleFragmentActivity>(
-                StatisticsDestination().toIntent(
-                    targetContext,
-                ),
-            )
-            advanceUntilIdle()
-            onView(withId(R.id.deck_name)).check(matches(withText(testDeckName1)))
-            onView(withId(R.id.deck_name)).perform(click())
-            advanceUntilIdle()
-            // select test deck 2
-            onView(withText(testDeckName2)).inRoot(isDialog()).perform(click())
-            // check the activity that it has the new deck name
-            onView(withId(R.id.deck_name)).check(matches(withText(testDeckName2)))
+            ActivityScenario
+                .launch<SingleFragmentActivity>(
+                    StatisticsDestination().toIntent(
+                        targetContext,
+                    ),
+                ).use {
+                    advanceUntilIdle()
+                    onView(withId(R.id.deck_name)).check(matches(withText(testDeckName1)))
+                    onView(withId(R.id.deck_name)).perform(click())
+                    advanceUntilIdle()
+                    // select test deck 2
+                    onView(withText(testDeckName2)).inRoot(isDialog()).perform(click())
+                    // check the activity that it has the new deck name
+                    onView(withId(R.id.deck_name)).check(matches(withText(testDeckName2)))
+                }
         }
 
     @Test
@@ -93,6 +97,6 @@ class StatisticsTest : RobolectricTest() {
                     assertFalse(deckSelectionDialog.requireArguments().getBoolean(DeckSelectionDialog.ARG_ALLOW_ALL, true))
                     assertFalse(deckSelectionDialog.requireArguments().getBoolean(DeckSelectionDialog.ARG_ALLOW_FILTERED, true))
                     assertTrue(deckSelectionDialog.requireArguments().getBoolean(DeckSelectionDialog.ARG_SKIP_EMPTY_DEFAULT, false))
-                }
+                }.close()
         }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesTest.kt
@@ -80,12 +80,12 @@ class PreferencesTest : RobolectricTest() {
     /** checks if any of the Preferences fragments throws while being created */
     @Test
     fun fragmentsDoNotThrowOnCreation() {
-        val activityScenario = ActivityScenario.launch<PreferencesActivity>(PreferencesActivity.getIntent(targetContext))
-
-        activityScenario.onActivity { activity ->
-            PreferenceTestUtils.getAllPreferencesFragments(activity).forEach {
-                activity.supportFragmentManager.commitNow {
-                    add(R.id.settings_container, it)
+        ActivityScenario.launch<PreferencesActivity>(PreferencesActivity.getIntent(targetContext)).use { activityScenario ->
+            activityScenario.onActivity { activity ->
+                PreferenceTestUtils.getAllPreferencesFragments(activity).forEach {
+                    activity.supportFragmentManager.commitNow {
+                        add(R.id.settings_container, it)
+                    }
                 }
             }
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PrefsSearchBarTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PrefsSearchBarTest.kt
@@ -88,11 +88,13 @@ class PrefsSearchBarTest : RobolectricTest() {
 
     private fun getPreferencesActivity(): PreferencesActivity {
         val intent = PreferencesActivity.getIntent(targetContext)
-        return Robolectric
-            .buildActivity(PreferencesActivity::class.java, intent)
-            .create()
-            .start()
-            .resume()
-            .get()
+        val controller =
+            Robolectric
+                .buildActivity(PreferencesActivity::class.java, intent)
+                .create()
+                .start()
+                .resume()
+        saveControllerForCleanup(controller)
+        return controller.get()
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/scheduling/SetDueDateDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/scheduling/SetDueDateDialogTest.kt
@@ -152,10 +152,10 @@ class SetDueDateDialogTest : RobolectricTest() {
             fragmentArgs = dialog.arguments,
         ) {
             return@launchFragment dialog
-        }.apply {
-            moveToState(Lifecycle.State.RESUMED)
+        }.use { scenario ->
+            scenario.moveToState(Lifecycle.State.RESUMED)
             advanceRobolectricLooper()
-            this.onFragment {
+            scenario.onFragment {
                 action(it)
             }
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
@@ -41,52 +41,55 @@ class SentenceCaseTest : RobolectricTest() {
     fun `English is converted to sentence case`() {
         ensureCollectionLoadIsSynchronous()
 
-        launchFragmentInContainer<Fragment>().onFragment { fragment ->
-            with(fragment) {
-                assertThat(TR.sentenceCase.toggleSuspend, equalTo("Toggle suspend"))
-                assertThat(TR.sentenceCase.toggleBury, equalTo("Toggle bury"))
-                assertThat(TR.sentenceCase.customStudy, equalTo("Custom study"))
-                assertThat(TR.sentenceCase.emptyCards, equalTo("Empty cards"))
-                assertThat(TR.sentenceCase.emptyTrash, equalTo("Empty trash"))
-                assertThat(TR.sentenceCase.restoreDeleted, equalTo("Restore deleted"))
-                assertThat(TR.sentenceCase.changeNoteType, equalTo("Change note type"))
-                assertThat(TR.sentenceCase.gradeNow, equalTo("Grade now"))
-            }
-        }
+        launchFragmentInContainer<Fragment>()
+            .onFragment { fragment ->
+                with(fragment) {
+                    assertThat(TR.sentenceCase.toggleSuspend, equalTo("Toggle suspend"))
+                    assertThat(TR.sentenceCase.toggleBury, equalTo("Toggle bury"))
+                    assertThat(TR.sentenceCase.customStudy, equalTo("Custom study"))
+                    assertThat(TR.sentenceCase.emptyCards, equalTo("Empty cards"))
+                    assertThat(TR.sentenceCase.emptyTrash, equalTo("Empty trash"))
+                    assertThat(TR.sentenceCase.restoreDeleted, equalTo("Restore deleted"))
+                    assertThat(TR.sentenceCase.changeNoteType, equalTo("Change note type"))
+                    assertThat(TR.sentenceCase.gradeNow, equalTo("Grade now"))
+                }
+            }.close()
 
-        ActivityScenario.launch(EmptyAnkiActivity::class.java).onActivity { activity ->
-            with(activity) {
-                assertThat(TR.sentenceCase.setDueDate, equalTo("Set due date"))
-                assertThat(TR.sentenceCase.addNoteType, equalTo("Add note type"))
-                assertThat(TR.sentenceCase.restoreToDefault, equalTo("Restore to default"))
-                assertThat(TR.sentenceCase.checkDatabase, equalTo("Check database"))
-                assertThat(TR.sentenceCase.checkMediaTitle, equalTo("Check media"))
-                assertThat(TR.sentenceCase.checkMediaAction, equalTo("Check media"))
-                assertThat(TR.sentenceCase.frontTemplate, equalTo("Front template"))
-                assertThat(TR.sentenceCase.backTemplate, equalTo("Back template"))
-                assertThat(TR.sentenceCase.renameDeck, equalTo("Rename deck"))
-                assertThat(TR.sentenceCase.customStudy, equalTo("Custom study"))
-                assertThat(TR.sentenceCase.deckOptions, equalTo("Deck options"))
-                assertThat(TR.sentenceCase.deleteDeck, equalTo("Delete deck"))
-                assertThat(TR.sentenceCase.logIn, equalTo("Log in"))
-                assertThat(TR.sentenceCase.logOut, equalTo("Log out"))
-                assertThat(TR.sentenceCase.cardInfo, equalTo("Card info"))
-                assertThat(TR.sentenceCase.buryNote, equalTo("Bury note"))
-                assertThat(TR.sentenceCase.buryCard, equalTo("Bury card"))
-                assertThat(TR.sentenceCase.suspendNote, equalTo("Suspend note"))
-                assertThat(TR.sentenceCase.suspendCard, equalTo("Suspend card"))
-                assertThat(TR.sentenceCase.markNote, equalTo("Mark note"))
-                assertThat(TR.sentenceCase.deleteNote, equalTo("Delete note"))
-                assertThat(TR.sentenceCase.previousCardInfo, equalTo("Previous card info"))
-                assertThat(TR.sentenceCase.ankiWebAccount, equalTo("AnkiWeb account"))
-                assertThat(TR.sentenceCase.browserAppearance, equalTo("Browser appearance"))
+        ActivityScenario
+            .launch(EmptyAnkiActivity::class.java)
+            .onActivity { activity ->
+                with(activity) {
+                    assertThat(TR.sentenceCase.setDueDate, equalTo("Set due date"))
+                    assertThat(TR.sentenceCase.addNoteType, equalTo("Add note type"))
+                    assertThat(TR.sentenceCase.restoreToDefault, equalTo("Restore to default"))
+                    assertThat(TR.sentenceCase.checkDatabase, equalTo("Check database"))
+                    assertThat(TR.sentenceCase.checkMediaTitle, equalTo("Check media"))
+                    assertThat(TR.sentenceCase.checkMediaAction, equalTo("Check media"))
+                    assertThat(TR.sentenceCase.frontTemplate, equalTo("Front template"))
+                    assertThat(TR.sentenceCase.backTemplate, equalTo("Back template"))
+                    assertThat(TR.sentenceCase.renameDeck, equalTo("Rename deck"))
+                    assertThat(TR.sentenceCase.customStudy, equalTo("Custom study"))
+                    assertThat(TR.sentenceCase.deckOptions, equalTo("Deck options"))
+                    assertThat(TR.sentenceCase.deleteDeck, equalTo("Delete deck"))
+                    assertThat(TR.sentenceCase.logIn, equalTo("Log in"))
+                    assertThat(TR.sentenceCase.logOut, equalTo("Log out"))
+                    assertThat(TR.sentenceCase.cardInfo, equalTo("Card info"))
+                    assertThat(TR.sentenceCase.buryNote, equalTo("Bury note"))
+                    assertThat(TR.sentenceCase.buryCard, equalTo("Bury card"))
+                    assertThat(TR.sentenceCase.suspendNote, equalTo("Suspend note"))
+                    assertThat(TR.sentenceCase.suspendCard, equalTo("Suspend card"))
+                    assertThat(TR.sentenceCase.markNote, equalTo("Mark note"))
+                    assertThat(TR.sentenceCase.deleteNote, equalTo("Delete note"))
+                    assertThat(TR.sentenceCase.previousCardInfo, equalTo("Previous card info"))
+                    assertThat(TR.sentenceCase.ankiWebAccount, equalTo("AnkiWeb account"))
+                    assertThat(TR.sentenceCase.browserAppearance, equalTo("Browser appearance"))
 
-                assertThat("syncMediaLogTitle", TR.syncMediaLogTitle(), equalTo("Media Sync Log"))
-                assertThat(TR.sentenceCase.mediaSyncLog, equalTo("Media sync log"))
+                    assertThat("syncMediaLogTitle", TR.syncMediaLogTitle(), equalTo("Media Sync Log"))
+                    assertThat(TR.sentenceCase.mediaSyncLog, equalTo("Media sync log"))
 
-                assertThat("Toggle Suspend".toSentenceCase(this, R.string.sentence_toggle_suspend), equalTo("Toggle suspend"))
-                assertThat("Ook? Ook?".toSentenceCase(this, R.string.sentence_toggle_suspend), equalTo("Ook? Ook?"))
-            }
-        }
+                    assertThat("Toggle Suspend".toSentenceCase(this, R.string.sentence_toggle_suspend), equalTo("Toggle suspend"))
+                    assertThat("Ook? Ook?".toSentenceCase(this, R.string.sentence_toggle_suspend), equalTo("Ook? Ook?"))
+                }
+            }.close()
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/ReviewerBigScreenTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/ReviewerBigScreenTest.kt
@@ -30,6 +30,6 @@ class ReviewerBigScreenTest : RobolectricTest() {
     fun `sw600dp layout is initialized`() {
         ensureCollectionLoadIsSynchronous()
         val intent = ReviewerFragment.getIntent(targetContext)
-        ActivityScenario.launch<CardViewerActivity>(intent)
+        ActivityScenario.launch<CardViewerActivity>(intent).close()
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/utils/ext/StateFlowLifecycleCollectionTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/utils/ext/StateFlowLifecycleCollectionTest.kt
@@ -36,6 +36,7 @@ class StateFlowLifecycleCollectionTest : RobolectricTest() {
     @Test
     fun `concurrent value change does not skip UI update`() {
         val controller = Robolectric.buildActivity(AnkiActivity::class.java, Intent())
+        saveControllerForCleanup(controller)
         val flow = MutableStateFlow(0)
         val concurrentFlow =
             ConcurrentStateFlow(flow) { emitted ->


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.8 - all

## Purpose / Description
There are parallelism fixes for macOS required, but before this, I did a scan of our tests and found issues


## Fixes
* Part of #21168

## Approach
* Scan for leaks
* `.use` and `.close`

## How Has This Been Tested?

<details>

<summary>Vibe coded</summary>

```patch
Subject: [PATCH]
---
Index: AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt	(revision a9b58465700c1acee0423fd0314ab20082b34d59)
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt	(date 1780011924238)
@@ -56,6 +56,7 @@
 import com.ichi2.compat.customtabs.CustomTabActivityHelper
 import com.ichi2.testutils.AndroidTest
 import com.ichi2.testutils.ProductionCollectionManager
+import com.ichi2.testutils.common.ActivityLeakDetectorRule
 import com.ichi2.testutils.common.FailOnUnhandledExceptionRule
 import com.ichi2.testutils.common.IgnoreFlakyTestsInCIRule
 import com.ichi2.testutils.filter
@@ -110,6 +111,10 @@
     @get:Rule
     val failOnUnhandledExceptions = FailOnUnhandledExceptionRule()
 
+    /** Profiling aid (#21168): reports Activities created but never destroyed. No-op unless `-DdetectActivityLeaks=true`. */
+    @get:Rule
+    val activityLeakDetector = ActivityLeakDetectorRule()
+
     @get:Rule
     val timeoutRule: TimeoutRule = TimeoutRule.seconds(60)
 
Index: build.gradle.kts
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/build.gradle.kts b/build.gradle.kts
--- a/build.gradle.kts	(revision a9b58465700c1acee0423fd0314ab20082b34d59)
+++ b/build.gradle.kts	(date 1780011924189)
@@ -80,6 +80,9 @@
                 it.forkEvery = 40
                 it.systemProperties["junit.jupiter.execution.parallel.enabled"] = true
                 it.systemProperties["junit.jupiter.execution.parallel.mode.default"] = "concurrent"
+
+                // #21168 profiling: forward the opt-in Activity-leak detector flag to the test fork
+                providers.systemProperty("detectActivityLeaks").orNull?.let { v -> it.systemProperties["detectActivityLeaks"] = v }
             }
 
             val androidComponentsExtension =
Index: AnkiDroid/src/androidTest/java/com/ichi2/testutils/common/AnkiAssert.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/androidTest/java/com/ichi2/testutils/common/AnkiAssert.kt b/AnkiDroid/src/androidTest/java/com/ichi2/testutils/common/AnkiAssert.kt
new file mode 100644
--- /dev/null	(date 1780011924206)
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/testutils/common/AnkiAssert.kt	(date 1780011924206)
@@ -0,0 +1,36 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils.common
+
+import org.junit.function.ThrowingRunnable
+
+/**
+ * Asserts that [runnable] throws an exception of type [T] when
+ * executed. If it does, the exception object is returned. If it does not throw an exception, an
+ * [AssertionError] is thrown. If it throws the wrong type of exception, an
+ * [AssertionError] is thrown describing the mismatch; the exception that was actually thrown can
+ * be obtained by calling `AssertionError.cause`.
+ *
+ * @param message the identifying message for the [AssertionError]
+ * @param T the expected type of the exception
+ * @param runnable a function that is expected to throw an exception when executed
+ * @return the exception thrown by [runnable]
+ */
+inline fun <reified T : Throwable> assertThrows(
+    message: String? = null,
+    runnable: ThrowingRunnable,
+): T = org.junit.Assert.assertThrows(message, T::class.java, runnable)
Index: AnkiDroid/src/testFixtures/java/com/ichi2/testutils/common/ActivityLeakDetectorRule.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/testFixtures/java/com/ichi2/testutils/common/ActivityLeakDetectorRule.kt b/AnkiDroid/src/testFixtures/java/com/ichi2/testutils/common/ActivityLeakDetectorRule.kt
new file mode 100644
--- /dev/null	(date 1780011927060)
+++ b/AnkiDroid/src/testFixtures/java/com/ichi2/testutils/common/ActivityLeakDetectorRule.kt	(date 1780011927060)
@@ -0,0 +1,146 @@
+/*
+ *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils.common
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import androidx.test.core.app.ApplicationProvider
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import java.io.File
+import java.util.Collections
+import java.util.IdentityHashMap
+
+/**
+ * Profiling aid for the `saveControllerForCleanup` contract in `RobolectricTest`.
+ *
+ * A Robolectric Activity whose controller is never `destroy()`d leaks for the lifetime of the
+ * test fork (bounded only by Gradle's `forkEvery`). Accumulated leaks raise the per-fork memory
+ * peak and contribute to the macOS CI OOMs tracked in #21168.
+ *
+ * When enabled, this rule records every Activity that received `onActivityCreated` but no
+ * matching `onActivityDestroyed` by the time the test method *and* its `@After` teardown have
+ * finished, attributing each leak to the test that created it. Because all JUnit `TestRule`s wrap
+ * outside `@After`, the check runs after teardown, so controllers correctly registered for cleanup
+ * have already been destroyed and are not reported.
+ *
+ * This detects the specific "never destroyed" gap. It does NOT detect "destroyed but still
+ * retained" leaks (e.g. a static holding a destroyed Activity) — use a heap-dump tool for those.
+ *
+ * Disabled by default: [apply] returns [base] unchanged unless `-DdetectActivityLeaks=true` is
+ * forwarded to the test JVM, so there is no overhead in normal runs.
+ *
+ * Output: one CSV per fork at `<module>/build/activity-leaks/leaks-<pid>.csv` with
+ * `testClass,testMethod,leakedActivityClass` rows. Aggregate across forks after the run.
+ */
+class ActivityLeakDetectorRule : TestRule {
+    override fun apply(
+        base: Statement,
+        description: Description,
+    ): Statement {
+        if (System.getProperty(ENABLE_PROPERTY) != "true") return base
+        return object : Statement() {
+            override fun evaluate() {
+                val app =
+                    try {
+                        ApplicationProvider.getApplicationContext<Application>()
+                    } catch (e: Exception) {
+                        // Not a Robolectric test (no Android environment): nothing to track.
+                        base.evaluate()
+                        return
+                    }
+                val live = Collections.synchronizedMap(IdentityHashMap<Activity, String>())
+                val callbacks =
+                    object : Application.ActivityLifecycleCallbacks {
+                        override fun onActivityCreated(
+                            activity: Activity,
+                            savedInstanceState: Bundle?,
+                        ) {
+                            live[activity] = activity.javaClass.name
+                        }
+
+                        override fun onActivityDestroyed(activity: Activity) {
+                            live.remove(activity)
+                        }
+
+                        override fun onActivityStarted(activity: Activity) = Unit
+
+                        override fun onActivityResumed(activity: Activity) = Unit
+
+                        override fun onActivityPaused(activity: Activity) = Unit
+
+                        override fun onActivityStopped(activity: Activity) = Unit
+
+                        override fun onActivitySaveInstanceState(
+                            activity: Activity,
+                            outState: Bundle,
+                        ) = Unit
+                    }
+                app.registerActivityLifecycleCallbacks(callbacks)
+                try {
+                    base.evaluate()
+                } finally {
+                    app.unregisterActivityLifecycleCallbacks(callbacks)
+                    val leaked = synchronized(live) { live.values.toList() }
+                    if (leaked.isNotEmpty()) {
+                        record(description, leaked)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun record(
+        description: Description,
+        leakedActivityClasses: List<String>,
+    ) {
+        val testClass = description.className ?: "unknown"
+        val testMethod = description.methodName ?: "unknown"
+        for (activityClass in leakedActivityClasses) {
+            // visible in test stdout (captured in test-results system-out) as a backstop to the file
+            println("$STDOUT_TAG\t$testClass\t$testMethod\t$activityClass")
+        }
+        synchronized(fileLock) {
+            try {
+                val dir = File(System.getProperty("user.dir"), OUTPUT_DIR)
+                dir.mkdirs()
+                val file = File(dir, "leaks-$pid.csv")
+                if (!file.exists()) {
+                    file.appendText("testClass,testMethod,leakedActivityClass\n")
+                }
+                for (activityClass in leakedActivityClasses) {
+                    file.appendText("${csv(testClass)},${csv(testMethod)},${csv(activityClass)}\n")
+                }
+            } catch (e: Exception) {
+                // Never let profiling break a test run; stdout tag above still captures the data.
+                System.err.println("$STDOUT_TAG failed to write CSV: ${e.message}")
+            }
+        }
+    }
+
+    private fun csv(value: String): String = "\"" + value.replace("\"", "\"\"") + "\""
+
+    companion object {
+        const val ENABLE_PROPERTY = "detectActivityLeaks"
+        private const val OUTPUT_DIR = "build/activity-leaks"
+        private const val STDOUT_TAG = "ACTIVITY_LEAK"
+        private val fileLock = Any()
+        private val pid: Long by lazy { ProcessHandle.current().pid() }
+    }
+}
```

</details>

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)