### PR TITLE
fix: remove unnecessary onCreate calls

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserOrderDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserOrderDialog.kt
@@ -33,7 +33,6 @@ class CardBrowserOrderDialog : AnalyticsDialogFragment() {
     private val viewModel: CardBrowserViewModel by activityViewModels()
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        super.onCreate(savedInstanceState)
         val items = resources.getStringArray(R.array.card_browser_order_labels)
         // Set sort order arrow
         for (i in items.indices) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ConfirmationDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ConfirmationDialog.kt
@@ -85,16 +85,13 @@ class ConfirmationDialog : DialogFragment() {
         this.cancel = cancel
     }
 
-    override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
-        super.onCreate(savedInstanceState)
-
-        return AlertDialog.Builder(requireContext()).create {
+    override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog =
+        AlertDialog.Builder(requireContext()).create {
             title(text = title)
             message(text = message)
             positiveButton(text = positiveButtonText) { confirm.run() }
             negativeButton(R.string.dialog_cancel) { cancel.run() }
         }
-    }
 
     companion object {
         /** The dialog message (required) */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerBackupNoSpaceLeftDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerBackupNoSpaceLeftDialog.kt
@@ -30,7 +30,6 @@ import com.ichi2.utils.title
 
 class DeckPickerBackupNoSpaceLeftDialog : AnalyticsDialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
-        super.onCreate(savedInstanceState)
         val res = resources
         val space = BackupManager.getFreeDiscSpace(CollectionHelper.getCollectionPath(requireActivity()))
         return AlertDialog

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
@@ -37,7 +37,6 @@ import com.ichi2.utils.title
 
 class DeckPickerContextMenu : AnalyticsDialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        super.onCreate(savedInstanceState)
         require(requireArguments().containsKey(ARG_DECK_ID)) { "Missing argument deck id" }
         require(requireArguments().containsKey(ARG_DECK_NAME)) { "Missing argument deck name" }
         require(requireArguments().containsKey(ARG_DECK_IS_DYN)) { "Missing argument deck is dynamic" }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerNoSpaceLeftDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerNoSpaceLeftDialog.kt
@@ -16,7 +16,6 @@
 
 package com.ichi2.anki.dialogs
 
-import android.app.Dialog
 import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
 import com.ichi2.anki.R
@@ -28,16 +27,14 @@ import com.ichi2.utils.positiveButton
 import com.ichi2.utils.title
 
 class DeckPickerNoSpaceLeftDialog : AnalyticsDialogFragment() {
-    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        super.onCreate(savedInstanceState)
-        return AlertDialog.Builder(requireActivity()).create {
+    override fun onCreateDialog(savedInstanceState: Bundle?) =
+        AlertDialog.Builder(requireActivity()).create {
             title(R.string.storage_full_title)
             message(R.string.backup_deck_no_storage_left)
             cancelable(true)
             positiveButton(R.string.dialog_ok) {}
             setOnCancelListener {}
         }
-    }
 
     companion object {
         fun newInstance(): DeckPickerNoSpaceLeftDialog = DeckPickerNoSpaceLeftDialog()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.kt
@@ -43,7 +43,6 @@ class ImportDialog : AsyncDialogFragment() {
         get() = requireArguments().getString(IMPORT_DIALOG_PACKAGE_PATH_KEY)!!
 
     override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
-        super.onCreate(savedInstanceState)
         val dialog = AlertDialog.Builder(requireActivity())
         dialog.setCancelable(true)
         val displayFileName = filenameFromPath(convertToDisplayName(packagePath))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/NoteTypeFieldEditorContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/NoteTypeFieldEditorContextMenu.kt
@@ -21,7 +21,6 @@ import timber.log.Timber
 class NoteTypeFieldEditorContextMenu : AnalyticsDialogFragment() {
     @SuppressLint("CheckResult")
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        super.onCreate(savedInstanceState)
         val availableItems = NoteTypeFieldEditorContextMenuAction.entries.sortedBy { it.order }
 
         return AlertDialog.Builder(requireActivity()).create {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SavedBrowserSearchesDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SavedBrowserSearchesDialogFragment.kt
@@ -49,7 +49,6 @@ import timber.log.Timber
 //  dialog(or maybe even add an option to remove all entries directly)
 class SavedBrowserSearchesDialogFragment : AnalyticsDialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        super.onCreate(savedInstanceState)
         val savedFilters: HashMap<String, String>? =
             requireArguments().getSerializableCompat(ARG_SAVED_FILTERS)
         val data =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
@@ -67,7 +67,6 @@ class SyncErrorDialog : AsyncDialogFragment() {
         get() = Type.fromCode(requireArguments().getInt(SYNC_ERROR_DIALOG_TYPE_KEY))
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        super.onCreate(savedInstanceState)
         val dialog =
             AlertDialog
                 .Builder(requireContext())

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -179,7 +179,6 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        super.onCreate(savedInstanceState)
         val option = selectedSubDialog
         return if (option == null || !defaultsAreInitialized()) {
             Timber.i("Showing Custom Study main menu")


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.8 - investigation and fix

## Purpose / Description
`super.onCreateDialog` was not required, as the classes returned a custom dialog

## Fixes
* Fixes #21171

## How Has This Been Tested?
Opened 'CustomStudyDialog'

Trusting Ci

## Learning

Added in ae7d237a5e3b74b630a7fbcebbd1f4efc3a26080

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)