### PR TITLE
build(ci): fix OOM errors on macOS runner

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.internal.jvm.Jvm
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
+import java.lang.management.ManagementFactory
 import java.util.Properties
 import kotlin.math.max
 import kotlin.system.exitProcess
@@ -44,6 +45,12 @@ val testSummaryService = System.getenv("GITHUB_STEP_SUMMARY")?.let { path ->
     }
 }
 
+/**
+ * Per-fork JVM heap for unit tests.
+ * See [Test.setMaxHeapSize]
+ */
+val unitTestForkMaxHeapGb = 2
+
 // Here we extract per-module "best practices" settings to a single top-level evaluation
 subprojects {
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
@@ -61,7 +68,7 @@ subprojects {
                 // tell backend to avoid rollover time, and disable interval fuzzing
                 it.environment("ANKI_TEST_MODE", "1")
 
-                it.maxHeapSize = "2g"
+                it.maxHeapSize = "${unitTestForkMaxHeapGb}g"
                 it.minHeapSize = "1g"
 
                 it.useJUnitPlatform()
@@ -158,6 +165,7 @@ if (jvmVersion !in jvmVersionLowerBound..jvmVersionUpperBound) {
 }
 
 val ciBuild by extra(System.getenv("CI") == "true") // true when running on GitHub Actions
+val isMacOs = System.getProperty("os.name") == "Mac OS X"
 // allows for -Dpre-dex=false to be set
 val preDexEnabled by extra("true" == System.getProperty("pre-dex", "true"))
 // allows for universal APKs to be generated
@@ -168,12 +176,48 @@ var androidTestVariantName by extra(
     if (testReleaseBuild) "Release" else "Debug"
 )
 
+private fun sysctl(key: String): Long =
+    providers.exec {
+        commandLine("sysctl", "-n", key)
+    }.standardOutput.asText.get().trim().toLong()
+
+/**
+ * The Gradle daemon's `-Xmx` max heap, in bytes.
+ *
+ * Reads from the launch flags as `getRuntime().maxMemory()` is GC-dependent.
+ *
+ * @throws IllegalStateException if `-Xmx` is missing or invalid.
+ */
+private fun gradleDaemonHeapBytes(): Long {
+    val xmx = ManagementFactory.getRuntimeMXBean().inputArguments
+        .lastOrNull { it.startsWith("-Xmx") } // last -Xmx wins, as in the JVM
+        ?: error("Gradle daemon has no -Xmx flag")
+    val match = Regex("-Xmx(\\d+)([MG])", RegexOption.IGNORE_CASE).matchEntire(xmx)
+        ?: error("Cannot parse Gradle daemon heap from '$xmx'; expected -Xmx<n>M or -Xmx<n>G")
+    val size = match.groupValues[1].toLong()
+    val byteMultiplier = when (match.groupValues[2].uppercase()) {
+        "G" -> 1024L * 1024 * 1024
+        else -> 1024L * 1024 // M
+    }
+    return size * byteMultiplier
+}
+
 val gradleTestMaxParallelForks by extra(
-    if (System.getProperty("os.name") == "Mac OS X") {
-        // macOS reports hardware cores. This is accurate for CI, Intel (halved due to SMT) and Apple Silicon
-        providers.exec {
-            commandLine("sysctl", "-n", "hw.physicalcpu")
-        }.standardOutput.asText.get().trim().toInt()
+    if (isMacOs) {
+        // macOS reports hardware cores.
+        // This is accurate for CI, Intel (halved due to SMT) and Apple Silicon
+        val physicalCpus = sysctl("hw.physicalcpu")
+
+        if (ciBuild) {
+            // #21168: The `macos-14` CI runner has only 7GB RAM and OOMs (exit 134) so bound by RAM.
+            // Reserve the daemon's own heap (the OS shares its slack); split the rest into forks.
+            val forkHeapBytes = unitTestForkMaxHeapGb * 1024L * 1024 * 1024
+            val availableBytes = sysctl("hw.memsize") - gradleDaemonHeapBytes()
+            val memoryBoundForkProcesses = max(1L, availableBytes / forkHeapBytes)
+            minOf(physicalCpus, memoryBoundForkProcesses).toInt()
+        } else {
+            physicalCpus.toInt()
+        }
     } else if (ciBuild) {
         // GitHub Actions run on Standard_D4ads_v5 Azure Compute Units with 4 vCPUs
         // They appear to be 2:1 vCPU to CPU on Linux/Windows with two vCPU cores but with performance 1:1-similar


### PR DESCRIPTION
...by taking physical memory into account when deciding how many test processes to spawn.

> [!NOTE]
> Assisted-by: Claude Opus 4.8 - diagnosis & some code


<!--- Please fill the necessary details below -->
## Purpose / Description
Even though `macos-14` has 3 CPUs, there is only 7GB of memory.
Each test process has a max heap of 2GB, with the addition of  Gradle this is enough to OOM the machine.

## Fixes
* Fixes #21168

## Approach

* Reserve 3GB of RAM for Gradle in our calculations
* Divide the remaining memory by 2GB per fork
* Cap the number of works


## How Has This Been Tested?
CI-only

## Learning (optional, can help others)

* `macos-14` runner. 3 CPUs, 7GB RAM
* 3GB reserved for Gradle (org.gradle.jvmargs=-Xmx3072M) and the OS
* 4GB remaining
* Heap size: 2GB
* => 2 forks; previously 3


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)