### PR TITLE
docs: use docs.ankidroid.org links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yml
@@ -61,7 +61,7 @@ body:
       label: Research
       description: Confirm the points below
       options:
-        - label: I have checked the [manual](https://ankidroid.org/docs/manual.html) and the [FAQ](https://github.com/ankidroid/Anki-Android/wiki/FAQ) and could not find a solution to my issue
+        - label: I have checked the [manual](https://docs.ankidroid.org/) and the [FAQ](https://github.com/ankidroid/Anki-Android/wiki/FAQ) and could not find a solution to my issue
           required: true
         - label: (Optional) I have confirmed the issue is not resolved in the latest alpha release ([instructions](https://docs.ankidroid.org/manual.html#betaTesting))
           required: false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -58,7 +58,6 @@ import com.ichi2.anki.reviewer.ReviewerBinding
 import com.ichi2.anki.reviewer.ReviewerBinding.Companion.fromPreferenceString
 import timber.log.Timber
 import java.util.Locale
-import kotlin.collections.ArrayList
 import kotlin.math.round
 
 private typealias VersionIdentifier = Int
@@ -595,7 +594,7 @@ object PreferenceUpgradeService {
          * Universal Analytics to Google Analytics 4, we want analytics to STRICTLY be opt-in
          *
          * As we likely have inadvertent opt-ins, we stated that we would opt everyone out:
-         * https://ankidroid.org/docs/changelog.html#_version_2_16_5_20230906
+         * https://docs.ankidroid.org/changelog.html#_version_2_16_5_20230906
          *
          * We now use "analytics_opt_in"
          *

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -116,7 +116,7 @@
     <string name="link_manual_ar">https://docs.ankidroid.org/manual-ar.html</string>
     <string name="link_manual_note_format_toolbar">https://docs.ankidroid.org/manual.html#noteFormattingToolbar</string>
     <string name="link_manual_browser_find_replace">https://docs.ankiweb.net/browsing.html#find-and-replace</string>
-    <string name="link_sync_conflict_help">https://ankidroid.org/#AnkiWebConflicts</string>
+    <string name="link_sync_conflict_help">https://docs.ankidroid.org/#AnkiWebConflicts</string>
     <string name="link_user_actions_help">https://docs.ankidroid.org/#userActions</string>
     <string name="link_faq_tts">https://github.com/ankidroid/Anki-Android/wiki/FAQ#tts--text-to-speech-is-not-speaking</string>
     <string name="link_faq_missing_media" tools:ignore="Typos">https://github.com/ankidroid/Anki-Android/wiki/FAQ#why-doesnt-my-sound-or-image-work-on-ankidroid</string>

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ View [Wiki](https://github.com/ankidroid/Anki-Android/wiki)
 
 Help
 ----
-Check the [user manual](https://ankidroid.org/docs/manual.html) and the wiki for usage instructions. See the [help page](https://ankidroid.org/docs/help.html) 
+Check the [user manual](https://docs.ankidroid.org/) and the wiki for usage instructions. See the [help page](https://docs.ankidroid.org/help.html) 
 for how to submit a bug report or contact a project member, etc.
 
 Contribute

--- a/docs/ankidroid/sdk-version-history.md
+++ b/docs/ankidroid/sdk-version-history.md
@@ -2,7 +2,7 @@
 
 Use https://apilevels.com/ to lookup Android version numbers/codenames.
 
-See https://ankidroid.org/changelog.html for user-facing changelogs.
+See https://docs.ankidroid.org/changelog.html for user-facing changelogs.
 
 | Version                                                                                      | minSdk | targetSdk   |
 |----------------------------------------------------------------------------------------------|--------|-------------|


### PR DESCRIPTION
## Purpose / Description
https://ankidroid.org will use a new home page. The manual is already at docs.ankidroid.org

## Fixes
* Part of https://github.com/ankidroid/ankidroiddocs/issues/181

## How Has This Been Tested?

Tested all relevant links

## Learning

Little disappointed, this drifted from 248617e3727665ae0dcb1b27dd8490f33942833a. My fault.

* https://github.com/ankidroid/Anki-Android/pull/17641


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->