### PR TITLE
fix FLAG_FULLSCREEN deprecation and use `WindowInsetsController`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -23,6 +23,7 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.view.Window
+import android.view.WindowInsetsController
 import android.view.WindowManager
 import android.widget.ProgressBar
 import androidx.activity.result.ActivityResult
@@ -47,6 +48,7 @@ import androidx.core.app.ShareCompat
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
+import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -139,7 +141,6 @@ open class AnkiActivity(
             }
         }
 
-    @Suppress("deprecation") // #9332: UI Visibility -> Insets
     override fun onCreate(savedInstanceState: Bundle?) {
         // The hardware buttons should control the music volume
         volumeControlStream = AudioManager.STREAM_MUSIC
@@ -147,14 +148,8 @@ open class AnkiActivity(
         Themes.setTheme(this)
         Themes.disableXiaomiForceDarkMode(this)
         super.onCreate(savedInstanceState)
-        // Disable the notifications bar if running under the test monkey.
-        if (AdaptionUtil.isUserATestClient) {
-            window.setFlags(
-                WindowManager.LayoutParams.FLAG_FULLSCREEN,
-                WindowManager.LayoutParams.FLAG_FULLSCREEN,
-            )
-        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            @Suppress("deprecation")
             window.navigationBarColor = getColor(R.color.transparent)
         }
         supportFragmentManager.setFragmentResultListener(REQUEST_EXPORT_SAVE, this) { _, bundle ->
@@ -183,6 +178,14 @@ open class AnkiActivity(
 
     override fun onStart() {
         super.onStart()
+        // Disable the notifications bar if running under the test monkey.
+        // This is a work-around for an issue with the monkey feature of adb - when the
+        // monkey runs on a physical device, it can pull the status bar down, and escape the app
+        // under test.
+        if (AdaptionUtil.isUserATestClient && window != null) {
+            // Note: this is run in `onStart`, since it appears the decorView can be null in `onCreate`
+            CompatHelper.compat.hideStatusBar(window)
+        }
         customTabActivityHelper.bindCustomTabsService(this)
     }
 

--- a/compat/src/main/java/com/ichi2/anki/compat/BaseCompat.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/BaseCompat.kt
@@ -21,6 +21,8 @@ import android.os.Environment
 import android.os.Vibrator
 import android.provider.MediaStore
 import android.view.View
+import android.view.Window
+import android.view.WindowManager
 import androidx.annotation.AnimRes
 import androidx.appcompat.widget.TooltipCompat
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
@@ -42,6 +44,14 @@ open class BaseCompat : Compat {
     // Until API26, tooltips cannot be defined declaratively in layouts
     override fun setTooltipTextByContentDescription(view: View) {
         TooltipCompat.setTooltipText(view, view.contentDescription)
+    }
+
+    // Until API36, `setFlags` is the recommended method to hide status controller
+    override fun hideStatusBar(window: Window) {
+        window.setFlags(
+            WindowManager.LayoutParams.FLAG_FULLSCREEN,
+            WindowManager.LayoutParams.FLAG_FULLSCREEN,
+        )
     }
 
     override fun overrideTransition(

--- a/compat/src/main/java/com/ichi2/anki/compat/Compat.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/Compat.kt
@@ -20,6 +20,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.os.Environment
 import android.view.View
+import android.view.Window
 import androidx.annotation.AnimRes
 import java.io.File
 import java.io.FileNotFoundException
@@ -76,6 +77,8 @@ interface Compat {
     )
 
     fun getMediaRecorder(context: Context): MediaRecorder
+
+    fun hideStatusBar(window: Window)
 
     fun overrideTransition(
         activity: Activity,

--- a/compat/src/main/java/com/ichi2/anki/compat/CompatHelper.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/CompatHelper.kt
@@ -43,6 +43,7 @@ class CompatHelper private constructor() {
             sdkVersion >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> CompatV34()
             sdkVersion >= Build.VERSION_CODES.TIRAMISU -> CompatV33()
             sdkVersion >= Build.VERSION_CODES.S -> CompatV31()
+            sdkVersion >= Build.VERSION_CODES.R -> CompatV30()
             sdkVersion >= Build.VERSION_CODES.Q -> CompatV29()
             sdkVersion >= Build.VERSION_CODES.O -> CompatV26()
             else -> BaseCompat()

--- a/compat/src/main/java/com/ichi2/anki/compat/CompatV30.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/CompatV30.kt
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2026 Cranberry Platypus <cranberryplatypus968@gmail.com>
+
+package com.ichi2.anki.compat
+
+import android.view.Window
+import androidx.annotation.RequiresApi
+import androidx.core.view.WindowInsetsCompat
+
+@RequiresApi(30)
+@Suppress("ktlint:standard:property-naming")
+open class CompatV30 : CompatV29() {
+    // As of API30, insetsController is the correct way to hide the status bar
+    @Suppress("SENSELESS_COMPARISON", "FoldInitializerAndIfToElvis")
+    override fun hideStatusBar(window: Window) {
+        if (window == null) {
+            return
+        }
+        val view = window.decorView
+        // Despite the type listed for window.decorView, it can, in fact, be null.
+        if (view == null) {
+            return
+        }
+        val controller = view.windowInsetsController
+        controller?.hide(WindowInsetsCompat.Type.statusBars())
+    }
+}

--- a/compat/src/main/java/com/ichi2/anki/compat/CompatV31.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/CompatV31.kt
@@ -13,7 +13,7 @@ import kotlin.time.Duration
 
 /** Implementation of [Compat] for SDK level 31  */
 @RequiresApi(31)
-open class CompatV31 : CompatV29() {
+open class CompatV31 : CompatV30() {
     override fun vibrate(
         context: Context,
         duration: Duration,


### PR DESCRIPTION
> [!NOTE]
> PR copied from from https://github.com/swe-productivity/Anki-Android/pull/10. See my comments there.
> Please note the **untested** note is no longer accurate

## Purpose / Description
Addresses deprecation of `FLAG_FULLSCREEN` in API 30

## Fixes
* Fixes #9332

## Approach
Replaces usage of `FLAG_FULLSCREEN` with recommended method to remove the status bar.

## How Has This Been Tested?
This PR has not been tested - the relevant code is only called when Android's Monkey is used,
or the app is loaded in a FirebaseTestLab. I can't reproduce either of these environments (Monkey
fairly reliably triggers some kind of memory leak detection on my device - and crashed my launcher
the last time I tried it), but I'm fairly confident the change will function as expected.

This being said, I'm not sure what the value of disabling the status bar is in either of these
cases is.

## Learning (optional, can help others)
https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_FULLSCREEN
https://developer.android.com/develop/ui/views/layout/immersive

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
