### PR TITLE
fix(whiteboard): prevent crash on rotation when type answer is open

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardView.kt
@@ -30,6 +30,7 @@ import android.view.ViewConfiguration
 import androidx.core.graphics.createBitmap
 import com.ichi2.anki.R
 import com.ichi2.anki.ui.windows.reviewer.whiteboard.SmoothPath.Companion.drawPath
+import timber.log.Timber
 
 /**
  * A custom view for the whiteboard that handles drawing and touch events.
@@ -89,6 +90,11 @@ class WhiteboardView : View {
         oldh: Int,
     ) {
         super.onSizeChanged(w, h, oldw, oldh)
+        // createBitmap requires a width and height > 0; #21096
+        if (w <= 0 || h <= 0) {
+            Timber.w("Width or height <= 0: w: $w h: $h Bitmap couldn't be created with the new size")
+            return
+        }
         if (::bufferBitmap.isInitialized) bufferBitmap.recycle()
         bufferBitmap = createBitmap(w, h)
         bufferCanvas = Canvas(bufferBitmap)


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Rotating the device while both the whiteboard and a `{{type:}}` answer
field are open crashes with:

    IllegalArgumentException: width and height must be > 0
    at WhiteboardView.onSizeChanged

## Fixes
* Fixes #21096

## Approach
```kotlin
if (w <= 0 || h <= 0) return
``` 
## How Has This Been Tested?
Not reproducible either 
The PR mirrors the identical fix already in old Whiteboard.kt
https://github.com/criticalAY/Anki-Android/blob/9c874e2490c9049a460b5983d9af9f41fb00393f/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt#L227

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)