### PR TITLE
[PROPOSAL] docs: Theme Overlays and theming in :common:android

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -511,7 +511,7 @@ open class DeckPicker :
         setViewBinding(binding)
         enableToolbar()
         // TODO This method is run on every activity recreation, which can happen often.
-        //  It seems that the original idea was for for this to only run once, on app start.
+        //  It seems that the original idea was for this to only run once, on app start.
         //  This method triggers backups, sync, and may re-show dialogs
         //  that may have been dismissed. Make this run only once?
         handleStartup()

--- a/common/android/README.md
+++ b/common/android/README.md
@@ -13,3 +13,40 @@ Android-specific utilities (e.g. `isRobolectric`)
 ### `com.ichi2.anki.common.utils.ext`
 
 Extension methods on Android framework classes (e.g. `Intent`)
+
+## Resource class references (`CommonR`)
+
+Resources for this module live in `com.ichi2.anki.common.android.R` due to 
+ `nonTransitiveRClass=true` (AGP default).
+
+Use `CommonR` as an alias when outside this module. Inside this module, `R` should be used as the alias.
+
+```
+// outside this module
+import com.ichi2.anki.common.android.R as CommonR
+
+// inside this module
+import com.ichi2.anki.common.android.R
+```
+
+## Future extensions
+
+### Theming
+
+See [docs/development/theming-modularization.md](../../docs/development/theming-modularization.md).
+
+This module will define base themes: `Base.Theme.Light.Plain` etc... to be extended in `:AnkiDroid` 
+with feature-level theme overlays.
+
+`:common:android` should only contain the following for theming:
+
+* well-known common values and attributes (Material Colors/attrs)
+* values and attributes which are used by multiple features
+
+```xml
+<!-- GOOD: overridable per-feature -->
+<attr name="appBarColor" format="color"/>
+
+<!-- BAD: declare it in a ':study-screen' feature or :AnkiDroid if there is no feature module --> 
+<attr name="showAnswerButtonBackground" format="color"/> 
+```

--- a/docs/development/theming-modularization.md
+++ b/docs/development/theming-modularization.md
@@ -1,0 +1,77 @@
+> [!CAUTION]
+> This is a plan for how theming will work in XML-Views and is subject to change.  
+> AnkiDroid will be Compose-first in the future.
+
+# Multimodule theming
+
+
+## Constraints
+
+- **A module cannot reference up the dependency tree.** `:common:android` can only define attrs/styles, or depend on attrs/styles in a module it depends on.
+- **Styles don't merge across modules.** A feature cannot contribute an `<item>` to a base theme it doesn't own.
+- **Themes are applied by `setTheme`.** Resource qualifiers (`values-night`) are insufficiently powerful 
+  to support two night themes: `Dark`/`Black`. 
+- **[`nonTransitiveRClass=true`](https://developer.android.com/build/optimize-your-build?utm_source=android-studio-app&)**.
+  Common code is in `CommonR` instead of `R` (see [`:common:android` README](../../common/android/README.md)).
+
+## Layers
+
+* `:common:android` defines base themes. All defined attrs must be common to multiple modules or
+ well-known common attributes (Material Colors/Themes).
+* `:feature:` modules may define a feature-specific `attr`, and a per-theme overlay (see below). This allows 
+  resources (colors, attrs, etc.) to be tightly scoped to the feature. This is optional, the majority of 
+  features will just use `attrs` defined in `:common:android`.
+* `:AnkiDroid` defines the app-level themes. These inherit from the base themes, and set feature-level `attr`s.
+
+Examples:
+
+```mermaid
+classDiagram
+    direction TB
+    class common[":common:android"] {
+        Theme = Base.Theme.Light.Plain
+        color = material_blue_grey_700
+        attr = colorPrimary
+    }
+    class feature[":feature:study-screen"] {
+        Defines attr: studyScreenThemeOverlay - used in :AnkiDroid
+        ThemeOverlay: ThemeOverlay.StudyScreen.Light.Plain
+        attr: hardButtonBackground
+        Defines feature-specific colors
+    }
+    class app[":AnkiDroid"] {
+        Define Theme_Light, inheriting from Base.Theme.Light.Plain
+        Theme_Light.studyScreenThemeOverlay = ThemeOverlay.StudyScreen.Light.Plain
+    }
+
+    common <|-- feature
+    feature <|-- app
+```
+
+## `:feature` Overlays and theme-overlay pointers 
+
+`:AnkiDroid` is responsible for wiring up themes, so adding a theme is a resource-only change, and 
+ features are not responsible for theme dispatch logic.
+ A theme-overlay pointer is used to move this decision to `:AnkiDroid`, which is defined in a 
+ `:feature` as:
+
+```xml
+<!-- theme-overlay pointer -->
+<attr name="studyScreenThemeOverlay" format="reference"/>
+
+<!-- Theme overlay -->
+<style name="ThemeOverlay.StudyScreen.Light.Plain" parent=""></style>
+```
+
+```kt
+// in activity startup: setThemeOverlay aliases setTheme
+setTheme(getResFromAttr(this, R.attr.studyScreenThemeOverlay))
+```
+
+#### in `:AnkiDroid`
+
+```xml
+<style name="Theme_Plain" parent="Base.Theme.Light.Plain">
+    <item name="studyScreenThemeOverlay">@style/ThemeOverlay.StudyScreen.Light.Plain</item>
+</style>
+```


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.8 - a lot of planning. Initial structure of the docs (badly formed)

## Purpose / Description

**Previews**

* https://github.com/david-allison/Anki-Android/blob/theming-docs/docs/development/theming-modularization.md
* https://github.com/david-allison/Anki-Android/blob/theming-docs/common/android/README.md#future-extensions

Enables a structure where all feature-level attrs, colors etc... are defined inside the feature, rather than leaking into ':common:android'.

* `:common` contains base-theme level responsibilities
* `:feature` contains feature-level responsibilities
* `:AnkiDroid` does coordination
* 

## Fixes
* A proposal: part of #20737

## Approach

I initially felt boxed-in with the strict hierarchy of modules and inability to define a union of themes - this meant study screen `attr`s  would be in the base theme, even though they felt unnecessary.

Theme overlays allowed me to extract this concern, along with the fact  that themes have parents, this allowed layers for an intuitive and  well-scoped design

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)