### PR TITLE
refactor(build): define addAnkiBackendDependencies

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -472,6 +472,7 @@ dependencies {
 
     implementation libs.protobuf.kotlin.lite // This is required when loading from a file
 
+    // TODO: migrate to `addAnkiBackendDependencies(...)` when this is a gradle.kts file
     Properties localProperties = new Properties()
     if (project.rootProject.file('local.properties').exists()) {
         localProperties.load(project.rootProject.file('local.properties').newDataInputStream())

--- a/buildSrc/src/main/kotlin/com/ichi2/anki/gradle/BackendDependencies.kt
+++ b/buildSrc/src/main/kotlin/com/ichi2/anki/gradle/BackendDependencies.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.gradle
+
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.DependencyHandlerScope
+import java.io.File
+import java.util.Properties
+
+// The Anki backend (rsdroid) is consumed either as a locally-built artifact in
+// ../Anki-Android-Backend (when `local_backend=true` in local.properties) or as
+// the published library from the version catalog.
+
+// Paths within the `Anki-Android-Backend` checkout, which sits beside the repo root.
+private const val RSDROID_AAR =
+    "rsdroid/build/outputs/aar/rsdroid-release.aar"
+private const val RSDROID_TESTING_JAR =
+    "rsdroid-testing/build/libs/rsdroid-testing.jar"
+
+/**
+ * Adds the Anki backend (rsdroid) dependencies, choosing between the locally-built
+ * artifacts and the published version-catalog libraries based on `local_backend` in
+ * `local.properties`.
+ *
+ * See https://github.com/ankidroid/Anki-Android-Backend/
+ */
+// TODO: use context parameters when we compile kts with Kotlin 2.4.0
+fun DependencyHandlerScope.addAnkiBackendDependencies(project: Project) {
+    with(project) {
+        val useLocalBackend = localBackendEnabled()
+
+        addBackendArtifact("implementation", useLocalBackend, RSDROID_AAR, "ankiBackend-backend")
+        addBackendArtifact("testImplementation", useLocalBackend, RSDROID_TESTING_JAR, "ankiBackend-testing")
+
+        // protobuf is required when loading from a file, regardless of the backend source
+        dependencies.addProvider("implementation", libsLibrary("protobuf-kotlin-lite"))
+
+        if (project.hasTestFixtures) {
+            addBackendArtifact("testFixturesImplementation", useLocalBackend, RSDROID_AAR, "ankiBackend-backend")
+            addBackendArtifact("testFixturesImplementation", useLocalBackend, RSDROID_TESTING_JAR, "ankiBackend-testing")
+            dependencies.addProvider("testFixturesImplementation", libsLibrary("protobuf-kotlin-lite"))
+        }
+    }
+}
+
+private val Project.hasTestFixtures: Boolean
+    get() = configurations.findByName("testFixturesImplementation") != null
+
+private fun Project.localBackendEnabled(): Boolean {
+    val localProperties = rootProject.layout.projectDirectory.file("local.properties")
+    val content = providers.fileContents(localProperties).asText.orNull ?: return false
+    val properties = Properties().apply { content.reader().use { load(it) } }
+    return properties["local_backend"] == "true"
+}
+
+private fun Project.addBackendArtifact(
+    configuration: String,
+    useLocalBackend: Boolean,
+    localPath: String,
+    catalogAlias: String,
+) {
+    if (useLocalBackend) {
+        // ../Anki-Android-Backend
+        val backendCheckout = File(rootProject.projectDir.parentFile, "Anki-Android-Backend")
+        dependencies.add(configuration, files(File(backendCheckout, localPath)))
+    } else {
+        dependencies.addProvider(configuration, libsLibrary(catalogAlias))
+    }
+}

--- a/buildSrc/src/main/kotlin/com/ichi2/anki/gradle/VersionCatalogs.kt
+++ b/buildSrc/src/main/kotlin/com/ichi2/anki/gradle/VersionCatalogs.kt
@@ -3,8 +3,10 @@
 package com.ichi2.anki.gradle
 
 import org.gradle.api.Project
+import org.gradle.api.artifacts.MinimalExternalModuleDependency
 import org.gradle.api.artifacts.VersionCatalog
 import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.getByType
 
 // Type-safe `libs` accessors aren't available in precompiled script plugins,
@@ -22,3 +24,12 @@ private fun Project.libs(): VersionCatalog =
 
 fun Project.libsVersionFor(alias: String): String =
     libs().findVersion(alias).get().requiredVersion
+
+// Provider<MinimalExternalModuleDependency> is tied to build-scoped services
+// so must not come from cachedLibs.
+fun Project.libsLibrary(alias: String): Provider<MinimalExternalModuleDependency> =
+    extensions
+        .getByType<VersionCatalogsExtension>()
+        .named("libs")
+        .findLibrary(alias)
+        .get()

--- a/libanki/build.gradle.kts
+++ b/libanki/build.gradle.kts
@@ -1,5 +1,5 @@
 import com.android.build.api.dsl.LibraryExtension
-import java.util.Properties
+import com.ichi2.anki.gradle.addAnkiBackendDependencies
 
 plugins {
     id("ankidroid.android.library")
@@ -16,23 +16,7 @@ dependencies {
     implementation(project(":common"))
 
     // Backend libraries
-    implementation(libs.protobuf.kotlin.lite) // This is required when loading from a file
-
-    val localProperties = Properties()
-    if (project.rootProject.file("local.properties").exists()) {
-        localProperties.load(project.rootProject.file("local.properties").inputStream())
-    }
-    if (localProperties["local_backend"] == "true") {
-        implementation(files(rootProject.file("../Anki-Android-Backend/rsdroid/build/outputs/aar/rsdroid-release.aar")))
-        testImplementation(files(rootProject.file("../Anki-Android-Backend/rsdroid-testing/build/libs/rsdroid-testing.jar")))
-        testFixturesImplementation(files(rootProject.file("../Anki-Android-Backend/rsdroid/build/outputs/aar/rsdroid-release.aar")))
-        testFixturesImplementation(files(rootProject.file("../Anki-Android-Backend/rsdroid-testing/build/libs/rsdroid-testing.jar")))
-    } else {
-        implementation(libs.ankiBackend.backend)
-        testImplementation(libs.ankiBackend.testing)
-        testFixturesImplementation(libs.ankiBackend.backend)
-        testFixturesImplementation(libs.ankiBackend.testing)
-    }
+    addAnkiBackendDependencies(project)
 
     // JVM dependencies
     implementation(libs.jakewharton.timber)
@@ -56,7 +40,6 @@ dependencies {
 
     // testFixtures dependencies
     testFixturesImplementation(project(":common"))
-    testFixturesImplementation(libs.protobuf.kotlin.lite)
     testFixturesImplementation(libs.jakewharton.timber)
     testFixturesImplementation(libs.junit.vintage.engine)
     testFixturesImplementation(libs.kotlinx.coroutines.core)


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.8

## Purpose / Description
I will add this to `anki-common`, and it's a lot of complexity

## Fixes
* Part of #20737

## How Has This Been Tested?
App still runs; local_backend is still blocked on the Anki-Android-Backend `java-library` conversion

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->