### PR TITLE
refactor: extract AnkiDroidFolder to :anki-common

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -22,7 +22,6 @@ import android.os.Environment
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
-import com.ichi2.anki.AnkiDroidFolder.AppPrivateFolder
 import com.ichi2.anki.CollectionHelper.PREF_COLLECTION_PATH
 import com.ichi2.anki.CollectionHelper.getCurrentAnkiDroidDirectory
 import com.ichi2.anki.backend.createDatabaseUsingAndroidFramework
@@ -33,6 +32,7 @@ import com.ichi2.anki.exception.UnknownDatabaseVersionException
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.CollectionFiles
 import com.ichi2.anki.libanki.DB
+import com.ichi2.anki.storage.AnkiDroidFolder
 import com.ichi2.preferences.getOrSetString
 import timber.log.Timber
 import java.io.File
@@ -187,7 +187,7 @@ object CollectionHelper {
         context: Context,
         directoryName: String = "AnkiDroid",
     ): File {
-        val legacyStorage = selectAnkiDroidFolder(context) != AppPrivateFolder
+        val legacyStorage = selectAnkiDroidFolder(context) != AnkiDroidFolder.APP_PRIVATE
         return if (legacyStorage) {
             legacyAnkiDroidDirectory(directoryName)
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -994,12 +994,12 @@ open class DeckPicker :
 
         val environment: AnkiDroidEnvironment =
             object : AnkiDroidEnvironment {
-                private val folder = selectAnkiDroidFolder(context)
+                private val permissions = selectStoragePermissions(context)
 
-                override fun hasRequiredPermissions(): Boolean = folder.hasRequiredPermissions(context)
+                override fun hasRequiredPermissions(): Boolean = permissions.hasRequiredPermissions(context)
 
                 override val requiredPermissions: PermissionSet
-                    get() = folder.permissionSet
+                    get() = permissions
 
                 override fun initializeAnkiDroidFolder(): Boolean = CollectionHelper.isCurrentAnkiDroidDirAccessible(context)
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -36,6 +36,7 @@ import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService.setPreferencesUpToDate
 import com.ichi2.anki.servicelayer.ScopedStorageService.isLegacyStorage
+import com.ichi2.anki.storage.AnkiDroidFolder
 import com.ichi2.anki.ui.windows.permissions.InternetPermissionFragment
 import com.ichi2.anki.ui.windows.permissions.NotificationsPermissionFragment
 import com.ichi2.anki.ui.windows.permissions.PermissionsFragment
@@ -189,31 +190,6 @@ object InitialActivity {
     }
 }
 
-sealed class AnkiDroidFolder(
-    val permissionSet: PermissionSet,
-) {
-    /**
-     * AnkiDroid will use the folder ~/AnkiDroid by default
-     * To access it, we must first get [permissionSet].permissions.
-     * This folder is not deleted when the user uninstalls the app, which reduces the risk of data loss,
-     * but increase the risk of space used on their storage when they don't want to.
-     * It can not be used on the play store starting with Sdk 30.
-     **/
-    class PublicFolder(
-        requiredPermissions: PermissionSet,
-    ) : AnkiDroidFolder(requiredPermissions)
-
-    /**
-     * AnkiDroid will use the app-private folder: `~/Android/data/com.ichi2.anki[.A]/files/AnkiDroid`.
-     * The user may delete when they uninstall the app, risking data loss.
-     * No permission dialog is required.
-     * Google will not allow [android.Manifest.permission.MANAGE_EXTERNAL_STORAGE], so this is default on the Play Store.
-     */
-    data object AppPrivateFolder : AnkiDroidFolder(PermissionSet.APP_PRIVATE)
-
-    fun hasRequiredPermissions(context: Context): Boolean = hasAllPermissions(context, permissionSet.permissions)
-}
-
 @Parcelize
 enum class PermissionSet(
     val permissions: List<String>,
@@ -229,43 +205,54 @@ enum class PermissionSet(
     /** Optional. */
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     NOTIFICATIONS(listOf(Manifest.permission.POST_NOTIFICATIONS), NotificationsPermissionFragment::class.java),
+    ;
+
+    fun hasRequiredPermissions(context: Context): Boolean = hasAllPermissions(context, permissions)
 }
 
 /**
- * Returns in which folder AnkiDroid data is saved.
- * [AnkiDroidFolder.PublicFolder] is preferred, as it reduce risk of data loss.
+ * Returns the [PermissionSet] required to access the folder where AnkiDroid data is saved.
+ * [com.ichi2.anki.storage.AnkiDroidFolder.PUBLIC] is preferred, as it reduces risk of data loss.
  * When impossible, we use the app-private directory.
  * See https://github.com/ankidroid/Anki-Android/issues/5304 for more context.
  */
-internal fun selectAnkiDroidFolder(
+internal fun selectStoragePermissions(
     canManageExternalStorage: Boolean,
     currentFolderIsAccessibleAndLegacy: Boolean,
-): AnkiDroidFolder {
+): PermissionSet {
     if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q || currentFolderIsAccessibleAndLegacy) {
         // match AnkiDroid behaviour before scoped storage - force the use of ~/AnkiDroid,
         // since it's fast & safe up to & including 'Q'
         // If a user upgrades their OS from Android 10 to 11 then storage speed is severely reduced
         // and a user should use one of the below options to provide faster speeds
-        return AnkiDroidFolder.PublicFolder(PermissionSet.LEGACY_ACCESS)
+        return PermissionSet.LEGACY_ACCESS
     }
 
     // If the user can manage external storage, we can access the safe folder & access is fast
     return if (canManageExternalStorage) {
-        AnkiDroidFolder.PublicFolder(PermissionSet.EXTERNAL_MANAGER)
+        PermissionSet.EXTERNAL_MANAGER
     } else {
-        AnkiDroidFolder.AppPrivateFolder
+        PermissionSet.APP_PRIVATE
     }
 }
 
-fun selectAnkiDroidFolder(context: Context): AnkiDroidFolder {
+fun selectStoragePermissions(context: Context): PermissionSet {
     val canAccessLegacyStorage = Build.VERSION.SDK_INT < Build.VERSION_CODES.Q || Environment.isExternalStorageLegacy()
     val currentFolderIsAccessibleAndLegacy = canAccessLegacyStorage && isLegacyStorage(context, setCollectionPath = false) == true
 
-    return selectAnkiDroidFolder(
+    return selectStoragePermissions(
         canManageExternalStorage = Permissions.canManageExternalStorage(context),
         currentFolderIsAccessibleAndLegacy = currentFolderIsAccessibleAndLegacy,
     )
 }
+
+/** The folder where AnkiDroid data is saved. See [selectStoragePermissions]. */
+fun selectAnkiDroidFolder(context: Context): AnkiDroidFolder =
+    if (selectStoragePermissions(context) == PermissionSet.APP_PRIVATE) {
+        AnkiDroidFolder.APP_PRIVATE
+    } else {
+        AnkiDroidFolder.PUBLIC
+    }
 
 /**
  * Configures either hardware or software rendering

--- a/AnkiDroid/src/main/java/com/ichi2/anki/introduction/CollectionPermissionScreenLauncher.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/introduction/CollectionPermissionScreenLauncher.kt
@@ -21,7 +21,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.app.ActivityCompat
 import com.ichi2.anki.AnkiActivity
-import com.ichi2.anki.selectAnkiDroidFolder
+import com.ichi2.anki.selectStoragePermissions
 import com.ichi2.anki.ui.windows.permissions.PermissionsActivity
 import timber.log.Timber
 
@@ -44,10 +44,10 @@ interface CollectionPermissionScreenLauncher {
      * @return `true` if the screen was opened
      */
     fun AnkiActivity.collectionPermissionScreenWasOpened(): Boolean {
-        val ankiDroidFolder = selectAnkiDroidFolder(this)
-        if (!ankiDroidFolder.hasRequiredPermissions(this)) {
+        val permissions = selectStoragePermissions(this)
+        if (!permissions.hasRequiredPermissions(this)) {
             Timber.i("${this.javaClass.simpleName}: postponing startup code - permission screen shown")
-            permissionScreenLauncher.launch(PermissionsActivity.getIntent(this, ankiDroidFolder.permissionSet))
+            permissionScreenLauncher.launch(PermissionsActivity.getIntent(this, permissions))
             return true
         }
         return false
@@ -55,6 +55,6 @@ interface CollectionPermissionScreenLauncher {
 }
 
 fun AnkiActivity.hasCollectionStoragePermissions(): Boolean {
-    val ankiDroidFolder = selectAnkiDroidFolder(this)
-    return ankiDroidFolder.hasRequiredPermissions(this)
+    val permissions = selectStoragePermissions(this)
+    return permissions.hasRequiredPermissions(this)
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.kt
@@ -23,15 +23,12 @@ import android.os.Build
 import androidx.core.content.edit
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.anki.AnkiDroidFolder.AppPrivateFolder
-import com.ichi2.anki.AnkiDroidFolder.PublicFolder
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService
 import com.ichi2.testutils.EmptyApplication
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.contains
-import org.hamcrest.core.IsInstanceOf.instanceOf
 import org.junit.Before
 import org.junit.Test
 import org.junit.experimental.categories.Category
@@ -133,11 +130,11 @@ class InitialActivityTest : RobolectricTest() {
 
         // force a safe startup before Q
         assertThat(
-            (selectAnkiDroidFolder(false) as PublicFolder).requiredPermissions.asIterable(),
+            selectStoragePermissions(canManageExternalStorage = false).permissions.asIterable(),
             contains(*expectedPermissions),
         )
         assertThat(
-            (selectAnkiDroidFolder(true) as PublicFolder).requiredPermissions.asIterable(),
+            selectStoragePermissions(canManageExternalStorage = true).permissions.asIterable(),
             contains(*expectedPermissions),
         )
     }
@@ -145,14 +142,8 @@ class InitialActivityTest : RobolectricTest() {
     @Config(sdk = [Q])
     @Test
     fun startupQ() {
-        assertThat(
-            selectAnkiDroidFolder(false),
-            instanceOf(PublicFolder::class.java),
-        )
-        assertThat(
-            selectAnkiDroidFolder(true),
-            instanceOf(PublicFolder::class.java),
-        )
+        assertThat(selectStoragePermissions(canManageExternalStorage = false), equalTo(PermissionSet.LEGACY_ACCESS))
+        assertThat(selectStoragePermissions(canManageExternalStorage = true), equalTo(PermissionSet.LEGACY_ACCESS))
     }
 
     @SuppressLint("InlinedApi")
@@ -167,12 +158,12 @@ class InitialActivityTest : RobolectricTest() {
                 android.Manifest.permission.INTERNET,
             )
 
-        selectAnkiDroidFolder(
+        selectStoragePermissions(
             canManageExternalStorage = true,
             currentFolderIsAccessibleAndLegacy = true,
         ).let {
             assertThat(
-                (it as PublicFolder).requiredPermissions.asIterable(),
+                it.permissions.asIterable(),
                 contains(*expectedPermissions),
             )
         }
@@ -182,35 +173,32 @@ class InitialActivityTest : RobolectricTest() {
     @Config(sdk = [R_OR_AFTER])
     @Test
     fun `Android 11 - After reinstall (with MANAGE_EXTERNAL_STORAGE)`() {
-        val ankiDroidFolder =
-            selectAnkiDroidFolder(
+        val permissions =
+            selectStoragePermissions(
                 canManageExternalStorage = true,
                 currentFolderIsAccessibleAndLegacy = false,
-            ) as PublicFolder
+            )
 
-        assertTrue(android.Manifest.permission.MANAGE_EXTERNAL_STORAGE in ankiDroidFolder.requiredPermissions)
+        assertTrue(android.Manifest.permission.MANAGE_EXTERNAL_STORAGE in permissions.permissions)
     }
 
     @Config(sdk = [R_OR_AFTER])
     @Test
     fun startupAfterQWithoutManageExternalStorage() {
         assertThat(
-            selectAnkiDroidFolder(canManageExternalStorage = false),
-            instanceOf(AppPrivateFolder::class.java),
+            selectStoragePermissions(canManageExternalStorage = false),
+            equalTo(PermissionSet.APP_PRIVATE),
         )
     }
 
-    private val AnkiDroidFolder.requiredPermissions
-        get() = permissionSet.permissions
-
     /**
-     * Helper for [com.ichi2.anki.selectAnkiDroidFolder], making `currentFolderIsAccessibleAndLegacy` optional
+     * Helper for [com.ichi2.anki.selectStoragePermissions], making `currentFolderIsAccessibleAndLegacy` optional
      */
-    private fun selectAnkiDroidFolder(
+    private fun selectStoragePermissions(
         canManageExternalStorage: Boolean,
         currentFolderIsAccessibleAndLegacy: Boolean = false,
-    ): AnkiDroidFolder =
-        com.ichi2.anki.selectAnkiDroidFolder(
+    ): PermissionSet =
+        com.ichi2.anki.selectStoragePermissions(
             canManageExternalStorage = canManageExternalStorage,
             currentFolderIsAccessibleAndLegacy = currentFolderIsAccessibleAndLegacy,
         )

--- a/AnkiDroid/src/test/java/com/ichi2/anki/IntroductionActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/IntroductionActivityTest.kt
@@ -42,8 +42,8 @@ class IntroductionActivityTest : RobolectricTest() {
     @Test
     fun `Sync without storage permission opens PermissionsActivity`() =
         runTest {
-            // Robolectric runs at API 35 where selectAnkiDroidFolder returns AppPrivateFolder,
-            // whose required PermissionSet is just [INTERNET]. Denying INTERNET is the cheapest
+            // Robolectric runs at API 35 where selectStoragePermissions returns PermissionSet.APP_PRIVATE,
+            // which is just [INTERNET]. Denying INTERNET is the cheapest
             // way to make hasCollectionStoragePermissions() return false in this environment.
             withDeniedPermissions(INTERNET) {
                 val activity = startRegularActivity<IntroductionActivity>(Intent())

--- a/anki-common/src/main/java/com/ichi2/anki/storage/AnkiDroidFolder.kt
+++ b/anki-common/src/main/java/com/ichi2/anki/storage/AnkiDroidFolder.kt
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.storage
+
+/**
+ * Where AnkiDroid stores its collection.
+ *
+ * See https://github.com/ankidroid/Anki-Android/issues/5304 for more context.
+ */
+enum class AnkiDroidFolder {
+    /**
+     * The folder `~/AnkiDroid`, used by default.
+     *
+     * This folder is not deleted when the user uninstalls the app, which reduces the risk of data
+     * loss, but increases the risk of space used on their storage when they don't want to.
+     *
+     * It cannot be used on the Play Store starting with SDK 30, as Google will not
+     *  allow [android.Manifest.permission.MANAGE_EXTERNAL_STORAGE].
+     */
+    PUBLIC,
+
+    /**
+     * The app-private folder: `~/Android/data/com.ichi2.anki[.A]/files/AnkiDroid`.
+     *
+     * The user may delete it when they uninstall the app, risking data loss.
+     * No permission dialog is required. This is the default on the Play Store
+     */
+    APP_PRIVATE,
+}


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.8

Part of making CollectionManager common-compatible

## Fixes
* Part of #20737
* I split this from https://github.com/ankidroid/Anki-Android/pull/21194 - it was big

## Approach
AnkiDroidFolder was split into the permissions and the private/public axis. This is subject to further change:

* The Storage Manager/Legacy/Standard storage split is now handled as `PermissonSet`, but now feels like another axis, I will likely extract this in a follow up

## How Has This Been Tested?
⚠️ Trusting tests - code LGTM

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)