### PR TITLE
fix: FAB opens menu on accessibility click

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
@@ -397,15 +397,20 @@ class DeckPickerFloatingActionMenu(
                 }
             }
         binding.addSharedButton.setOnKeyListener(addSharedKeyListener)
-        val addNoteLabelListener =
+        // Mirrors the touch DoubleTapListener above: TalkBack and hardware keyboards activate via
+        // ACTION_CLICK -> performClick(), which bypasses the touch GestureDetector. Opening the menu
+        // must live here too, otherwise the FAB is inoperable when a screen reader is enabled.
+        val fabMainClickListener =
             View.OnClickListener {
-                if (isFABOpen) {
+                if (!isFABOpen) {
+                    showFloatingActionMenu()
+                } else {
                     closeFloatingActionMenu(applyRiseAndShrinkAnimation = false)
-                    Timber.d("configureFloatingActionsMenu::addNoteLabel::onClickListener - Adding Note")
+                    Timber.d("configureFloatingActionsMenu::fabMain::onClickListener - Adding Note")
                     addNote()
                 }
             }
-        binding.fabMain.setOnClickListener(addNoteLabelListener)
+        binding.fabMain.setOnClickListener(fabMainClickListener)
 
         // Enable keyboard activation for Enter/DPAD_CENTER keys
         binding.fabMain.setOnKeyListener(

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -681,6 +681,16 @@ class DeckPickerTest : RobolectricTest() {
         }
 
     @Test
+    fun `FAB opens menu on accessibility click`() =
+        deckPicker {
+            val fab = findViewById<View>(R.id.fab_main)
+            assertThat("menu starts closed", floatingActionMenu.isFABOpen, equalTo(false))
+            // TalkBack activate a focused control, which routes to [View.performClick]
+            fab.performClick()
+            assertThat("FAB menu opens on click", floatingActionMenu.isFABOpen, equalTo(true))
+        }
+
+    @Test
     fun `On a new startup, the App Intro is displayed`() =
         deckPicker(skipIntroduction = false) {
             val nextIntent = Shadows.shadowOf(this).nextStartedActivity


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
With TalkBack enabled, tapping the deck picker "+" FAB did nothing the add menu never opened. Make the fab_main OnClickListener open the menu when closed (mirroring the touch listener's onUnconfirmedSingleTap), so screen-reader activation works.

## Fixes
* Fixes #20379

## Approach
Previously, the FAB's open logic relied solely on a touch GestureDetector, which TalkBack bypasses in favor of the view's OnClickListener (double-tap-to-activate dispatches ACTION_CLICK - > View.performClick()). Since this click listener did nothing when the menu was closed, screen reader users were completely unable to open the FAB menu. The fix moves the open-when-closed logic into the OnClickListener.

## How Has This Been Tested?
Google emulator API 35
[Screen_recording_20260602_074003.webm](https://github.com/user-attachments/assets/352e27a3-c3be-4a70-bdee-87b37c01268b)



## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->