### PR TITLE
Fix: restore keyboard/D-pad control of deck picker FAB menu

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
@@ -309,6 +309,7 @@ class DeckPickerFloatingActionMenu(
                         if (!isFABOpen) {
                             showFloatingActionMenu()
                         } else {
+                            closeFloatingActionMenu(applyRiseAndShrinkAnimation = false)
                             addNote()
                         }
                         return@setOnKeyListener true
@@ -399,16 +400,6 @@ class DeckPickerFloatingActionMenu(
                 }
             }
         binding.fabMain.setOnClickListener(fabMainClickListener)
-
-        // Enable keyboard activation for Enter/DPAD_CENTER keys
-        binding.fabMain.setOnKeyListener(
-            createActivationKeyListener("Add Note label: ENTER key pressed") {
-                if (isFABOpen) {
-                    closeFloatingActionMenu(applyRiseAndShrinkAnimation = false)
-                    addNote()
-                }
-            },
-        )
     }
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.database.sqlite.SQLiteDatabaseCorruptException
+import android.view.KeyEvent
 import android.view.Menu
 import android.view.View
 import android.widget.TextView
@@ -688,6 +689,30 @@ class DeckPickerTest : RobolectricTest() {
             // TalkBack activate a focused control, which routes to [View.performClick]
             fab.performClick()
             assertThat("FAB menu opens on click", floatingActionMenu.isFABOpen, equalTo(true))
+        }
+
+    @Test
+    fun `FAB menu opens on ENTER key`() =
+        deckPicker {
+            val fab = findViewById<View>(R.id.fab_main)
+
+            assertThat("menu starts closed", floatingActionMenu.isFABOpen, equalTo(false))
+
+            fab.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER))
+
+            assertThat("ENTER key opens the FAB menu", floatingActionMenu.isFABOpen, equalTo(true))
+        }
+
+    @Test
+    fun `FAB menu closes on ESCAPE key`() =
+        deckPicker {
+            val fab = findViewById<View>(R.id.fab_main)
+            floatingActionMenu.showFloatingActionMenu()
+            assertThat("menu is open", floatingActionMenu.isFABOpen, equalTo(true))
+
+            fab.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ESCAPE))
+
+            assertThat("ESCAPE key closes the FAB menu", floatingActionMenu.isFABOpen, equalTo(false))
         }
 
     @Test


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.8

<!--- Please fill the necessary details below -->
## Purpose / Description
- ~Blocked by #21199~
The main FAB registered two OnKeyListeners in init so this fixes that

## Fixes
* Fixes #21200

## Approach
See commit

## How Has This Been Tested?
tests and manually tested on emulator

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->