### PR TITLE
feat: define 'Storage Decision'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -20,6 +20,7 @@ import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.CollectionFiles
 import com.ichi2.anki.libanki.DB
 import com.ichi2.anki.storage.AnkiDroidFolder
+import com.ichi2.anki.storage.StorageDecision
 import com.ichi2.preferences.getOrSetString
 import timber.log.Timber
 import java.io.File
@@ -258,6 +259,15 @@ object CollectionHelper {
     var ankiDroidDirectoryOverride: File? = null
 
     /**
+     * Whether the user has chosen where the collection is stored.
+     *
+     * TODO: real implementation based on whether [PREF_COLLECTION_PATH] is set.
+     *  TODO: What is a user revokes full storage?
+     *  This currently returns [StorageDecision.Decided], so callers that gate on it are no-ops.
+     */
+    fun storageDecision(): StorageDecision = storageDecisionTestOverride ?: StorageDecision.Decided
+
+    /**
      * @return the absolute path to the AnkiDroid directory.
      *
      * @throws SystemStorageException if `getExternalFilesDir` returns null
@@ -337,4 +347,8 @@ object CollectionHelper {
             db?.close()
         }
     }
+
+    /** Test-only override for [storageDecision]. @see ankiDroidDirectoryOverride */
+    @VisibleForTesting
+    var storageDecisionTestOverride: StorageDecision? = null
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
@@ -33,11 +33,13 @@ import com.ichi2.anki.CollectionManager.withQueue
 import com.ichi2.anki.backend.createDatabaseUsingRustBackend
 import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.utils.android.isRobolectric
+import com.ichi2.anki.exception.StorageNotConfiguredException
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.CollectionFiles
 import com.ichi2.anki.libanki.LibAnki
 import com.ichi2.anki.libanki.Storage.collection
 import com.ichi2.anki.libanki.importCollectionPackage
+import com.ichi2.anki.storage.StorageDecision
 import com.ichi2.utils.Threads
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -138,6 +140,9 @@ object CollectionManager {
      * Parallel calls to this function are guaranteed to be serialized, so you can be
      * sure the collection won't be closed or modified by another thread. This guarantee
      * does not hold if legacy code calls [getColUnsafe].
+     *
+     * @throws StorageNotConfiguredException If [CollectionHelper.storageDecision] is undecided
+     * (user has not selected a storage location).
      */
     suspend fun <T> withCol(
         @WorkerThread block: Collection.() -> T,
@@ -259,6 +264,9 @@ object CollectionManager {
      *
      * Automatically called by [withCol]. Can be called directly to ensure collection
      * is loaded at a certain point in time, or to ensure no errors occur.
+     *
+     * @throws StorageNotConfiguredException If [CollectionHelper.storageDecision] is undecided
+     * (user has not selected a storage location).
      */
     suspend fun ensureOpen() {
         withQueue {
@@ -266,8 +274,14 @@ object CollectionManager {
         }
     }
 
-    /** See [ensureOpen]. This must only be run inside the queue. */
+    /**
+     * See [ensureOpen]. This must only be run inside the queue.
+     *
+     * @throws StorageNotConfiguredException If [CollectionHelper.storageDecision] is not
+     * [StorageDecision.Decided] (user has not selected a storage location).
+     */
     private fun ensureOpenInner() {
+        if (CollectionHelper.storageDecision() != StorageDecision.Decided) throw StorageNotConfiguredException()
         ensureBackendInner()
         emulatedOpenFailure?.triggerFailure()
         if (collection == null || collection!!.dbClosed) {
@@ -326,6 +340,9 @@ object CollectionManager {
      * safe, as code in other threads could open or close
      * the collection while the reference is held. [withCol]
      * is a better alternative.
+     *
+     * @throws StorageNotConfiguredException If [CollectionHelper.storageDecision] is undecided
+     * (user has not selected a storage location).
      */
     fun getColUnsafe(): Collection =
         logUIHangs {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/StorageDecisionGateTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/StorageDecisionGateTest.kt
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.exception.StorageNotConfiguredException
+import com.ichi2.anki.storage.StorageDecision
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertFailsWith
+
+/**
+ * Proves the storage-decision gate in [CollectionManager.ensureOpenInner] is wired up. In production
+ * [CollectionHelper.storageDecision] always returns [com.ichi2.anki.storage.StorageDecision.Decided], so this never fires;
+ * here we force [com.ichi2.anki.storage.StorageDecision.Undecided] via the test override.
+ */
+@RunWith(AndroidJUnit4::class)
+class StorageDecisionGateTest : RobolectricTest() {
+    @Test
+    fun `opening the collection throws when storage is undecided`() {
+        CollectionHelper.storageDecisionTestOverride = StorageDecision.Undecided
+        try {
+            assertFailsWith<StorageNotConfiguredException> { CollectionManager.getColUnsafe() }
+        } finally {
+            CollectionHelper.storageDecisionTestOverride = null
+        }
+    }
+}

--- a/anki-common/src/main/java/com/ichi2/anki/exception/StorageNotConfiguredException.kt
+++ b/anki-common/src/main/java/com/ichi2/anki/exception/StorageNotConfiguredException.kt
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.exception
+
+/**
+ * Thrown when the collection is accessed before the user has chosen where it should be stored
+ * (the [storage decision][com.ichi2.anki.storage.StorageDecision] is `Undecided`).
+ *
+ * Use `StorageAccessException` if a known path is unusable.
+ */
+class StorageNotConfiguredException(
+    msg: String? = null,
+    e: Throwable? = null,
+) : Exception(msg, e)

--- a/anki-common/src/main/java/com/ichi2/anki/storage/StorageDecision.kt
+++ b/anki-common/src/main/java/com/ichi2/anki/storage/StorageDecision.kt
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.storage
+
+/**
+ * Whether the user has chosen where AnkiDroid stores its collection.
+ *
+ * On a fresh install the location must be chosen explicitly (see [com.ichi2.anki.AnkiDroidFolder]); there is no
+ * silent default, and the collection must not be opened until a choice has been made.
+ */
+sealed interface StorageDecision {
+    /** A storage location has been chosen; the collection may be opened. */
+    data object Decided : StorageDecision
+
+    /** No storage location has been chosen yet; the collection must not be opened. */
+    data object Undecided : StorageDecision
+}


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.8

## Purpose / Description
Currently, `withCol` implicitly creates the collection. I want this to stop happening so we can guarantee that the collection creation is deferred until the user has selected 'full' or 'play'-style storage.

## Fixes
* Part of #21204

## Approach
We need a means to know whether the collection was created or not, and throw if it's not created.

`StorageDecision` handles this. Currently a no-op.

## How Has This Been Tested?
No-op; unit tested

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)