### PR TITLE
lint: enable unused import checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,9 @@ end_of_line = crlf
 # This feels like an acceptable commenting strategy
 ktlint_standard_no-consecutive-comments = disabled
 
+# TODO: move this to detekt when 2.0.0 is stable (handles Kotlin 2.3.21)
+ktlint_standard_no-unused-imports = enabled
+
 # These lines add significant verbosity to the codebase. The PR introducing these rules (19817)
 # added 2k LOC to the codebase, often quadrupling the number of lines:
 #

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -23,8 +23,6 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.view.Window
-import android.view.WindowInsetsController
-import android.view.WindowManager
 import android.widget.ProgressBar
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultLauncher
@@ -48,7 +46,6 @@ import androidx.core.app.ShareCompat
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
-import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -37,7 +37,6 @@ import com.ichi2.anki.AnkiDroidApp.Companion.sharedPreferencesTestingOverride
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
 import com.ichi2.anki.common.android.ApplicationContextInitializer
-import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.annotations.LegacyNotifications
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.coroutines.applicationScope

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -89,7 +89,6 @@ import com.ichi2.anki.utils.ext.onAllFragmentsLoaded
 import com.ichi2.ui.CardBrowserSearchView
 import com.ichi2.utils.AndroidUiUtils.hideKeyboard
 import com.ichi2.utils.LanguageUtil
-import net.ankiweb.rsdroid.RustCleanup
 import timber.log.Timber
 
 @Suppress("LeakingThis")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -108,7 +108,6 @@ import com.ichi2.anki.utils.ext.dismissAllDialogFragments
 import com.ichi2.anki.utils.ext.doOnTabSelected
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.utils.postDelayed
-import com.ichi2.themes.Themes
 import com.ichi2.utils.copyToClipboard
 import com.ichi2.utils.dp
 import com.ichi2.utils.listItems

--- a/AnkiDroid/src/main/java/com/ichi2/anki/account/LoginViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/account/LoginViewModel.kt
@@ -28,7 +28,6 @@ import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.settings.Prefs
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import net.ankiweb.rsdroid.exceptions.BackendSyncException
 import timber.log.Timber

--- a/AnkiDroid/src/main/java/com/ichi2/anki/android/AnkiShakeDetector.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/android/AnkiShakeDetector.kt
@@ -18,7 +18,6 @@ package com.ichi2.anki.android
 import android.content.Context
 import android.hardware.SensorManager
 import android.os.SystemClock
-import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import com.squareup.seismic.ShakeDetector
 import timber.log.Timber

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
@@ -32,7 +32,6 @@ import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsConstants
 import com.ichi2.anki.analytics.UsageAnalytics
-import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.requireAnkiActivity
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.utils.MimeTypeUtils

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileManager.kt
@@ -18,7 +18,6 @@
 package com.ichi2.anki.multiprofile
 
 import android.content.Context
-import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Build
 import android.webkit.CookieManager

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
@@ -66,7 +66,6 @@ import com.ichi2.utils.AndroidUiUtils
 import com.ichi2.utils.create
 import com.ichi2.utils.dp
 import com.ichi2.utils.negativeButton
-import com.ichi2.utils.neutralButton
 import com.ichi2.utils.positiveButton
 import com.ichi2.utils.title
 import com.ichi2.utils.titleWithHelpIcon

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -28,7 +28,6 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.R
-import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.databinding.ItemDeckBinding
 import com.ichi2.anki.deckpicker.DisplayDeckNode
 import com.ichi2.anki.libanki.DeckId

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CardSideSelectionDialogScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CardSideSelectionDialogScreenshotTest.kt
@@ -3,10 +3,8 @@
 package com.ichi2.anki.dialogs
 
 import androidx.fragment.app.FragmentActivity
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.ScreenshotTest
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.robolectric.Robolectric.buildActivity
 
 class CardSideSelectionDialogScreenshotTest : ScreenshotTest() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/ImportFileSelectionFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/ImportFileSelectionFragmentTest.kt
@@ -25,7 +25,6 @@ import com.ichi2.anki.dialogs.ImportFileSelectionFragment.ImportOptions
 import com.ichi2.anki.utils.MimeTypeUtils
 import com.ichi2.testutils.launchFragment
 import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.CoreMatchers.notNullValue
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/AnkiDroid/src/test/java/com/ichi2/anki/libanki/DeckNodeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/libanki/DeckNodeTest.kt
@@ -21,7 +21,6 @@ import anki.decks.deckTreeNode
 import com.ichi2.anki.deckpicker.DeckFilters
 import com.ichi2.anki.deckpicker.filterAndFlattenDisplay
 import com.ichi2.anki.libanki.sched.DeckNode
-import org.apache.commons.collections4.map.ListOrderedMap
 import org.junit.Assert.assertEquals
 import org.junit.Test
 


### PR DESCRIPTION
* Issue #21208

Detekt 2.0.0 is unstable so can't be used yet

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)