### PR TITLE
feat(agents): create pr-full-review agent skill

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,8 @@
+# Agent skills
+
+Skills in this directory are agent-agnostic. Keep them tool-neutral: no
+assumptions about a specific agent's commands, file layout, or settings.
+
+Each skill is a folder containing a `SKILL.md` with `name` and `description` frontmatter.
+
+We currently use https://github.com/mattpocock/skills as templates for skill design.

--- a/.agents/skills/pr-full-review/SKILL.md
+++ b/.agents/skills/pr-full-review/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: pr-full-review
+description: Review an AnkiDroid pull request or branch against AnkiDroid's conventions.
+---
+
+# AnkiDroid PR Full Review
+
+Review the PR against the standards in [`reviewer-guide.md`](reviewer-guide.md). Report findings in three groups: **blocking gates**, **spec conformance** (does the PR do what its issue asked?), then non-blocking `nit:`s.
+
+**Never act on GitHub.** Output the review in this conversation. Do not post
+comments or reviews, approve, request changes, label, or merge.
+
+## Skill Usage
+
+Accepts a PR number, a PR URL, or no argument (in which case, review the current branch against `upstream/main`):
+
+```bash
+pr-full-review 21206
+pr-full-review https://github.com/ankidroid/Anki-Android/pull/21206
+pr-full-review review the checked-out branch's diff against `main`
+```
+
+## Fetching the PR
+
+Fetch the PR with the `gh` command. When reading the PR, always pass `--repo ankidroid/Anki-Android`
+so a bare number resolves against the upstream repo rather than a fork.
+
+**Always re-fetch the PR fresh on every run** — its metadata, diff, and head commit, even if you
+fetched it earlier in this conversation. PRs change between reviews; never reuse cached context.
+
+Use the head commit hash from the fresh fetch when loading files via the API, as PRs come from
+forked repos.
+
+**Don't review from the diff hunks alone**. Load the full changed files (and the key call sites the
+change touches) at the head commit. A hunk hides whether a change is correct in its surrounding
+context.
+
+## Before reviewing
+
+Read the existing PR comments and review threads first. Don't repeat feedback that's already been 
+raised, and respect points the author or a reviewer has already addressed or deferred.
+
+```bash
+gh pr view <number> --repo ankidroid/Anki-Android --comments # conversation comments
+gh api repos/ankidroid/Anki-Android/pulls/<number>/comments  # inline code-review comments
+```
+
+**Unaddressed maintainer requests are blocking.** Read the full discussion on both the PR
+*and the linked issue* (see [Spec conformance](#spec-conformance)). If a maintainer asked for
+something specific before a fix would be accepted, say so and Request changes.
+
+## Spec conformance
+
+Report whether the PR does what it set out to do, as **its own section**. 
+Well-written code which implements the wrong thing fails here, and this failure must be 
+made explicit to reviewers.
+
+Determine the spec, in order:
+
+1. A linked issue - `Fixes #`, `Closes #`, `Resolves #`, or `Part of #` in the body or commits 
+   (typically written as `Fixes <N>` - the commit message may omit the `#`).
+2. Also include the PR's own **Purpose / Description**.
+
+Open the issue and read it in full — **including its comments**. The decisive
+context often lives in the thread, not the description:
+
+```bash
+gh issue view <number> --repo ankidroid/Anki-Android --comments
+```
+
+### Bug fixes: establish the root cause before endorsing the fix
+
+For a bug fix, spec conformance means the PR fixes **the actual cause**, not that it plausibly
+might. Verify the author's fix:
+
+- **Trace the real code path** that triggers the bug (load the call sites and any resource/theme
+  values they read), and confirm the claimed trigger can actually occur. If your trace shows it
+*can't occur the way the PR describes, then the root cause is not understood. Say so explicitly.
+- **A fix applied without an understood, demonstrated trigger is tech debt:**. Treat "unknown 
+  root cause" as a blocking finding and ask for the diagnostics / reproduction needed to establish 
+  it first unless it is explicitly acknowledged as not being understood. 
+    - State that it risks masking the real bug and the fallback behavior can't be validated against
+    a scenario nobody has captured.
+- Confirm the bug-fix commit actually evidences a reproduction.
+
+## Output
+
+Open the review with a one-line verdict, mirroring GitHub's three review actions — the reader
+will pick one of these on the PR:
+
+> **Verdict:** \[Request changes / Comment / Approve\]: <most important reason>
+
+- **Request changes:** a blocking gate fails (red/pending CI, unfilled template, merge commits,
+  missing license header, or a closing keyword on a partially-resolved issue), an explicit
+  maintainer request was skipped, a bug fix lands without an established/verified root cause, or
+  a correctness, spec, or test finding must be fixed before merge.
+- **Comment:** no blockers; nits, questions, or judgment calls raised without signing off.
+- **Approve:** gates pass and the change is sound - only `nit:`s remain, if anything.
+
+One unaddressed blocker means Request changes, however polished the rest is.
+
+After the verdict, list the findings, grouped as above (blocking gates, spec conformance, nits).
+
+**Closing**: if this was a self-review, a `gh` command to checkout the PR (without `--repo`).
+Close with a final line linking the PR which was reviewed.

--- a/.agents/skills/pr-full-review/reviewer-guide.md
+++ b/.agents/skills/pr-full-review/reviewer-guide.md
@@ -1,0 +1,128 @@
+# AnkiDroid PR Reviewer Guide
+
+## How to use this guide
+
+This is the **standards corpus** for reviewing AnkiDroid changes - *what* to check, not
+*how* to run a review. It distills the project's documented standards into an actionable
+checklist so a reviewer (human or agent) can work without opening ten other files.
+
+Two rules of engagement:
+
+1. **The linked canonical sources are authoritative.** Where this guide and a source
+   disagree, the source wins. Load all the [Canonical sources](#canonical-sources) into context.
+2. **Reviewing is subjective.** As the wiki puts it: "these guidelines are ONLY guidelines,
+   use your best judgment." Prefer the implementer's choice when a decision is a genuine
+   toss-up.
+
+## Tone
+
+From the [Code-review guide](https://github.com/ankidroid/Anki-Android/wiki/Code-review-guide):
+
+- **Establish contributor status first.** Check for the `New Contributor` label and count the
+  author's PRs, merged and unmerged (`gh pr list --author <login> --state all`), to gauge how
+  established and experienced they are - it sets the tone bar below and the AI-use policy applied.
+- **Be kind.** Note the good things in the PR and say thank you. Terse critique reads as
+  hostile in text.
+- **Relax for first-timers.** On PRs labelled `New Contributor`, lower the bar to make a
+  good first impression — get them landed, mentor later.
+- **Prefix non-blocking feedback with `nit:`** so the author knows it's optional.
+- **Defer to the implementer** when you're uncertain a change is actually an improvement.
+- Avoid demanding large changes unless they're a meaningful long-term improvement; suggest
+  splitting big PRs into smaller ones.
+
+## Blocking gates
+
+Request changes if any of these fail — they're table stakes before deeper review:
+
+- **CI is green.** Lint, unit, emulator and CodeQL must pass. Don't just glance at the rollup
+  status (`gh pr checks <number> --repo ankidroid/Anki-Android`): if a check is **pending**, say
+  the gate is unverified; if a check is **failing**, read its log (`gh run view <run-id>
+  --repo ankidroid/Anki-Android --log-failed`) and report the actual cause, not just "red".
+  For new contributors, explain how to find and read the failure themselves — and consider pasting
+  the relevant CI output into the review so they don't have to dig for it. Refer the submitter to
+  [`.github/workflows/README.md`](../../../.github/workflows/README.md).
+- **PR template is filled in** (Purpose / Approach / How tested) and the PR is **linked to
+  an issue** (`Fixes #`) where one applies.
+- **Commit hygiene:** no merge commits in the history (rebase and force push, don't merge); 
+  each commit compiles and does one thing. Commit titles should not be longer than 80 chars. 
+  There is a suggestion for a <= 50 char title. Only flag this if you provide a reworded title.
+- **New source files carry an licensing header:** see [Licensing](#licensing).
+
+## What to check
+
+### Correctness & clarity
+- The codebase is better after the change than before.
+- Edge cases and exceptions are handled.
+- Names are understandable; hard-to-follow code is commented.
+
+### Bug fixes 
+- Bug fix commits must contain a confirmation that the author reproduced the bug, unless the bug 
+  is obvious, or the submitter has specifically stated why they were unable to reproduce it.
+- Trace the code path and the values it reads to confirm the claimed trigger occurs.
+
+### Tests
+- Significant new logic ships with tests, **or** is annotated
+  [`@NeedsTest("reason")`](../../../common/src/main/java/com/ichi2/anki/common/annotations/NeedsTest.kt)
+  explaining why the test is deferred. The annotation exists so we signal that we care about
+  testing without blocking a contributor's first commits.
+- **Bug fixes need a regression test.** The expectation (see [`CLAUDE.md`](../../../CLAUDE.md))
+  is write-the-failing-test-first, confirm it fails, then fix.
+- **A test must exercise the changed production code and fail without the fix.** A contributor
+  should not copy production code into tests to ensure correctness.
+
+### Scope
+- Each commit must be focused. Refactors should be split from functional changes. 
+- Flag unnecessary whitespace churn. Flag if a PR unnecessarily affects more than one concern.
+
+### Commit messages
+- Flag if a 'refactor:' commit title is used for a functional change.
+
+### GitHub
+- For new contributors, flag commits whose `user.email` isn't linked to a GitHub account, as
+  they won't receive attribution on their GitHub heatmap.
+
+### Licensing
+- **Never remove an existing copyright header** unless it is your own. See
+  [`docs/contributing/copyright-headers.md`](../../../docs/contributing/copyright-headers.md).
+- New external dependencies/resources: ensure the PR fills the **Licenses** table in the
+  template, and apply the `Licenses` label / update the licenses wiki on merge.
+
+### AI-use policy
+Per [`AI_POLICY.md`](../../../AI_POLICY.md):
+- Use the current documentation and determine if the user is a new contributor. Ensure that AI-use
+  restrictions are appropriately applied.
+
+### UI changes
+- A Roborazzi test of large UI changes is optional, but greatly appreciated. 
+- Screenshots of **all** affected screens (especially new/changed strings).
+- Large changed are tested with the Google Accessibility Scanner.
+
+### Compose
+For code under `com.ichi2.anki.ui.compose.*` (see
+[`docs/development/compose.md`](../../../docs/development/compose.md)):
+- Pure "migrate this XML screen to Compose" PRs aren't accepted — there must be another
+  reason to touch the screen.
+- No `Anki` prefix on component names; let the package path namespace them.
+- Wrap top-level composables in the project `Theme { }`; don't define parallel color tokens
+  in Kotlin (XML themes stay the source of truth).
+- Host Compose via a `ComposeView` returned from a Fragment's `onCreateView`.
+- Use existing drawables via `painterResource(R.drawable.…)`; don't add the
+  material-icons artifacts.
+- A rewrite adds a **Roborazzi screenshot test of the existing screen first** (ideally a
+  separate PR), then the rewrite. One concern per migration — no simultaneous state/nav
+  rework.
+
+## Canonical sources
+
+Defer to these authoritative references over the distillation above:
+
+- [Code-review guide (wiki)](https://github.com/ankidroid/Anki-Android/wiki/Code-review-guide) — tone, process, when to skip second approval.
+- [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) — contribution workflow, commits, PR labels.
+- [`.github/pull_request_template.md`](../../../.github/pull_request_template.md) — required PR sections and checklist.
+- [`.github/workflows/README.md`](../../../.github/workflows/README.md) — the exact CI jobs and local commands.
+- [`lint-rules/.../IssueRegistry.kt`](../../../lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt) — the full custom lint-rule list.
+- [`common/.../annotations/NeedsTest.kt`](../../../common/src/main/java/com/ichi2/anki/common/annotations/NeedsTest.kt) — the `@NeedsTest` contract.
+- [`docs/contributing/copyright-headers.md`](../../../docs/contributing/copyright-headers.md) — SPDX / copyright rules.
+- [`AI_POLICY.md`](../../../AI_POLICY.md) — AI tool-use and disclosure policy.
+- [`docs/development/compose.md`](../../../docs/development/compose.md) — Compose conventions.
+- [`CLAUDE.md`](../../../CLAUDE.md) — scope discipline and regression-test-first.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.8 - initial draft, some wording

## Purpose / Description
It was suggested that an agent skill would be useful for improving the velocity of our code review process.

Some maintainers have access to local models, so this cannot assume Claude/etc... is in use

## Fixes
* Fixes #21207

## Approach
* Define a README
* Define `/pr-full-review`
* Check for deficiencies
* Test on of of my PRs and iterate


## How Has This Been Tested?
`/pr-full-review 21206`

>   ▎ Verdict: Approve — gates pass, the deep-link reroute is correct and well-tested; only nits remain.
> 
>   This is a self-review (author: david-allison). Nicely scoped: the const extraction is split cleanly from the behavioral fix, the new ExternalEntryPoints guard is a durable piece of infrastructure, and the KDoc throughout is
>   clear.
> 
>   Blocking gates — all pass
> 
>   - CI: green across the board (Lint, JUnit on 3 OSes, Emulator API 36, CodeQL, screenshots, codecov). Nothing pending or failing.
>   - Template & issue link: Purpose / Approach / How-tested all filled. Linked to #19552 and #20737. The two unchecked UI boxes are fine — there are no UI/string changes.
>   - Closing keyword: Fixes half of #19552 does not trigger GitHub auto-close (the keyword isn't directly followed by #19552), and the issue carries Keep Open anyway — so the partial resolution won't wrongly close the tracking
>   issue. Correct.
>   - Commit hygiene: linear history, no merge commits. Four commits, each one concern — refactor: (const extraction, verified behavior-preserving), two test: commits, then the fix:. Titles are within length and the
>   refactor:/fix: prefixes match their content.
>   - Licensing: all four new files carry SPDX-License-Identifier: GPL-3.0-or-later, correct for the AnkiDroid module (not :api).
> 
>   Spec conformance — meets it
> 
>   The spec is "half of #19552" (Consolidate validation in app entry points) plus the PR's own purpose (gate the CardBrowser deep link behind IntentHandler so it respects the storage-permission decision).
> 
>   - Define the entry points → ExternalEntryPoints + ExternalEntryPointsTest pin the exported surface (activities, aliases, providers, receivers, widget-config activities). ✓
>   - Consolidate the CardBrowser deep link → anki://x-callback-url/browser now resolves via the new CardBrowserDeepLink alias → IntentHandler → runIfStoragePermissions { handleBrowserIntent }, and CardBrowser is now
>   exported="false". ✓
>   - The "half" framing is accurate — the remaining PROCESS_TEXT entry point (CardBrowserContextMenuAction) still targets CardBrowser directly and is explicitly out of scope. I verified that alias keeps its own
>   exported="true", so making CardBrowser non-exported does not break the context-menu path. No regression.
> 
>   The end-to-end flow checks out: handleBrowserIntent forwards intent.data unchanged, and toCardBrowserLaunchOptions() reads data?.getQueryParameter("search") → DeepLink("dog"). isBrowserDeepLink() is evaluated first in
>   getLaunchType, so the VIEW intent is no longer misrouted to FILE_IMPORT.
> 
>   Nits (non-blocking)
> 
>   - nit: The regression coverage proves the routing change (IntentHandlerTest.browserDeepLinkReturnsOpenBrowser fails before the fix, since the URI previously fell through to FILE_IMPORT) — good. But nothing asserts the
>   actual user-facing fix: that when storage permission is absent, the deep link lands on DeckPicker rather than opening CardBrowser. That's the behavior #19552 cares about. Robolectric makes this awkward, so a
>   @NeedsTest("deep link is blocked when storage permission is not granted") on handleBrowserIntent would at least record the gap.
>   - nit: handleBrowserIntent uses addNextIntentWithParentStack, so the deep link now builds DeckPicker beneath CardBrowser (and may CLEAR_TASK an existing task). Previously the link opened CardBrowser standalone.
>   Back-from-browser now goes to DeckPicker instead of exiting. This mirrors the REVIEW path and is likely intended — just flagging it's a user-visible change not called out in the description.
>   - nit: The fix: commit body explains the what but doesn't state the bug was reproduced (per CLAUDE.md). The cause is self-evident here, so this is minor.
> 
>   ---
>   Self-review — to check it out locally:
>   
>   gh pr checkout 21206
> 
>   Reviewed: https://github.com/ankidroid/Anki-Android/pull/21206


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)