### PR TITLE
fix(ci): remove 'Has Conflicts' when fixed

### DIFF
--- a/.github/workflows/conflict.yaml
+++ b/.github/workflows/conflict.yaml
@@ -120,13 +120,17 @@ jobs:
                                 await wait(1000);
                                 iterations++;
 
-                                // Check for terminal conditions
-                                if (pullRequestData.data.mergeable_state !== 'unknown' || iterations >= maxIterations) {
+                                // 'mergeable' is null while GitHub computes mergeability
+                                if (pullRequestData.data.mergeable !== null || iterations >= maxIterations) {
                                   break;
                                 }
-                            } while (pullRequestData.data.mergeable_state === 'unknown');
+                            } while (pullRequestData.data.mergeable === null);
 
-                            if (pullRequestData.data.mergeable_state === 'dirty') {
+                            // 'mergeable' is a nullable boolean; true = no conflicts,
+                            // https://docs.github.com/en/rest/pulls/pulls?apiVersion=2026-03-10#get-a-pull-request
+                            const mergeable = pullRequestData.data.mergeable;
+
+                            if (mergeable === false) {
                                 console.log(`Conflict exists in PR #${prNumber}`);
                                 if (pullRequestData.data.labels.find(label => label.name === 'Has Conflicts')) {
                                     console.log(`'Has Conflicts' label already exists on PR #${prNumber}`);
@@ -139,32 +143,23 @@ jobs:
                                         console.warn(`PR #${prNumber} is stale, skipping label addition to prevent timer reset`);
                                     }
                                 }
-                            } else if (pullRequestData.data.mergeable_state === 'clean') {
+                            } else if (mergeable === true) {
                                 // if PR has no conflicts, remove the label
                                 if (pullRequestData.data.labels.find(label => label.name === 'Has Conflicts')) {
                                     console.log(`Removing 'Has Conflicts' label from PR #${prNumber}`);
-                                    await removeLabel(['Has Conflicts'], prNumber);
-                                }
-                            } else if (pullRequestData.data.mergeable_state === 'unstable') {
-                                console.log(`PR #${prNumber} is unstable`);
-                                const mergeable = pullRequestData.data.mergeable;
-                                if (mergeable) {
-                                    console.log(`PR #${prNumber} is mergeable`);
-                                    // if PR has no conflicts, remove the label
-                                    if (pullRequestData.data.labels.find(label => label.name === 'Has Conflicts')) {
-                                        console.log(`Removing 'Has Conflicts' label from PR #${prNumber}`);
-                                        try {
-                                            await removeLabel(['Has Conflicts'], prNumber);
-                                        } catch(err) {
-                                            if (err.status === 404) {
-                                                console.warn("(Has Conflicts) label no longer found when trying to remove it");
-                                            } else {
-                                                console.log("Unexpected error while removing (Has Conflicts) label: " + err);
-                                                throw err;
-                                            }
+                                    try {
+                                        await removeLabel(['Has Conflicts'], prNumber);
+                                    } catch(err) {
+                                        if (err.status === 404) {
+                                            console.warn("(Has Conflicts) label no longer found when trying to remove it");
+                                        } else {
+                                            console.log("Unexpected error while removing (Has Conflicts) label: " + err);
+                                            throw err;
                                         }
                                     }
                                 }
+                            } else {
+                                console.warn(`PR #${prNumber} mergeability is unknown; skipping`);
                             }
                         } catch (err) {
                             console.error(`Error while processing PR #${prNumber}`);


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.8 - diagnostics; code; docs were mine


## Purpose / Description
Previously if `"mergeStateStatus": "BLOCKED"`, then the label on the PR was not updated, as `BLOCKED` was unhandled.

## Fixes
* Fixes #21216 

## Approach

The fix is to use the raw `mergeable`: a nullable boolean:

> The value of the mergeable attribute can be true, false, or null.
> If the value is null, then GitHub has started a background job to
> compute the mergeability

https://docs.github.com/en/rest/pulls/pulls?apiVersion=2026-03-10#get-a-pull-request


## How Has This Been Tested?

> [!NOTE]
> Generated by Claude Opus 4.8

```bash
# Field types on the reported PR
gh api repos/ankidroid/Anki-Android/pulls/20992 \
  --jq '{mergeable, mergeable_state}'

# Full-population correlation (single request)
gh api graphql -f query='
query {
  repository(owner:"ankidroid", name:"Anki-Android") {
    pullRequests(states:OPEN, first:100) {
      nodes { number mergeable mergeStateStatus isDraft }
    }
  }
}' --jq '.data.repository.pullRequests.nodes[] | [.mergeable, .mergeStateStatus] | @tsv' \
  | sort | uniq -c | sort -rn
```

| `mergeable` | state | count | old code | new code |
|---|---|---|---|---|
| MERGEABLE | **BLOCKED** | **40** | **does nothing → label stuck** 🐛 | removes label ✅ |
| CONFLICTING | DIRTY | 37 | adds label | adds label ✅ |
| MERGEABLE | CLEAN | 15 | removes label | removes label ✅ |
| MERGEABLE | UNSTABLE | 2 | removes label | removes label ✅ |



## Learning (optional, can help others)
GraphQL: 
* https://docs.github.com/en/graphql/reference/pulls#enum-mergeablestate `"CONFLICTING" | "MERGEABLE" | "UNKNOWN"`
* https://docs.github.com/en/graphql/reference/pulls#enum-mergeablestate


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)