### PR TITLE
perf: reduce webView startup time

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -21,6 +21,11 @@ import androidx.core.net.toUri
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewOutcomeReceiver
+import androidx.webkit.WebViewStartUpConfig
+import androidx.webkit.WebViewStartUpResult
+import androidx.webkit.WebViewStartupException
 import anki.collection.OpChanges
 import com.ichi2.anki.AnkiDroidApp.Companion.sharedPreferencesTestingOverride
 import com.ichi2.anki.analytics.UsageAnalytics
@@ -62,6 +67,7 @@ import com.ichi2.anki.startup.getDefaultAnkiDroidDirectory
 import com.ichi2.anki.ui.dialogs.ActivityAgnosticDialogs
 import com.ichi2.utils.ExceptionUtil
 import com.ichi2.utils.LanguageUtil
+import com.ichi2.utils.coMeasureTime
 import com.ichi2.utils.measureTime
 import com.ichi2.utils.setWebContentsDebuggingEnabled
 import com.ichi2.widget.DayRolloverAlarm
@@ -69,9 +75,12 @@ import com.ichi2.widget.cardanalysis.CardAnalysisWidget
 import com.ichi2.widget.deckpicker.DeckPickerWidget
 import com.ichi2.widget.restoreRecurringAlarms
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import timber.log.Timber
 import timber.log.Timber.DebugTree
 import java.util.Locale
+import java.util.concurrent.Executors
+import kotlin.coroutines.resume
 
 /**
  * Application class.
@@ -195,6 +204,7 @@ open class AnkiDroidApp :
         setupLifecycleLogging()
         activityAgnosticDialogs = ActivityAgnosticDialogs.register(this)
         setupTextToSpeech()
+        setupWebView()
     }
 
     /**
@@ -465,6 +475,45 @@ open class AnkiDroidApp :
             sendExceptionReport(e, "checkWebViewAvailable")
             Timber.e(e, "checkWebViewAvailable")
             false
+        }
+
+    /**
+     * Start up the WebView to speed up later WebView usages.
+     */
+    private fun setupWebView() {
+        applicationScope.launch {
+            coMeasureTime("setupWebView") {
+                startUpWebView()
+            }
+        }
+    }
+
+    private suspend fun startUpWebView() =
+        suspendCancellableCoroutine { continuation ->
+            val executor = Executors.newSingleThreadExecutor()
+            val config = WebViewStartUpConfig.Builder(executor).build()
+
+            val callback =
+                object : WebViewOutcomeReceiver<WebViewStartUpResult, WebViewStartupException> {
+                    override fun onResult(result: WebViewStartUpResult?) {
+                        executor.shutdown()
+                        continuation.resume(Unit)
+                    }
+
+                    override fun onError(e: WebViewStartupException) {
+                        fatalInitializationError = FatalInitializationError.WebViewError(e)
+                        sendExceptionReport(e, "setupWebView")
+                        Timber.e(e, "setupWebView")
+                        executor.shutdown()
+                        continuation.resume(Unit)
+                    }
+                }
+
+            WebViewCompat.startUpWebView(
+                this@AnkiDroidApp,
+                config,
+                callback,
+            )
         }
 
     /**


### PR DESCRIPTION
This introduces WebView startup helper to help starting up WebView, which will be used for all WebView init to produce performace improvement on WebView usages. 

## Purpose / Description
Introduces WebView startup helper by integrating `androidx:startUpWebView` and setup WebView when app launch
The startup helper will warm up the WebView framework to speed up other later WebView usages

## Fixes
* Fixes #20973

## Approach
I setup WebView when app launchs with WebView startup helper which integrates new API - `androidx:startUpWebView`. Make other WebView setup like `setWebContentsDebuggingEnabled` wait until this setup is complete.

## How Has This Been Tested?
App launch normally and WebView functionality works

## Learning (optional, can help others)
* https://developer.android.com/reference/androidx/webkit/WebViewCompat#startUpWebView(android.content.Context,androidx.webkit.WebViewStartUpConfig,androidx.webkit.WebViewOutcomeReceiver%3Candroidx.webkit.WebViewStartUpResult,androidx.webkit.WebViewStartupException%3E)
* https://developer.android.com/reference/androidx/webkit/WebViewStartUpConfig

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code   
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
