### PR TITLE
docs: map FSRS library versions to displayString

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/Fsrs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/Fsrs.kt
@@ -43,7 +43,7 @@ value class FsrsVersion(
         when (libraryVersion) {
             "0.6.4" -> "FSRS 4.5"
             "1.4.3", "2.0.3" -> "FSRS 5"
-            "4.1.1", "5.1.0" -> "FSRS 6"
+            "4.1.1", "5.1.0", "5.2.0", "6.3.0" -> "FSRS 6"
             else -> null
         }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/Fsrs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/Fsrs.kt
@@ -29,7 +29,7 @@ value class FsrsVersion(
         when (libraryVersion) {
             "0.6.4" -> "FSRS 4.5"
             "1.4.3", "2.0.3" -> "FSRS 5"
-            "4.1.1", "5.1.0", "5.2.0" -> "FSRS 6"
+            "4.1.1", "5.1.0", "5.2.0", "6.3.0", "6.6.2" -> "FSRS 6"
             else -> null
         }
 }


### PR DESCRIPTION
https://forums.ankiweb.net/t/anki-26-05-beta-1/69707/9?u=david FSRS "5.2.0" is still FSRS 6

https://github.com/ankitects/anki/pull/4956#issuecomment-4621331276 FSRS "6.3.0" is still FSRS 6

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)