### PR TITLE
refactor: remove deprecated 'bundleOf' from tests

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorIntentTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorIntentTest.kt
@@ -16,7 +16,7 @@
 package com.ichi2.anki
 
 import android.content.Intent
-import androidx.core.os.bundleOf
+import android.os.Bundle
 import androidx.lifecycle.Lifecycle
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -74,7 +74,7 @@ class NoteEditorIntentTest : InstrumentedTest() {
 
     private val noteEditorTextIntent: Intent
         get() {
-            val bundle = bundleOf(Intent.EXTRA_TEXT to "sample text")
+            val bundle = Bundle().apply { putString(Intent.EXTRA_TEXT, "sample text") }
             return NoteEditorLauncher.PassArguments(bundle).toIntent(testContext, Intent.ACTION_SEND)
         }
 }

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/dialogs/NoteTypeFieldEditorContextMenuTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/dialogs/NoteTypeFieldEditorContextMenuTest.kt
@@ -15,7 +15,7 @@
  */
 package com.ichi2.anki.dialogs
 
-import androidx.core.os.bundleOf
+import android.os.Bundle
 import androidx.fragment.app.testing.launchFragment
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -39,7 +39,7 @@ class NoteTypeFieldEditorContextMenuTest : InstrumentedTest() {
     @Ignore("flaky")
     fun showsAllOptions() {
         launchFragment(
-            fragmentArgs = bundleOf(NoteTypeFieldEditorContextMenu.KEY_LABEL to testDialogTitle),
+            fragmentArgs = Bundle().apply { putString(NoteTypeFieldEditorContextMenu.KEY_LABEL, testDialogTitle) },
             themeResId = R.style.Theme_Light,
         ) { NoteTypeFieldEditorContextMenu() }
         onView(withText(testDialogTitle))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -4,11 +4,11 @@ package com.ichi2.anki
 
 import android.content.Intent
 import android.os.Build
+import android.os.Bundle
 import android.os.Parcelable
 import android.webkit.RenderProcessGoneDetail
 import androidx.annotation.CheckResult
 import androidx.core.os.BundleCompat
-import androidx.core.os.bundleOf
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SdkSuppress
 import anki.config.ConfigKey
@@ -214,11 +214,11 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
 
             val animation = gesture.toAnimationTransition().invert()
             val bundle =
-                bundleOf(
-                    NoteEditorFragment.EXTRA_CALLER to NoteEditorCaller.EDIT.value,
-                    NoteEditorFragment.EXTRA_CARD_ID to viewer.currentCard!!.id,
-                    FINISH_ANIMATION_EXTRA to animation as Parcelable,
-                )
+                Bundle().apply {
+                    putInt(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.EDIT.value)
+                    putLong(NoteEditorFragment.EXTRA_CARD_ID, viewer.currentCard!!.id)
+                    putParcelable(FINISH_ANIMATION_EXTRA, animation as Parcelable)
+                }
             val noteEditor = openNoteEditorWithArgs(bundle)
             val actualInverseAnimation =
                 BundleCompat.getParcelable(

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -26,7 +26,6 @@ import android.widget.SpinnerAdapter
 import android.widget.TextView
 import androidx.core.app.ActivityCompat
 import androidx.core.content.edit
-import androidx.core.os.bundleOf
 import androidx.core.view.children
 import androidx.core.view.get
 import androidx.core.view.size
@@ -708,10 +707,10 @@ class CardBrowserTest : RobolectricTest() {
             // simulate the user using the ForgetCardsDialog to start the cards reset process
             b.supportFragmentManager.setFragmentResult(
                 ForgetCardsDialog.REQUEST_KEY_FORGET,
-                bundleOf(
-                    ForgetCardsDialog.ARG_RESTORE_ORIGINAL to true,
-                    ForgetCardsDialog.ARG_RESET_REPETITION to false,
-                ),
+                Bundle().apply {
+                    putBoolean(ForgetCardsDialog.ARG_RESTORE_ORIGINAL, true)
+                    putBoolean(ForgetCardsDialog.ARG_RESET_REPETITION, false)
+                },
             )
 
             assertThat(
@@ -1930,15 +1929,15 @@ class CardBrowserTest : RobolectricTest() {
     ) {
         supportFragmentManager.setFragmentResult(
             REQUEST_FIND_AND_REPLACE,
-            bundleOf(
-                ARG_SEARCH to search,
-                ARG_REPLACEMENT to replacement,
-                ARG_FIELD to field,
-                ARG_ONLY_SELECTED_NOTES to onlyInSelectedNotes,
+            Bundle().apply {
+                putString(ARG_SEARCH, search)
+                putString(ARG_REPLACEMENT, replacement)
+                putString(ARG_FIELD, field)
+                putBoolean(ARG_ONLY_SELECTED_NOTES, onlyInSelectedNotes)
                 // "Ignore case" checkbox text => when it's checked we pass false to the backend
-                ARG_MATCH_CASE to matchCase,
-                ARG_REGEX to regex,
-            ),
+                putBoolean(ARG_MATCH_CASE, matchCase)
+                putBoolean(ARG_REGEX, regex)
+            },
         )
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/IntroductionActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/IntroductionActivityTest.kt
@@ -18,7 +18,7 @@ package com.ichi2.anki
 
 import android.Manifest.permission.INTERNET
 import android.content.Intent
-import androidx.core.os.bundleOf
+import android.os.Bundle
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.SingleFragmentActivity.Companion.FRAGMENT_NAME_EXTRA
 import com.ichi2.anki.account.LoginFragment
@@ -85,7 +85,7 @@ class IntroductionActivityTest : RobolectricTest() {
 
             activity.supportFragmentManager.setFragmentResult(
                 SetupCollectionFragment.FRAGMENT_KEY,
-                bundleOf(SetupCollectionFragment.RESULT_KEY to DeckPickerWithNewCollection),
+                Bundle().apply { putParcelable(SetupCollectionFragment.RESULT_KEY, DeckPickerWithNewCollection) },
             )
 
             val intent = assertNotNull(shadowOf(activity).nextStartedActivity)
@@ -108,7 +108,7 @@ class IntroductionActivityTest : RobolectricTest() {
     private fun IntroductionActivity.clickSync() {
         supportFragmentManager.setFragmentResult(
             SetupCollectionFragment.FRAGMENT_KEY,
-            bundleOf(SetupCollectionFragment.RESULT_KEY to SyncFromExistingAccount),
+            Bundle().apply { putParcelable(SetupCollectionFragment.RESULT_KEY, SyncFromExistingAccount) },
         )
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/FindAndReplaceDialogFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/FindAndReplaceDialogFragmentTest.kt
@@ -17,9 +17,9 @@
 package com.ichi2.anki.browser
 
 import android.content.Context
+import android.os.Bundle
 import android.widget.Spinner
 import android.widget.SpinnerAdapter
-import androidx.core.os.bundleOf
 import androidx.fragment.app.testing.FragmentScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -92,7 +92,7 @@ class FindAndReplaceDialogFragmentTest : RobolectricTest() {
             FragmentScenario
                 .launch(
                     fragmentClass = FindAndReplaceDialogFragment::class.java,
-                    fragmentArgs = bundleOf(FindAndReplaceDialogFragment.ARG_IDS to file),
+                    fragmentArgs = Bundle().apply { putParcelable(FindAndReplaceDialogFragment.ARG_IDS, file) },
                     themeResId = R.style.Theme_Light,
                 ).use { scenario ->
                     scenario.onFragment { fragment ->
@@ -132,7 +132,7 @@ class FindAndReplaceDialogFragmentTest : RobolectricTest() {
         FragmentScenario
             .launch(
                 fragmentClass = FindAndReplaceDialogFragment::class.java,
-                fragmentArgs = bundleOf(FindAndReplaceDialogFragment.ARG_IDS to file),
+                fragmentArgs = Bundle().apply { putParcelable(FindAndReplaceDialogFragment.ARG_IDS, file) },
                 themeResId = R.style.Theme_Light,
             ).use { scenario -> scenario.onFragment { fragment -> fragment.action() } }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
@@ -18,7 +18,6 @@ package com.ichi2.anki.dialogs
 import android.os.Bundle
 import android.widget.ListView
 import androidx.appcompat.app.AlertDialog
-import androidx.core.os.bundleOf
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -230,7 +229,7 @@ class CustomStudyDialogTest : RobolectricTest() {
                 // simulate tag selection
                 studyDialog.parentFragmentManager.setFragmentResult(
                     ON_SELECTED_TAGS_KEY,
-                    bundleOf(ON_SELECTED_TAGS__SELECTED_TAGS to selectedTags),
+                    Bundle().apply { putStringArrayList(ON_SELECTED_TAGS__SELECTED_TAGS, selectedTags) },
                 )
                 val customStudyDeck = col.decks.customStudySession
                 assertNotNull(customStudyDeck)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DatabaseErrorDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DatabaseErrorDialogTest.kt
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith
 class DatabaseErrorDialogTest {
     @Test
     fun `ShowDatabaseErrorDialog serialization`() {
-        // concerns with 'bundleOf' + '@Parcelize'
+        // concerns with 'Bundle()' + '@Parcelize'
         val error = ShowDatabaseErrorDialog(DatabaseErrorDialogType.DIALOG_DB_ERROR)
         val message = error.toMessage()
         val deserialized = ShowDatabaseErrorDialog.fromMessage(message)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
@@ -19,7 +19,6 @@ package com.ichi2.anki.dialogs
 import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.edit
-import androidx.core.os.bundleOf
 import androidx.fragment.app.testing.FragmentScenario
 import androidx.fragment.app.testing.FragmentScenario.Companion.launch
 import androidx.test.core.app.ApplicationProvider
@@ -192,10 +191,10 @@ class DeckPickerContextMenuTest {
         deckName: String = "Deck 1",
         isDynamic: Boolean = false,
         hasBuriedCards: Boolean = false,
-    ) = bundleOf(
-        DeckPickerContextMenu.ARG_DECK_ID to deckId,
-        DeckPickerContextMenu.ARG_DECK_NAME to deckName,
-        DeckPickerContextMenu.ARG_DECK_IS_DYN to isDynamic,
-        DeckPickerContextMenu.ARG_DECK_HAS_BURIED_IN_DECK to hasBuriedCards,
-    )
+    ) = Bundle().apply {
+        putLong(DeckPickerContextMenu.ARG_DECK_ID, deckId)
+        putString(DeckPickerContextMenu.ARG_DECK_NAME, deckName)
+        putBoolean(DeckPickerContextMenu.ARG_DECK_IS_DYN, isDynamic)
+        putBoolean(DeckPickerContextMenu.ARG_DECK_HAS_BURIED_IN_DECK, hasBuriedCards)
+    }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/help/HelpDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/help/HelpDialogTest.kt
@@ -13,7 +13,7 @@
  */
 package com.ichi2.anki.dialogs.help
 
-import androidx.core.os.bundleOf
+import android.os.Bundle
 import androidx.fragment.app.testing.launchFragment
 import androidx.lifecycle.Lifecycle
 import androidx.test.espresso.Espresso.onView
@@ -125,10 +125,10 @@ class HelpDialogTest {
         // simulate a help menu start
         launchFragment<HelpDialog>(
             fragmentArgs =
-                bundleOf(
-                    HelpDialog.ARG_MENU_TITLE to R.string.help,
-                    ARG_MENU_ITEMS to mainHelpMenuItems,
-                ),
+                Bundle().apply {
+                    putInt(HelpDialog.ARG_MENU_TITLE, R.string.help)
+                    putParcelableArray(ARG_MENU_ITEMS, mainHelpMenuItems)
+                },
             themeResId = R.style.Theme_Light,
             initialState = Lifecycle.State.RESUMED,
         ).onFragment {
@@ -175,10 +175,10 @@ class HelpDialogTest {
         // simulate a help menu start
         launchFragment<HelpDialog>(
             fragmentArgs =
-                bundleOf(
-                    HelpDialog.ARG_MENU_TITLE to R.string.help,
-                    ARG_MENU_ITEMS to mainHelpMenuItems,
-                ),
+                Bundle().apply {
+                    putInt(HelpDialog.ARG_MENU_TITLE, R.string.help)
+                    putParcelableArray(ARG_MENU_ITEMS, mainHelpMenuItems)
+                },
             themeResId = R.style.Theme_Light,
             initialState = Lifecycle.State.RESUMED,
         ).onFragment { fragment ->


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.8 - all

Deprecated in androidx:core 1.18.0

https://developer.android.com/jetpack/androidx/releases/core#core_and_core-ktx_version_118_2

Trusting unit tests for this one

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)