### PR TITLE
refactor(card-browser): remove bundleOf: deprecated

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserColumnSelectionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserColumnSelectionFragment.kt
@@ -23,7 +23,6 @@ import androidx.activity.ComponentDialog
 import androidx.activity.OnBackPressedCallback
 import androidx.annotation.StringRes
 import androidx.core.os.BundleCompat
-import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.ItemTouchHelper
@@ -239,9 +238,9 @@ class BrowserColumnSelectionFragment : DialogFragment(R.layout.dialog_browser_co
             BrowserColumnSelectionFragment().apply {
                 Timber.d("Building 'Manage columns' dialog for %s mode", cardsOrNotes)
                 arguments =
-                    bundleOf(
-                        ARG_MODE to cardsOrNotes,
-                    )
+                    Bundle().apply {
+                        putParcelable(ARG_MODE, cardsOrNotes)
+                    }
             }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -22,7 +22,6 @@ import android.os.Parcelable
 import androidx.annotation.CheckResult
 import androidx.core.content.edit
 import androidx.core.os.BundleCompat
-import androidx.core.os.bundleOf
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.createSavedStateHandle
@@ -602,9 +601,9 @@ class CardBrowserViewModel(
 
     @VisibleForTesting // far too complicated to mock setSavedStateProvider
     fun generateExpensiveSavedState() =
-        bundleOf(
-            STATE_MULTISELECT_VALUES to IdsFile(cacheDir, selectedRows.map { it.cardOrNoteId }, "multiselect-values"),
-        )
+        Bundle().apply {
+            putParcelable(STATE_MULTISELECT_VALUES, IdsFile(cacheDir, selectedRows.map { it.cardOrNoteId }, "multiselect-values"))
+        }
 
     /**
      * Called if `onCreate` is called again, which may be due to the collection being reopened

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/ColumnSelectionDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/ColumnSelectionDialogFragment.kt
@@ -24,7 +24,6 @@ import android.widget.LinearLayout
 import android.widget.ListView
 import androidx.appcompat.app.AlertDialog
 import androidx.core.os.BundleCompat
-import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
@@ -140,7 +139,7 @@ class ColumnSelectionDialogFragment : DialogFragment() {
 
         fun newInstance(selectedColumn: ColumnHeading): ColumnSelectionDialogFragment =
             ColumnSelectionDialogFragment().apply {
-                arguments = bundleOf(SELECTED_COLUMN to selectedColumn)
+                arguments = Bundle().apply { putParcelable(SELECTED_COLUMN, selectedColumn) }
             }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/FindAndReplaceDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/FindAndReplaceDialogFragment.kt
@@ -25,7 +25,6 @@ import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.Companion.PRIVATE
 import androidx.appcompat.app.AlertDialog
 import androidx.core.os.BundleCompat
-import androidx.core.os.bundleOf
 import androidx.core.text.HtmlCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.setFragmentResult
@@ -166,15 +165,15 @@ class FindAndReplaceDialogFragment : AnalyticsDialogFragment() {
         Timber.i("Sending request to find and replace...")
         setFragmentResult(
             REQUEST_FIND_AND_REPLACE,
-            bundleOf(
-                ARG_SEARCH to search.toString(),
-                ARG_REPLACEMENT to replacement.toString(),
-                ARG_FIELD to selectedField,
-                ARG_ONLY_SELECTED_NOTES to onlyInSelectedNotes,
+            Bundle().apply {
+                putString(ARG_SEARCH, search.toString())
+                putString(ARG_REPLACEMENT, replacement.toString())
+                putString(ARG_FIELD, selectedField)
+                putBoolean(ARG_ONLY_SELECTED_NOTES, onlyInSelectedNotes)
                 // "Ignore case" checkbox text => when it's checked we pass false to the backend
-                ARG_MATCH_CASE to !ignoreCase,
-                ARG_REGEX to inputAsRegex,
-            ),
+                putBoolean(ARG_MATCH_CASE, !ignoreCase)
+                putBoolean(ARG_REGEX, inputAsRegex)
+            },
         )
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/RepositionCardFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/RepositionCardFragment.kt
@@ -21,7 +21,6 @@ import android.os.Bundle
 import android.text.InputFilter
 import android.view.WindowManager
 import androidx.appcompat.app.AlertDialog
-import androidx.core.os.bundleOf
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.setFragmentResult
@@ -88,12 +87,12 @@ class RepositionCardFragment : DialogFragment() {
                         binding.stepInputEditText.textAsIntOrNull() ?: return@positiveButton
                     setFragmentResult(
                         REQUEST_REPOSITION_NEW_CARDS,
-                        bundleOf(
-                            ARG_POSITION to position,
-                            ARG_STEP to step,
-                            ARG_RANDOM to binding.randomizeOrderCheck.isChecked,
-                            ARG_SHIFT to binding.shiftPositionCheck.isChecked,
-                        ),
+                        Bundle().apply {
+                            putInt(ARG_POSITION, position)
+                            putInt(ARG_STEP, step)
+                            putBoolean(ARG_RANDOM, binding.randomizeOrderCheck.isChecked)
+                            putBoolean(ARG_SHIFT, binding.shiftPositionCheck.isChecked)
+                        },
                     )
                 }
             }
@@ -150,12 +149,12 @@ class RepositionCardFragment : DialogFragment() {
             shift: Boolean,
         ) = RepositionCardFragment().apply {
             arguments =
-                bundleOf(
-                    ARG_QUEUE_TOP to queueTop,
-                    ARG_QUEUE_BOTTOM to queueBottom,
-                    ARG_RANDOM to random,
-                    ARG_SHIFT to shift,
-                )
+                Bundle().apply {
+                    putInt(ARG_QUEUE_TOP, queueTop)
+                    putInt(ARG_QUEUE_BOTTOM, queueBottom)
+                    putBoolean(ARG_RANDOM, random)
+                    putBoolean(ARG_SHIFT, shift)
+                }
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/search/AdvancedSearchFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/search/AdvancedSearchFragment.kt
@@ -21,7 +21,6 @@ import android.os.Parcelable
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.os.BundleCompat
-import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -350,9 +349,9 @@ class AdvancedSearchFragment : Fragment(R.layout.fragment_advanced_search) {
             fun createInstance(data: List<OptionData>) =
                 SelectAdvancedSearchFragment().apply {
                     arguments =
-                        bundleOf(
-                            ARG_OPTION_DATA to ArrayList(data),
-                        )
+                        Bundle().apply {
+                            putParcelableArrayList(ARG_OPTION_DATA, ArrayList(data))
+                        }
                 }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/search/FlagsBottomSheetFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/search/FlagsBottomSheetFragment.kt
@@ -23,7 +23,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.DrawableRes
 import androidx.core.os.BundleCompat
-import androidx.core.os.bundleOf
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.RecyclerView
@@ -176,7 +175,7 @@ class FlagsBottomSheetFragment : BottomSheetDialogFragment(R.layout.fragment_bot
                         FlagUiModel(it, label = userDefinedNames.getValue(it))
                     }
 
-                arguments = bundleOf(ARG_FLAGS to ArrayList(flags))
+                arguments = Bundle().apply { putParcelableArrayList(ARG_FLAGS, ArrayList(flags)) }
             }
     }
 }


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.8 - all

Deprecated in androidx:core 1.18.0

https://developer.android.com/jetpack/androidx/releases/core#core_and_core-ktx_version_118_2



## How Has This Been Tested?

API 29 emulator:
* Advanced Search
* Flag Filter
* Find and replace
* Both column selections

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->