### PR TITLE
refactor: move AnkiBroadcastReceiver to :common:android

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -58,10 +58,10 @@ import com.ichi2.anim.ActivityTransitionAnimation.Direction
 import com.ichi2.anim.ActivityTransitionAnimation.Direction.DEFAULT
 import com.ichi2.anim.ActivityTransitionAnimation.Direction.NONE
 import com.ichi2.anki.analytics.UsageAnalytics
-import com.ichi2.anki.android.AnkiBroadcastReceiver
 import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.ShortcutGroupProvider
 import com.ichi2.anki.android.input.shortcut
+import com.ichi2.anki.common.android.AnkiBroadcastReceiver
 import com.ichi2.anki.common.annotations.LegacyNotifications
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.crashreporting.CrashReportService

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -25,6 +25,8 @@ import com.ichi2.anki.AnkiDroidApp.Companion.sharedPreferencesTestingOverride
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
 import com.ichi2.anki.common.android.ApplicationContextInitializer
+import com.ichi2.anki.common.android.getCurrentLocaleTag
+import com.ichi2.anki.common.android.withAppLocale
 import com.ichi2.anki.common.annotations.LegacyNotifications
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.coroutines.applicationScope
@@ -55,7 +57,6 @@ import com.ichi2.anki.ui.dialogs.ActivityAgnosticDialogs
 import com.ichi2.utils.AdaptionUtil
 import com.ichi2.utils.ExceptionUtil
 import com.ichi2.utils.LanguageUtil
-import com.ichi2.utils.LanguageUtil.withAppLocale
 import com.ichi2.utils.measureTime
 import com.ichi2.utils.setWebContentsDebuggingEnabled
 import com.ichi2.widget.DayRolloverAlarm
@@ -535,7 +536,7 @@ open class AnkiDroidApp :
         val feedbackUrl: String
             get() = // TODO actually this can be done by translating "link_help" string for each language when the App is
                 // properly translated
-                when (LanguageUtil.getCurrentLocaleTag()) {
+                when (getCurrentLocaleTag()) {
                     "ja" -> appResources.getString(R.string.link_help_ja)
                     "zh" -> appResources.getString(R.string.link_help_zh)
                     "ar" -> appResources.getString(R.string.link_help_ar)
@@ -549,7 +550,7 @@ open class AnkiDroidApp :
         val manualUrl: String
             get() = // TODO actually this can be done by translating "link_manual" string for each language when the App is
                 // properly translated
-                when (LanguageUtil.getCurrentLocaleTag()) {
+                when (getCurrentLocaleTag()) {
                     "ja" -> appResources.getString(R.string.link_manual_ja)
                     "zh" -> appResources.getString(R.string.link_manual_zh)
                     "ar" -> appResources.getString(R.string.link_manual_ar)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -40,7 +40,7 @@ import com.ichi2.anki.CrashReportData.Companion.toCrashReportData
 import com.ichi2.anki.CrashReportData.HelpAction
 import com.ichi2.anki.CrashReportData.HelpAction.AnkiBackendLink
 import com.ichi2.anki.CrashReportData.HelpAction.OpenDeckOptions
-import com.ichi2.anki.android.AnkiBroadcastReceiver
+import com.ichi2.anki.common.android.AnkiBroadcastReceiver
 import com.ichi2.anki.common.annotations.UseContextParameter
 import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.crashreporting.CrashReportService

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DayRolloverHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DayRolloverHandler.kt
@@ -34,7 +34,7 @@ import androidx.core.content.ContextCompat.RECEIVER_EXPORTED
 import anki.collection.OpChanges
 import anki.collection.opChanges
 import com.ichi2.anki.CollectionManager.withOpenColOrNull
-import com.ichi2.anki.android.AnkiBroadcastReceiver
+import com.ichi2.anki.common.android.AnkiBroadcastReceiver
 import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.crashreporting.CrashReportService

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -37,7 +37,7 @@ import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.SharedDecksActivity.Companion.DOWNLOAD_FILE
-import com.ichi2.anki.android.AnkiBroadcastReceiver
+import com.ichi2.anki.common.android.AnkiBroadcastReceiver
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.utils.android.showThemedToast
 import com.ichi2.anki.compat.CompatHelper.Companion.getSerializableCompat

--- a/AnkiDroid/src/main/java/com/ichi2/anki/android/AnkiBroadcastReceiver.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/android/AnkiBroadcastReceiver.kt
@@ -19,7 +19,7 @@ package com.ichi2.anki.android
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import com.ichi2.utils.LanguageUtil.withAppLocale
+import com.ichi2.anki.common.android.withAppLocale
 
 /**
  * A base class for all [BroadcastReceiver] instances in the app

--- a/AnkiDroid/src/main/java/com/ichi2/anki/receiver/SdCardReceiver.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/receiver/SdCardReceiver.kt
@@ -19,7 +19,7 @@ package com.ichi2.anki.receiver
 import android.content.Context
 import android.content.Intent
 import com.ichi2.anki.CollectionManager
-import com.ichi2.anki.android.AnkiBroadcastReceiver
+import com.ichi2.anki.common.android.AnkiBroadcastReceiver
 import timber.log.Timber
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/AlarmManagerService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/AlarmManagerService.kt
@@ -25,7 +25,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.app.PendingIntentCompat
 import androidx.core.content.getSystemService
 import com.ichi2.anki.R
-import com.ichi2.anki.android.AnkiBroadcastReceiver
+import com.ichi2.anki.common.android.AnkiBroadcastReceiver
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.utils.android.showThemedToast
 import com.ichi2.anki.reviewreminders.ReviewReminder

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
@@ -24,7 +24,7 @@ import androidx.core.app.PendingIntentCompat
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.IntentHandler.Companion.grantedStoragePermissions
 import com.ichi2.anki.R
-import com.ichi2.anki.android.AnkiBroadcastReceiver
+import com.ichi2.anki.common.android.AnkiBroadcastReceiver
 import com.ichi2.anki.common.annotations.LegacyNotifications
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.preferences.sharedPrefs

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
@@ -29,8 +29,8 @@ import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.IntentHandler
 import com.ichi2.anki.R
-import com.ichi2.anki.android.AnkiBroadcastReceiver
 import com.ichi2.anki.canUserAccessDeck
+import com.ichi2.anki.common.android.AnkiBroadcastReceiver
 import com.ichi2.anki.common.annotations.LegacyNotifications
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.libanki.Decks

--- a/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.kt
@@ -19,7 +19,6 @@ import android.content.Context
 import android.content.res.Configuration
 import android.content.res.Resources
 import androidx.annotation.StringRes
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.ConfigurationCompat
 import androidx.fragment.app.Fragment
 import com.ichi2.anki.R
@@ -27,7 +26,6 @@ import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.compat.CompatHelper
 import net.ankiweb.rsdroid.BackendFactory
-import timber.log.Timber
 import java.util.Locale
 
 /**
@@ -364,43 +362,12 @@ object LanguageUtil {
         return createConfigurationContext(configuration).resources.getString(stringRes, *formatArgs)
     }
 
-    /**
-     * Returns a [Context] with resources using the app language.
-     *
-     * Needed for resources accessed outside an Activity (e.g. from a [BroadcastReceiver][android.content.BroadcastReceiver]
-     * or [Service][android.app.Service]):
-     *
-     * On API < 33, [AppCompatDelegate.setApplicationLocales] only applies to Activity contexts, so
-     *  resources resolve in the system locale.
-     *
-     * Returns [this] unchanged (System language) when no in-app language is set.
-     *
-     * This method will not throw.
-     */
-    fun Context.withAppLocale(): Context =
-        try {
-            val tag = getCurrentLocaleTag()
-            if (tag.isEmpty()) return this
-            val configuration = Configuration(resources.configuration)
-            configuration.setLocale(Locale.forLanguageTag(tag))
-            return createConfigurationContext(configuration)
-        } catch (e: Exception) {
-            Timber.w(e, "withAppLocale")
-            return this
-        }
-
     /** @return string defined with [stringRes] on the specified [locale] */
     fun Fragment.getStringByLocale(
         @StringRes stringRes: Int,
         locale: Locale,
         vararg formatArgs: Any,
     ): String = requireContext().getStringByLocale(stringRes, locale, *formatArgs)
-
-    /**
-     * This should always be called after Activity.onCreate()
-     * @return locale language tag of the app configured language
-     */
-    fun getCurrentLocaleTag(): String = AppCompatDelegate.getApplicationLocales().toLanguageTags()
 
     /**
      * Returns the character to use when separating a list; `, ` in English

--- a/AnkiDroid/src/main/java/com/ichi2/widget/DayRolloverAlarm.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/DayRolloverAlarm.kt
@@ -27,7 +27,7 @@ import androidx.core.app.PendingIntentCompat
 import androidx.core.content.getSystemService
 import anki.collection.opChanges
 import com.ichi2.anki.CollectionManager.withOpenColOrNull
-import com.ichi2.anki.android.AnkiBroadcastReceiver
+import com.ichi2.anki.common.android.AnkiBroadcastReceiver
 import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.exception.ManuallyReportedException

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetPermissionReceiver.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetPermissionReceiver.kt
@@ -21,7 +21,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import com.ichi2.anki.IntentHandler
-import com.ichi2.anki.android.AnkiBroadcastReceiver
+import com.ichi2.anki.common.android.AnkiBroadcastReceiver
 
 /**
  * BroadcastReceiver to handle the scenario where storage permissions are granted,

--- a/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidgetConfig.kt
@@ -26,7 +26,7 @@ import androidx.core.os.BundleCompat
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
-import com.ichi2.anki.android.AnkiBroadcastReceiver
+import com.ichi2.anki.common.android.AnkiBroadcastReceiver
 import com.ichi2.anki.common.utils.android.showThemedToast
 import com.ichi2.anki.common.utils.ext.unregisterReceiverSilently
 import com.ichi2.anki.databinding.ActivityCardAnalysisWidgetConfigBinding

--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
@@ -33,7 +33,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.R
-import com.ichi2.anki.android.AnkiBroadcastReceiver
+import com.ichi2.anki.common.android.AnkiBroadcastReceiver
 import com.ichi2.anki.common.utils.android.showThemedToast
 import com.ichi2.anki.common.utils.ext.unregisterReceiverSilently
 import com.ichi2.anki.databinding.WidgetDeckPickerConfigBinding

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
@@ -22,6 +22,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.cardviewer.Gesture
+import com.ichi2.anki.common.android.getCurrentLocaleTag
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.utils.HashUtil
 import com.ichi2.anki.libanki.Consts
@@ -217,7 +218,7 @@ class PreferenceUpgradeServiceTest : RobolectricTest() {
             // - follow app use path: get help / using / ankidroid manual -> it should send you to English manual
             // - manual is translated in Japanese, so set app language preference to Japanese
             // - set app language back to english, verify it goes to english manual again
-            // assertThat(LanguageUtil.getCurrentLocaleTag(), equalTo(languageTag))
+            // assertThat(getCurrentLocaleTag(), equalTo(languageTag))
         }
     }
 
@@ -226,7 +227,7 @@ class PreferenceUpgradeServiceTest : RobolectricTest() {
         PreferenceUpgrade.UpgradeAppLocale().performUpgrade(prefs)
 
         assertNotNull(prefs.getString("language", null))
-        assertThat(LanguageUtil.getCurrentLocaleTag(), equalTo(""))
+        assertThat(getCurrentLocaleTag(), equalTo(""))
     }
 
     @Test
@@ -235,7 +236,7 @@ class PreferenceUpgradeServiceTest : RobolectricTest() {
         PreferenceUpgrade.UpgradeAppLocale().performUpgrade(prefs)
 
         assertThat(prefs.getString("language", null), equalTo(""))
-        assertThat(LanguageUtil.getCurrentLocaleTag(), equalTo(""))
+        assertThat(getCurrentLocaleTag(), equalTo(""))
     }
 
     @Test

--- a/common/android/build.gradle.kts
+++ b/common/android/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(project(":common"))
 
     implementation(libs.androidx.annotation)
+    implementation(libs.androidx.appcompat)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.preference.ktx)
     implementation(libs.google.material)

--- a/common/android/src/main/java/com/ichi2/anki/common/android/AnkiBroadcastReceiver.kt
+++ b/common/android/src/main/java/com/ichi2/anki/common/android/AnkiBroadcastReceiver.kt
@@ -14,12 +14,11 @@
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.ichi2.anki.android
+package com.ichi2.anki.common.android
 
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import com.ichi2.anki.common.android.withAppLocale
 
 /**
  * A base class for all [BroadcastReceiver] instances in the app

--- a/common/android/src/main/java/com/ichi2/anki/common/android/AppLocale.kt
+++ b/common/android/src/main/java/com/ichi2/anki/common/android/AppLocale.kt
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.common.android
+
+import android.content.Context
+import android.content.res.Configuration
+import androidx.appcompat.app.AppCompatDelegate
+import timber.log.Timber
+import java.util.Locale
+
+/**
+ * Returns a [Context] wrapped with the in-app locale.
+ *
+ * Needed for resources accessed outside an Activity (e.g. from a [android.content.BroadcastReceiver]
+ * or [android.app.Service]):
+ *
+ * On API < 33, [AppCompatDelegate.setApplicationLocales] only applies to Activity contexts, so
+ * resources resolve in the system locale.
+ *
+ * Returns [this] unchanged (System language) when no in-app language is set.
+ *
+ * This method will not throw.
+ */
+fun Context.withAppLocale(): Context =
+    try {
+        val tag = getCurrentLocaleTag()
+        if (tag.isEmpty()) return this
+        val configuration = Configuration(resources.configuration)
+        configuration.setLocale(Locale.forLanguageTag(tag))
+        return createConfigurationContext(configuration)
+    } catch (e: Exception) {
+        Timber.w(e, "withAppLocale")
+        return this
+    }
+
+/**
+ * This should always be called after Activity.onCreate()
+ * @return locale language tag of the app configured language
+ */
+fun getCurrentLocaleTag(): String = AppCompatDelegate.getApplicationLocales().toLanguageTags()


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Moves AnkiBroadcastReceiver and its locale-helper dependencies (Context.withAppLocale(), getCurrentLocaleTag()) from :AnkiDroid down to :common:android, so widgets, services and other receivers can extend the base receiver without depending on :AnkiDroid.

## Fixes
* Part of #20737

## Approach
See commits

## How Has This Been Tested?
Local build and CI

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->