### PR TITLE
test(ci): workaround codecov artifact signing errors

### DIFF
--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -250,3 +250,7 @@ jobs:
         with:
           verbose: true
           fail_ci_if_error: ${{ github.repository == 'ankidroid/Anki-Android' }} # optional (default = false)
+          # See https://github.com/codecov/codecov-action/issues/1940#issuecomment-4639834138
+          # ...and related commits. This uses a different install path to get the artifact so it has a valid signature
+          # without this as of 20260607 codecov fails signature verification and fails the build
+          use_pypi: true

--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -199,3 +199,7 @@ jobs:
         with:
           verbose: true
           fail_ci_if_error: ${{ github.repository == 'ankidroid/Anki-Android' }} # optional (default = false)
+          # See https://github.com/codecov/codecov-action/issues/1940#issuecomment-4639834138
+          # ...and related commits. This uses a different install path to get the artifact so it has a valid signature
+          # without this as of 20260607 codecov fails signature verification and fails the build
+          use_pypi: true


### PR DESCRIPTION
## Purpose / Description

Codecov is currently failing all CI runs for unit and emulator tests because their current codecov artifact isn't verifying correctly against their checksum. Using a differently install vector (`use_pypi`) apparently gets us an artifact that has a valid signature

see: https://github.com/codecov/codecov-action/issues/1940#issuecomment-4639834138 (solution from commits linked to issue + working per observed CI run status)

## Fixes

Fixes all unit and emulator tests

## Approach

Check out the related issue upstream and spider out to related commits that apparently succeed

## How Has This Been Tested?

I can't locally but CI unit test or emulator will work with this, where they fail currently without it

## Learning (optional, can help others)
I like coverage data a lot but it's one of my more frequent CI "touchs". Breaks a lot.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->