### PR TITLE
arch: migrate CardInfoDestination to Navigation pattern

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/PagesTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/PagesTest.kt
@@ -23,11 +23,12 @@ import android.content.Intent
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import com.ichi2.anki.common.annotations.NeedsTest
+import com.ichi2.anki.common.destinations.CardInfoDestination
 import com.ichi2.anki.libanki.Card
-import com.ichi2.anki.pages.CardInfoDestination
 import com.ichi2.anki.pages.DeckOptions
 import com.ichi2.anki.pages.PageFragment
 import com.ichi2.anki.pages.StatisticsDestination
+import com.ichi2.anki.pages.toIntent
 import com.ichi2.anki.tests.InstrumentedTest
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/PagesTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/PagesTest.kt
@@ -24,6 +24,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.destinations.CardInfoDestination
+import com.ichi2.anki.common.destinations.CardInfoDestination.EntryPoint
 import com.ichi2.anki.libanki.Card
 import com.ichi2.anki.pages.DeckOptions
 import com.ichi2.anki.pages.PageFragment
@@ -89,13 +90,13 @@ fun PagesTest.getStatistics(context: Context): Intent = StatisticsDestination().
 fun PagesTest.getCardInfo(context: Context): Intent =
     addNoteUsingBasicNoteType().firstCard(col).let { card ->
         this.card = card
-        CardInfoDestination(card.id, "Unused").toIntent(context)
+        CardInfoDestination(card.id, EntryPoint.CURRENT_CARD_STUDY).toIntent(context)
     }
 
 fun PagesTest.getCongratsPage(context: Context): Intent =
     addNoteUsingBasicNoteType().firstCard(col).let { card ->
         this.card = card
-        CardInfoDestination(card.id, "Unused").toIntent(context)
+        CardInfoDestination(card.id, EntryPoint.CURRENT_CARD_STUDY).toIntent(context)
     }
 
 fun PagesTest.getDeckOptions(context: Context): Intent =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -57,6 +57,7 @@ import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.crashreporting.CrashReportService
+import com.ichi2.anki.common.destinations.CardInfoDestination
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.utils.android.HandlerUtils.executeFunctionWithDelay
@@ -81,8 +82,8 @@ import com.ichi2.anki.multimedia.audio.AudioRecordingController.Companion.tempAu
 import com.ichi2.anki.multimedia.audio.AudioRecordingController.RecordingState
 import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.observability.undoableOp
-import com.ichi2.anki.pages.CardInfoDestination
 import com.ichi2.anki.pages.PostRequestUri
+import com.ichi2.anki.pages.toIntent
 import com.ichi2.anki.reviewer.ActionButtons
 import com.ichi2.anki.reviewer.AnswerButtons.Companion.getBackgroundColors
 import com.ichi2.anki.reviewer.AnswerButtons.Companion.getTextColors

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -58,6 +58,7 @@ import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.destinations.CardInfoDestination
+import com.ichi2.anki.common.destinations.CardInfoDestination.EntryPoint
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.utils.android.HandlerUtils.executeFunctionWithDelay
@@ -110,10 +111,8 @@ import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.ui.windows.reviewer.ReviewerFragment
 import com.ichi2.anki.utils.ext.cardStatsNoCardClean
-import com.ichi2.anki.utils.ext.currentCardStudy
 import com.ichi2.anki.utils.ext.flag
 import com.ichi2.anki.utils.ext.getLongOrNull
-import com.ichi2.anki.utils.ext.previousCardStudy
 import com.ichi2.anki.utils.ext.setUserFlagForCards
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.utils.navBarNeedsScrim
@@ -799,7 +798,7 @@ open class Reviewer :
             return
         }
         Timber.i("opening card info")
-        val intent = CardInfoDestination(currentCard!!.id, TR.currentCardStudy()).toIntent(this)
+        val intent = CardInfoDestination(currentCard!!.id, EntryPoint.CURRENT_CARD_STUDY).toIntent(this)
         val animation = getAnimationTransitionFromGesture(fromGesture)
         intent.putExtra(FINISH_ANIMATION_EXTRA, getInverseTransition(animation) as Parcelable)
         startActivityWithAnimation(intent, animation)
@@ -812,7 +811,7 @@ open class Reviewer :
             return
         }
         Timber.i("opening previous card info")
-        val intent = CardInfoDestination(previousCardId!!, TR.previousCardStudy()).toIntent(this)
+        val intent = CardInfoDestination(previousCardId!!, EntryPoint.PREVIOUS_CARD_STUDY).toIntent(this)
         val animation = getAnimationTransitionFromGesture(fromGesture)
         intent.putExtra(FINISH_ANIMATION_EXTRA, getInverseTransition(animation) as Parcelable)
         startActivityWithAnimation(intent, animation)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -106,6 +106,7 @@ import com.ichi2.anki.browser.search.iconRes
 import com.ichi2.anki.browser.search.savedFilters
 import com.ichi2.anki.common.ALL_DECKS_ID
 import com.ichi2.anki.common.annotations.NeedsTest
+import com.ichi2.anki.common.destinations.navigate
 import com.ichi2.anki.common.utils.ext.ifNotZero
 import com.ichi2.anki.dialogs.BrowserOptionsDialog
 import com.ichi2.anki.dialogs.CardBrowserOrderDialog
@@ -1423,7 +1424,7 @@ class CardBrowserFragment :
     fun displayCardInfo() =
         launchCatchingTask {
             activityViewModel.queryCardInfoDestination()?.let { destination ->
-                startActivity(destination.toIntent(requireContext()))
+                navigate(destination)
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -53,6 +53,7 @@ import com.ichi2.anki.browser.search.SearchString
 import com.ichi2.anki.common.ALL_DECKS_ID
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.crashreporting.CrashReportService
+import com.ichi2.anki.common.destinations.CardInfoDestination
 import com.ichi2.anki.common.utils.ext.indexOfOrNull
 import com.ichi2.anki.export.ExportDialogFragment.ExportType
 import com.ichi2.anki.launchCatchingIO
@@ -76,7 +77,6 @@ import com.ichi2.anki.model.SortType
 import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.observability.undoableOp
-import com.ichi2.anki.pages.CardInfoDestination
 import com.ichi2.anki.preferences.SharedPreferencesProvider
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.settings.PrefsRepository

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -54,6 +54,7 @@ import com.ichi2.anki.common.ALL_DECKS_ID
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.destinations.CardInfoDestination
+import com.ichi2.anki.common.destinations.CardInfoDestination.EntryPoint
 import com.ichi2.anki.common.utils.ext.indexOfOrNull
 import com.ichi2.anki.export.ExportDialogFragment.ExportType
 import com.ichi2.anki.launchCatchingIO
@@ -80,7 +81,6 @@ import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.preferences.SharedPreferencesProvider
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.settings.PrefsRepository
-import com.ichi2.anki.utils.ext.currentCardBrowse
 import com.ichi2.anki.utils.ext.getCardOrNull
 import com.ichi2.anki.utils.ext.ignoreAccentsInSearch
 import com.ichi2.anki.utils.ext.setUserFlagForCards
@@ -433,7 +433,7 @@ class CardBrowserViewModel(
 
     suspend fun queryCardInfoDestination(): CardInfoDestination? {
         val firstSelectedCard = selectedRows.firstOrNull()?.toCardId(cardsOrNotes) ?: return null
-        return CardInfoDestination(firstSelectedCard, TR.currentCardBrowse())
+        return CardInfoDestination(firstSelectedCard, EntryPoint.CURRENT_CARD_BROWSE)
     }
 
     private suspend fun getInitialDeck(): SelectableDeck {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/navigation/AnkiDroidNavigator.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/navigation/AnkiDroidNavigator.kt
@@ -6,6 +6,7 @@ import android.app.Application
 import android.content.Intent
 import com.ichi2.anki.browser.toIntent
 import com.ichi2.anki.common.destinations.BrowserDestination
+import com.ichi2.anki.common.destinations.CardInfoDestination
 import com.ichi2.anki.common.destinations.CsvImporterDestination
 import com.ichi2.anki.common.destinations.Destination
 import com.ichi2.anki.common.destinations.Navigator
@@ -22,6 +23,7 @@ object AnkiDroidNavigator : Navigator {
     override fun toIntent(destination: Destination): Intent =
         when (destination) {
             is BrowserDestination -> destination.toIntent(navContext)
+            is CardInfoDestination -> destination.toIntent(navContext)
             is CsvImporterDestination -> destination.toIntent(navContext)
         }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CardInfoDestination.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CardInfoDestination.kt
@@ -6,26 +6,21 @@ package com.ichi2.anki.pages
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.annotation.StringRes
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.SingleFragmentActivity
 import com.ichi2.anki.common.destinations.CardInfoDestination
+import com.ichi2.anki.common.destinations.CardInfoDestination.EntryPoint
 import com.ichi2.anki.libanki.withoutUnicodeIsolation
 import com.ichi2.anki.ui.internationalization.toSentenceCase
 
 /** Builds the [Intent] that opens the card info screen for this destination. */
 fun CardInfoDestination.toIntent(context: Context): Intent {
-    // title contains FSI and PDI character types
-    val simplifiedTitle = withoutUnicodeIsolation(title)
-    val sentenceStrings =
-        listOf(
-            simplifiedTitle.toSentenceCase(context, R.string.sentence_card_stats_current_card_study),
-            simplifiedTitle.toSentenceCase(context, R.string.sentence_card_stats_current_card_browse),
-            simplifiedTitle.toSentenceCase(context, R.string.sentence_card_stats_previous_card_study),
-        )
-    val cardInfoTitle = sentenceStrings.firstOrNull { it != simplifiedTitle } ?: title
+    val title = entryPoint.title(TR).toCardInfoTitle(context, entryPoint.sentenceCaseResId)
     val arguments =
         Bundle().apply {
-            putString(CardInfoFragment.KEY_TITLE, cardInfoTitle)
+            putString(CardInfoFragment.KEY_TITLE, title)
             putLong(CardInfoFragment.KEY_CARD_ID, cardId)
         }
     return SingleFragmentActivity.getIntent(
@@ -33,4 +28,30 @@ fun CardInfoDestination.toIntent(context: Context): Intent {
         fragmentClass = CardInfoFragment::class,
         arguments = arguments,
     )
+}
+
+/** The sentence case resource matching this entry point's backend [EntryPoint.title]. */
+@get:StringRes
+private val EntryPoint.sentenceCaseResId: Int
+    get() =
+        when (this) {
+            EntryPoint.CURRENT_CARD_STUDY -> R.string.sentence_card_stats_current_card_study
+            EntryPoint.CURRENT_CARD_BROWSE -> R.string.sentence_card_stats_current_card_browse
+            EntryPoint.PREVIOUS_CARD_STUDY -> R.string.sentence_card_stats_previous_card_study
+        }
+
+/**
+ * Converts a backend card-stats title to AnkiDroid's sentence-cased form when it matches [resId].
+ *
+ * @see toSentenceCase
+ */
+private fun String.toCardInfoTitle(
+    context: Context,
+    @StringRes resId: Int,
+): String {
+    // The title contains FSI and PDI character types - these need to be stripped for the comparison
+    val simplifiedTitle = withoutUnicodeIsolation(this)
+    val sentenceCased = simplifiedTitle.toSentenceCase(context, resId)
+    // Do not return the stripped title if there's no match
+    return if (sentenceCased != simplifiedTitle) sentenceCased else this
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CardInfoDestination.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CardInfoDestination.kt
@@ -1,18 +1,6 @@
-/*
- *  Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+
 package com.ichi2.anki.pages
 
 import android.content.Context
@@ -20,34 +8,29 @@ import android.content.Intent
 import android.os.Bundle
 import com.ichi2.anki.R
 import com.ichi2.anki.SingleFragmentActivity
-import com.ichi2.anki.libanki.CardId
+import com.ichi2.anki.common.destinations.CardInfoDestination
 import com.ichi2.anki.libanki.withoutUnicodeIsolation
 import com.ichi2.anki.ui.internationalization.toSentenceCase
-import com.ichi2.anki.utils.Destination
 
-data class CardInfoDestination(
-    val cardId: CardId,
-    val title: String,
-) : Destination {
-    override fun toIntent(context: Context): Intent {
-        // title contains FSI and PDI character types
-        val simplifiedTitle = withoutUnicodeIsolation(title)
-        val sentenceStrings =
-            listOf(
-                simplifiedTitle.toSentenceCase(context, R.string.sentence_card_stats_current_card_study),
-                simplifiedTitle.toSentenceCase(context, R.string.sentence_card_stats_current_card_browse),
-                simplifiedTitle.toSentenceCase(context, R.string.sentence_card_stats_previous_card_study),
-            )
-        val cardInfoTitle = sentenceStrings.firstOrNull { it != simplifiedTitle } ?: title
-        val arguments =
-            Bundle().apply {
-                putString(CardInfoFragment.KEY_TITLE, cardInfoTitle)
-                putLong(CardInfoFragment.KEY_CARD_ID, cardId)
-            }
-        return SingleFragmentActivity.getIntent(
-            context,
-            fragmentClass = CardInfoFragment::class,
-            arguments = arguments,
+/** Builds the [Intent] that opens the card info screen for this destination. */
+fun CardInfoDestination.toIntent(context: Context): Intent {
+    // title contains FSI and PDI character types
+    val simplifiedTitle = withoutUnicodeIsolation(title)
+    val sentenceStrings =
+        listOf(
+            simplifiedTitle.toSentenceCase(context, R.string.sentence_card_stats_current_card_study),
+            simplifiedTitle.toSentenceCase(context, R.string.sentence_card_stats_current_card_browse),
+            simplifiedTitle.toSentenceCase(context, R.string.sentence_card_stats_previous_card_study),
         )
-    }
+    val cardInfoTitle = sentenceStrings.firstOrNull { it != simplifiedTitle } ?: title
+    val arguments =
+        Bundle().apply {
+            putString(CardInfoFragment.KEY_TITLE, cardInfoTitle)
+            putLong(CardInfoFragment.KEY_CARD_ID, cardId)
+        }
+    return SingleFragmentActivity.getIntent(
+        context,
+        fragmentClass = CardInfoFragment::class,
+        arguments = arguments,
+    )
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -30,6 +30,7 @@ import com.ichi2.anki.asyncIO
 import com.ichi2.anki.cardviewer.SingleCardSide
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.destinations.BrowserDestination
+import com.ichi2.anki.common.destinations.CardInfoDestination
 import com.ichi2.anki.launchCatchingIO
 import com.ichi2.anki.libanki.Card
 import com.ichi2.anki.libanki.CardId
@@ -43,7 +44,6 @@ import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.pages.AnkiServer
-import com.ichi2.anki.pages.CardInfoDestination
 import com.ichi2.anki.pages.DeckOptionsDestination
 import com.ichi2.anki.pages.DeckOptionsEntry
 import com.ichi2.anki.pages.PostRequestUri
@@ -287,7 +287,7 @@ class ReviewerViewModel(
         val cardId = currentCard.await().id
         val destination = CardInfoDestination(cardId, TR.currentCardStudy())
         Timber.i("Launching 'card info' for card %d", cardId)
-        destinationFlow.emit(destination)
+        navigateFlow.emit(destination)
     }
 
     private suspend fun emitPreviousCardInfoDestination() {
@@ -299,7 +299,7 @@ class ReviewerViewModel(
         }
         val destination = CardInfoDestination(previousCardId, TR.previousCardStudy())
         Timber.i("Launching 'previous card info' for card %d", previousCardId)
-        destinationFlow.emit(destination)
+        navigateFlow.emit(destination)
     }
 
     @NeedsTest("verify that we show the proper deck option targets for the current card")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -31,6 +31,7 @@ import com.ichi2.anki.cardviewer.SingleCardSide
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.destinations.BrowserDestination
 import com.ichi2.anki.common.destinations.CardInfoDestination
+import com.ichi2.anki.common.destinations.CardInfoDestination.EntryPoint
 import com.ichi2.anki.launchCatchingIO
 import com.ichi2.anki.libanki.Card
 import com.ichi2.anki.libanki.CardId
@@ -68,10 +69,8 @@ import com.ichi2.anki.ui.windows.reviewer.autoadvance.QuestionAction
 import com.ichi2.anki.utils.Destination
 import com.ichi2.anki.utils.ext.answerCard
 import com.ichi2.anki.utils.ext.cardStatsNoCardClean
-import com.ichi2.anki.utils.ext.currentCardStudy
 import com.ichi2.anki.utils.ext.flag
 import com.ichi2.anki.utils.ext.getLongOrNull
-import com.ichi2.anki.utils.ext.previousCardStudy
 import com.ichi2.anki.utils.ext.setUserFlagForCards
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
@@ -285,7 +284,7 @@ class ReviewerViewModel(
 
     private suspend fun emitCardInfoDestination() {
         val cardId = currentCard.await().id
-        val destination = CardInfoDestination(cardId, TR.currentCardStudy())
+        val destination = CardInfoDestination(cardId, EntryPoint.CURRENT_CARD_STUDY)
         Timber.i("Launching 'card info' for card %d", cardId)
         navigateFlow.emit(destination)
     }
@@ -297,7 +296,7 @@ class ReviewerViewModel(
             actionFeedbackFlow.emit(TR.cardStatsNoCardClean())
             return
         }
-        val destination = CardInfoDestination(previousCardId, TR.previousCardStudy())
+        val destination = CardInfoDestination(previousCardId, EntryPoint.PREVIOUS_CARD_STUDY)
         Timber.i("Launching 'previous card info' for card %d", previousCardId)
         navigateFlow.emit(destination)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Translations.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Translations.kt
@@ -27,12 +27,3 @@ fun Translations.cardStatsNoCardClean(): String {
     // regex removes any parentheses or dots from the string
     return cardStatsNoCard().replace("[().]".toRegex(), "")
 }
-
-/** Previous Card (Study) */
-fun Translations.previousCardStudy() = cardStatsPreviousCard(decksStudy())
-
-/** Current Card (Browse) */
-fun Translations.currentCardBrowse() = cardStatsCurrentCard(qtMiscBrowse())
-
-/** Current Card (Study) */
-fun Translations.currentCardStudy() = cardStatsCurrentCard(decksStudy())

--- a/anki-common/build.gradle.kts
+++ b/anki-common/build.gradle.kts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import com.android.build.api.dsl.LibraryExtension
+import com.ichi2.anki.gradle.addAnkiBackendDependencies
 
 plugins {
     id("ankidroid.android.library")
@@ -16,6 +17,8 @@ configure<LibraryExtension> {
 dependencies {
     implementation(project(":common"))
     implementation(project(":libanki"))
+
+    addAnkiBackendDependencies(project)
 
     implementation(libs.androidx.activity)
     implementation(libs.androidx.fragment.ktx)

--- a/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/CardInfoDestination.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/CardInfoDestination.kt
@@ -4,9 +4,28 @@
 package com.ichi2.anki.common.destinations
 
 import com.ichi2.anki.libanki.CardId
+import net.ankiweb.rsdroid.Translations
 
-/** Opens the Card Info screen for [cardId], using [title] as the screen title. */
+/**
+ * Opens the Card Info screen for [cardId]. [entryPoint] defines the backend-provided title.
+ */
 data class CardInfoDestination(
     val cardId: CardId,
-    val title: String,
-) : Destination()
+    val entryPoint: EntryPoint,
+) : Destination() {
+    /**
+     * Where the Card Info screen was opened from. Used to obtain the screen title.
+     */
+    enum class EntryPoint(
+        val title: Translations.() -> String,
+    ) {
+        /** Current Card (Study) */
+        CURRENT_CARD_STUDY({ cardStatsCurrentCard(decksStudy()) }),
+
+        /** Current Card (Browse) */
+        CURRENT_CARD_BROWSE({ cardStatsCurrentCard(qtMiscBrowse()) }),
+
+        /** Previous Card (Study) */
+        PREVIOUS_CARD_STUDY({ cardStatsPreviousCard(decksStudy()) }),
+    }
+}

--- a/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/CardInfoDestination.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/CardInfoDestination.kt
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+
+package com.ichi2.anki.common.destinations
+
+import com.ichi2.anki.libanki.CardId
+
+/** Opens the Card Info screen for [cardId], using [title] as the screen title. */
+data class CardInfoDestination(
+    val cardId: CardId,
+    val title: String,
+) : Destination()


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.8 - most

## Purpose / Description
I extracted `CardInfoDestination` to `:anki-common` to decouple it and support multi-module work.

## Fixes
* Related to #20558
* Part of #20737

## Approach
* Extract the class
* Realise that `title` is a leaky abstraction, so replace it with `EntryPoint`
* For this, we needed our first dependency on the Anki backend


## How Has This Been Tested?
API 29 emulator - tested `Current card (browse)`

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)