### PR TITLE
feat(tts): support all installed TTS engines

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AndroidTtsPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AndroidTtsPlayer.kt
@@ -102,6 +102,8 @@ class AndroidTtsPlayer(
         this.scope = scope
         // Eagerly warm the default engine so the common case has no first-play latency.
         // Other engines are created lazily on first use.
+        // TODO(#18737): warming here blocks player readiness on TextToSpeech init; revisit so the
+        //  user does not wait (e.g. warm off the critical path, or make it fully lazy).
         TtsVoices.ttsEngine?.let { defaultEngine -> getOrCreateTts(defaultEngine) }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AndroidTtsPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AndroidTtsPlayer.kt
@@ -32,16 +32,31 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import timber.log.Timber
 import kotlin.coroutines.resume
 
 class AndroidTtsPlayer(
     private val voices: List<TtsVoice>,
+    /** Builds a [TextToSpeech] bound to an engine package. Overridable for testing */
+    private val ttsFactory: suspend (engine: String) -> TextToSpeech? = { engine -> TtsVoices.createTts(engine) },
 ) : TtsPlayer() {
     private lateinit var scope: CoroutineScope
 
-    // this can be null in the case that TTS failed to load
-    private var tts: TextToSpeech? = null
+    /**
+     * [TextToSpeech] instances keyed by engine package name (#18737).
+     *
+     * Lazily populated as voices from new engines are played ([getOrCreateTts]) and disposed of in
+     * [close]. An engine which failed to initialise is absent from the map.
+     */
+    private val ttsByEngine = HashMap<String, TextToSpeech>()
+
+    /** Guards [ttsByEngine] against concurrent initialisation */
+    private val ttsMutex = Mutex()
+
+    /** The engine which is currently (or was most recently) speaking */
+    private var currentTts: TextToSpeech? = null
 
     /** Flyweight pattern for an empty bundle */
     private val bundleFlyweight = Bundle()
@@ -51,44 +66,63 @@ class AndroidTtsPlayer(
     private val cancelledUtterances = HashSet<String>()
     private var currentUtterance: String? = null
 
+    /** Shared across every engine instance: playback is serialized, so a single channel suffices */
+    private val utteranceProgressListener =
+        object : UtteranceProgressListenerCompat() {
+            override fun onStart(utteranceId: String?) {
+                // handle calling .stopPlaying() BEFORE onStart() is called
+                if (cancelledUtterances.remove(utteranceId) && currentUtterance == utteranceId) {
+                    Timber.d("immediately stopped playing %s", utteranceId)
+                    currentTts?.stopPlaying()
+                }
+            }
+
+            override fun onDone(utteranceId: String?) {
+                scope.launch(Dispatchers.IO) { ttsCompletedChannel.send(TtsCompletionStatus.success()) }
+            }
+
+            override fun onStop(
+                utteranceId: String?,
+                interrupted: Boolean,
+            ) {
+                scope.launch(Dispatchers.IO) { ttsCompletedChannel.send(TtsCompletionStatus.stopped()) }
+            }
+
+            override fun onError(
+                utteranceId: String?,
+                errorCode: Int,
+            ) {
+                val error = AndroidTtsError.fromErrorCode(errorCode)
+                scope.launch(Dispatchers.IO) { ttsCompletedChannel.send(TtsCompletionStatus.failure(error)) }
+            }
+        }
+
     suspend fun init(scope: CoroutineScope) {
         this.scope = scope
-        this.tts =
-            TtsVoices.createTts()?.apply {
-                setOnUtteranceProgressListener(
-                    object : UtteranceProgressListenerCompat() {
-                        override fun onStart(utteranceId: String?) {
-                            // handle calling .stopPlaying() BEFORE onStart() is called
-                            if (cancelledUtterances.remove(utteranceId) && currentUtterance == utteranceId) {
-                                Timber.d("immediately stopped playing %s", utteranceId)
-                                stopPlaying()
-                            }
-                        }
-
-                        override fun onDone(utteranceId: String?) {
-                            scope.launch(Dispatchers.IO) { ttsCompletedChannel.send(TtsCompletionStatus.success()) }
-                        }
-
-                        override fun onStop(
-                            utteranceId: String?,
-                            interrupted: Boolean,
-                        ) {
-                            scope.launch(Dispatchers.IO) { ttsCompletedChannel.send(TtsCompletionStatus.stopped()) }
-                        }
-
-                        override fun onError(
-                            utteranceId: String?,
-                            errorCode: Int,
-                        ) {
-                            val error = AndroidTtsError.fromErrorCode(errorCode)
-                            scope.launch(Dispatchers.IO) { ttsCompletedChannel.send(TtsCompletionStatus.failure(error)) }
-                        }
-                    },
-                )
-            }
+        // Eagerly warm the default engine so the common case has no first-play latency.
+        // Other engines are created lazily on first use.
+        TtsVoices.ttsEngine?.let { defaultEngine -> getOrCreateTts(defaultEngine) }
     }
 
     override fun getAvailableVoices(): List<TtsVoice> = this.voices
+
+    /**
+     * Returns a ready [TextToSpeech] bound to [engine], creating and caching one if necessary.
+     *
+     * @return the engine's [TextToSpeech], or `null` if initialisation failed
+     */
+    private suspend fun getOrCreateTts(engine: String): TextToSpeech? =
+        ttsMutex.withLock {
+            ttsByEngine[engine] ?: run {
+                val tts = ttsFactory(engine)?.apply { setOnUtteranceProgressListener(utteranceProgressListener) }
+                if (tts == null) {
+                    Timber.w("Failed to initialize TTS engine: %s", engine)
+                } else {
+                    ttsByEngine[engine] = tts
+                }
+                tts
+            }
+        }
 
     override suspend fun play(tag: TTSTag): TtsCompletionStatus {
         val match = voiceForTag(tag)
@@ -111,19 +145,26 @@ class AndroidTtsPlayer(
     private suspend fun play(
         tag: TTSTag,
         voice: AndroidTtsVoice,
-    ): TtsCompletionStatus =
-        suspendCancellableCoroutine { continuation ->
-            val tts =
-                tts?.also {
-                    it.voice = voice.voice
-                    tag.speed?.let { speed ->
-                        if (it.setSpeechRate(speed) == ERROR) {
-                            return@suspendCancellableCoroutine continuation.resume(AndroidTtsError.SpeechRateFailed)
-                        }
-                    }
-                    // if it's already playing: stop it
-                    it.stopPlaying()
-                } ?: return@suspendCancellableCoroutine continuation.resume(AndroidTtsError.InitFailed)
+    ): TtsCompletionStatus {
+        // route to the engine which owns the voice (#18737)
+        val tts =
+            getOrCreateTts(voice.engine)
+                ?: return TtsCompletionStatus.failure(AndroidTtsError.InitFailed)
+
+        return suspendCancellableCoroutine { continuation ->
+            // QUEUE_FLUSH only flushes the queue of the engine it's called on, so stop any other
+            // engine which may still be speaking to avoid overlapping playback
+            currentTts?.takeIf { it !== tts }?.stopPlaying()
+
+            tts.voice = voice.voice
+            tag.speed?.let { speed ->
+                if (tts.setSpeechRate(speed) == ERROR) {
+                    return@suspendCancellableCoroutine continuation.resume(AndroidTtsError.SpeechRateFailed)
+                }
+            }
+            // if it's already playing: stop it
+            tts.stopPlaying()
+            currentTts = tts
 
             Timber.d("tts text '%s' to be played for locale (%s)", tag.fieldText, tag.lang)
             continuation.ensureActive()
@@ -150,6 +191,7 @@ class AndroidTtsPlayer(
                 )
             }
         }
+    }
 
     companion object {
         private fun TextToSpeech.stopPlaying() {
@@ -170,9 +212,14 @@ class AndroidTtsPlayer(
     }
 
     override fun close() {
-        Timber.d("Disposing of TTS Engine")
-        tts?.stop()
-        tts?.shutdown()
+        Timber.d("Disposing of TTS Engines")
+        // snapshot to avoid concurrent modification if a playback is racing close()
+        for (tts in ttsByEngine.values.toList()) {
+            tts.stop()
+            tts.shutdown()
+        }
+        ttsByEngine.clear()
+        currentTts = null
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AndroidTtsPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AndroidTtsPlayer.kt
@@ -48,9 +48,10 @@ class AndroidTtsPlayer(
      * [TextToSpeech] instances keyed by engine package name (#18737).
      *
      * Lazily populated as voices from new engines are played ([getOrCreateTts]) and disposed of in
-     * [close]. An engine which failed to initialise is absent from the map.
+     * [close]. A present key means the engine was already attempted; a `null` value means it failed
+     * to initialise and is not retried for the rest of the session.
      */
-    private val ttsByEngine = HashMap<String, TextToSpeech>()
+    private val ttsByEngine = HashMap<String, TextToSpeech?>()
 
     /** Guards [ttsByEngine] against concurrent initialisation */
     private val ttsMutex = Mutex()
@@ -113,15 +114,19 @@ class AndroidTtsPlayer(
      */
     private suspend fun getOrCreateTts(engine: String): TextToSpeech? =
         ttsMutex.withLock {
-            ttsByEngine[engine] ?: run {
-                val tts = ttsFactory(engine)?.apply { setOnUtteranceProgressListener(utteranceProgressListener) }
-                if (tts == null) {
-                    Timber.w("Failed to initialize TTS engine: %s", engine)
-                } else {
-                    ttsByEngine[engine] = tts
-                }
-                tts
+            // A present key means the engine was already attempted; a null value means it failed
+            // to initialise and must not be retried again this session
+            if (ttsByEngine.containsKey(engine)) {
+                return@withLock ttsByEngine[engine]
             }
+
+            val tts = ttsFactory(engine)?.apply { setOnUtteranceProgressListener(utteranceProgressListener) }
+            if (tts == null) {
+                Timber.w("Failed to initialize TTS engine: %s", engine)
+            }
+            // cache the result, including a null failure, so a broken engine is not re-initialised
+            ttsByEngine[engine] = tts
+            tts
         }
 
     override suspend fun play(tag: TTSTag): TtsCompletionStatus {
@@ -214,7 +219,8 @@ class AndroidTtsPlayer(
     override fun close() {
         Timber.d("Disposing of TTS Engines")
         // snapshot to avoid concurrent modification if a playback is racing close()
-        for (tts in ttsByEngine.values.toList()) {
+        // values may be null for engines that failed to initialise
+        for (tts in ttsByEngine.values.toList().filterNotNull()) {
             tts.stop()
             tts.shutdown()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/TtsVoices.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/TtsVoices.kt
@@ -157,40 +157,84 @@ object TtsVoices {
     }
 
     /**
-     * Populates [availableLocaleData] with the list of available TTS voices
+     * Populates [availableVoices] and [availableLocaleData] with the voices and locales available
+     * across every installed TTS engine (#18737), not just the user's default engine.
      */
     private suspend fun loadTtsVoicesData() {
-        val tts = createTts()
-        if (tts == null) {
+        // A default-engine instance is needed first to enumerate the installed engines
+        val probeTts = createTts()
+        if (probeTts == null) {
             Timber.e("Unable to build list of TTS Voices")
             availableVoices = emptySet()
             availableLocaleData = emptyList()
             return
         }
 
-        // Samsung TextToSpeech engine returns locales with a displayName of "GBR,DEFAULT"/"GBR,f00"
-        // so normalize them before displaying them to users
-        // sample of problematic data: language = "eng", region = "GBR", variant = "f00"
-        try {
-            // TODO: Handle multiple engines
-            val ttsEngine = tts.defaultEngine
-            availableVoices = tts.voices.map { it.toTtsVoice(ttsEngine) }.toSet()
-            availableLocaleData = tts.availableLanguages.map { it.normalize() }
-        } catch (_: Exception) {
-            availableVoices = emptySet()
-            availableLocaleData = emptyList()
-        } finally {
-            tts.shutdown()
+        val enginePackages =
+            try {
+                // `engines` lists every installed engine; include the default defensively
+                (probeTts.engines.map { it.name } + listOfNotNull(probeTts.defaultEngine)).distinct()
+            } catch (e: Exception) {
+                Timber.w(e, "unable to list TTS engines")
+                listOfNotNull(probeTts.defaultEngine)
+            } finally {
+                probeTts.shutdown()
+            }
+
+        val (voices, locales) = loadVoicesFromEngines(enginePackages) { engine -> createTts(engine) }
+        availableVoices = voices
+        availableLocaleData = locales
+    }
+
+    /**
+     * Loads the voices and locales available across the provided [enginePackages].
+     *
+     * Each engine is initialised independently so a single misbehaving engine cannot prevent the
+     * others from being listed.
+     *
+     * @param createTts builds a [TextToSpeech] bound to the provided engine package, or `null` on failure
+     * @return the union of all voices, and the union of all normalized locales, across [enginePackages]
+     */
+    internal suspend fun loadVoicesFromEngines(
+        enginePackages: List<String>,
+        createTts: suspend (engine: String) -> TextToSpeech?,
+    ): Pair<Set<AndroidTtsVoice>, List<Locale>> {
+        val voices = mutableSetOf<AndroidTtsVoice>()
+        val locales = mutableSetOf<Locale>()
+        for (engine in enginePackages) {
+            val tts = createTts(engine)
+            if (tts == null) {
+                Timber.w("Unable to initialize TTS engine: %s", engine)
+                continue
+            }
+            // Samsung TextToSpeech engine returns locales with a displayName of "GBR,DEFAULT"/"GBR,f00"
+            // so normalize them before displaying them to users
+            // sample of problematic data: language = "eng", region = "GBR", variant = "f00"
+            try {
+                tts.voices?.let { engineVoices ->
+                    voices += engineVoices.map { it.toTtsVoice(engine) }
+                }
+                tts.availableLanguages?.let { engineLocales ->
+                    locales += engineLocales.map { it.normalize() }
+                }
+            } catch (e: Exception) {
+                Timber.w(e, "error reading voices from TTS engine: %s", engine)
+            } finally {
+                tts.shutdown()
+            }
         }
+        return voices to locales.toList()
     }
 
     /**
      * Creates a usable instance of a [TextToSpeech] as a `suspend` function
      *
+     * @param engine the package name of the TTS engine to use, or `null` to use the user's
+     * default engine
      * @return a usable [TextToSpeech] instance, or `null` if the [TextToSpeech.OnInitListener]
      * returns [TextToSpeech.ERROR]
      */
-    suspend fun createTts() =
+    suspend fun createTts(engine: String? = null) =
         suspendCancellableCoroutine { continuation ->
             var textToSpeech: TextToSpeech? = null
             continuation.invokeOnCancellation {
@@ -198,21 +242,30 @@ object TtsVoices {
                 textToSpeech?.stop()
                 textToSpeech?.shutdown()
             }
-            Timber.v("begin TTS creation")
-            textToSpeech =
-                // TextToSpeech retains the context. So we can't give it any context that
-                // may be expected to disappear, as it would cause a memory leak. Hence
-                // we pass it the application as context.
-                TextToSpeech(appContext) { status ->
+            Timber.v("begin TTS creation (engine: %s)", engine)
+            val onInit =
+                TextToSpeech.OnInitListener { status ->
                     if (status == TextToSpeech.SUCCESS) {
-                        Timber.v("TTS creation success")
-                        ttsEngine = textToSpeech?.defaultEngine
+                        Timber.v("TTS creation success (engine: %s)", engine)
+                        // `ttsEngine` tracks the user's default engine only
+                        if (engine == null) {
+                            ttsEngine = textToSpeech?.defaultEngine
+                        }
                         continuation.resume(textToSpeech)
                     } else {
-                        Timber.e("TTS creation failed. status: %d", status)
+                        Timber.e("TTS creation failed. status: %d (engine: %s)", status, engine)
                         textToSpeech?.shutdown()
                         continuation.resume(null)
                     }
+                }
+            // TextToSpeech retains the context. So we can't give it any context that
+            // may be expected to disappear, as it would cause a memory leak. Hence
+            // we pass it the application as context.
+            textToSpeech =
+                if (engine == null) {
+                    TextToSpeech(appContext, onInit)
+                } else {
+                    TextToSpeech(appContext, onInit, engine)
                 }
         }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AndroidTtsPlayerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AndroidTtsPlayerTest.kt
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2026 Ashish Yadav <mailtoashish693@gmail.com>
+
+package com.ichi2.anki
+
+import android.speech.tts.TextToSpeech
+import android.speech.tts.UtteranceProgressListener
+import android.speech.tts.Voice
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.libanki.TTSTag
+import com.ichi2.anki.libanki.TtsPlayer.TtsCompletionStatus
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasItem
+import org.hamcrest.Matchers.not
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Locale
+import kotlin.time.Duration.Companion.milliseconds
+
+/** Test for [AndroidTtsPlayer] */
+@RunWith(AndroidJUnit4::class)
+class AndroidTtsPlayerTest {
+    @Test
+    fun `playback is routed to the engine which owns the voice`() {
+        val test = playerTest()
+
+        val result = test.play(test.voiceB)
+
+        assertThat("playback succeeded", result.success, equalTo(true))
+        // engine B owns the voice: it speaks, engine A is never touched
+        assertThat(test.factoryCalls, hasItem(ENGINE_B))
+        assertThat(test.factoryCalls, not(hasItem(ENGINE_A)))
+        verify(exactly = 1) { test.ttsB.speak(any(), any(), any(), any()) }
+        verify(exactly = 0) { test.ttsA.speak(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `each engine is only created once`() {
+        val test = playerTest()
+
+        test.play(test.voiceB)
+        test.play(test.voiceB)
+
+        // second playback reuses the cached engine instance
+        assertThat(test.factoryCalls.count { it == ENGINE_B }, equalTo(1))
+        verify(exactly = 2) { test.ttsB.speak(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `voices from different engines route to their own engine`() {
+        val test = playerTest()
+
+        test.play(test.voiceB)
+        test.play(test.voiceA)
+
+        assertThat(test.factoryCalls.count { it == ENGINE_A }, equalTo(1))
+        assertThat(test.factoryCalls.count { it == ENGINE_B }, equalTo(1))
+        verify(exactly = 1) { test.ttsB.speak(any(), any(), any(), any()) }
+        verify(exactly = 1) { test.ttsA.speak(any(), any(), any(), any()) }
+    }
+
+    /** Builds a player backed by two engines, each owning a single voice */
+    private fun playerTest(): PlayerTestFixture {
+        val ttsA = fakeTts()
+        val ttsB = fakeTts()
+        val voiceA = AndroidTtsVoice(fakeVoice("voice-a", Locale.forLanguageTag("en-US")), ENGINE_A)
+        val voiceB = AndroidTtsVoice(fakeVoice("voice-b", Locale.forLanguageTag("fr-FR")), ENGINE_B)
+        val factoryCalls = mutableListOf<String>()
+
+        val factory: suspend (String) -> TextToSpeech? = { engine ->
+            factoryCalls.add(engine)
+            when (engine) {
+                ENGINE_A -> ttsA
+                ENGINE_B -> ttsB
+                else -> null
+            }
+        }
+
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        val player = AndroidTtsPlayer(listOf(voiceA, voiceB), factory)
+        runBlocking { player.init(scope) }
+
+        return PlayerTestFixture(player, ttsA, ttsB, voiceA, voiceB, factoryCalls)
+    }
+
+    private class PlayerTestFixture(
+        val player: AndroidTtsPlayer,
+        val ttsA: TextToSpeech,
+        val ttsB: TextToSpeech,
+        val voiceA: AndroidTtsVoice,
+        val voiceB: AndroidTtsVoice,
+        val factoryCalls: MutableList<String>,
+    ) {
+        fun play(voice: AndroidTtsVoice): TtsCompletionStatus =
+            runBlocking {
+                withTimeout(PLAYBACK_TIMEOUT_MS.milliseconds) {
+                    player.play(
+                        TTSTag(
+                            fieldText = "hello world",
+                            lang = voice.lang,
+                            voices = listOf(voice.name),
+                            speed = null,
+                            otherArgs = emptyList(),
+                        ),
+                    )
+                }
+            }
+    }
+
+    /** A relaxed [TextToSpeech] mock whose `speak()` immediately reports completion */
+    private fun fakeTts(): TextToSpeech {
+        val listenerSlot = slot<UtteranceProgressListener>()
+        val utteranceSlot = slot<String>()
+        return mockk(relaxed = true) {
+            every { setOnUtteranceProgressListener(capture(listenerSlot)) } returns TextToSpeech.SUCCESS
+            every { speak(any(), any(), any(), capture(utteranceSlot)) } answers {
+                // drive the player's completion channel so play() returns
+                listenerSlot.captured.onDone(utteranceSlot.captured)
+                TextToSpeech.SUCCESS
+            }
+        }
+    }
+
+    private fun fakeVoice(
+        voiceName: String,
+        voiceLocale: Locale,
+    ): Voice =
+        mockk(relaxed = true) {
+            every { name } returns voiceName
+            every { locale } returns voiceLocale
+            every { features } returns emptySet()
+        }
+
+    companion object {
+        private const val ENGINE_A = "com.example.engine.a"
+        private const val ENGINE_B = "com.example.engine.b"
+        private const val PLAYBACK_TIMEOUT_MS = 5_000L
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AndroidTtsPlayerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AndroidTtsPlayerTest.kt
@@ -69,6 +69,34 @@ class AndroidTtsPlayerTest {
         verify(exactly = 1) { test.ttsA.speak(any(), any(), any(), any()) }
     }
 
+    @Test
+    fun `an engine that fails to initialise is not retried`() {
+        val factoryCalls = mutableListOf<String>()
+        val voice = AndroidTtsVoice(fakeVoice("voice-x", Locale.forLanguageTag("en-US")), ENGINE_FAILING)
+        val factory: suspend (String) -> TextToSpeech? = { engine ->
+            factoryCalls.add(engine)
+            null // this engine always fails to initialise
+        }
+        val player = AndroidTtsPlayer(listOf(voice), factory)
+        runBlocking { player.init(CoroutineScope(SupervisorJob() + Dispatchers.IO)) }
+
+        val tag =
+            TTSTag(
+                fieldText = "hello world",
+                lang = voice.lang,
+                voices = listOf(voice.name),
+                speed = null,
+                otherArgs = emptyList(),
+            )
+        val first = runBlocking { withTimeout(PLAYBACK_TIMEOUT_MS.milliseconds) { player.play(tag) } }
+        val second = runBlocking { withTimeout(PLAYBACK_TIMEOUT_MS.milliseconds) { player.play(tag) } }
+
+        assertThat("first playback fails", first.success, equalTo(false))
+        assertThat("second playback fails", second.success, equalTo(false))
+        // the failed engine is cached and not initialised a second time
+        assertThat(factoryCalls.count { it == ENGINE_FAILING }, equalTo(1))
+    }
+
     /** Builds a player backed by two engines, each owning a single voice */
     private fun playerTest(): PlayerTestFixture {
         val ttsA = fakeTts()
@@ -144,6 +172,7 @@ class AndroidTtsPlayerTest {
     companion object {
         private const val ENGINE_A = "com.example.engine.a"
         private const val ENGINE_B = "com.example.engine.b"
+        private const val ENGINE_FAILING = "com.example.engine.failing"
         private const val PLAYBACK_TIMEOUT_MS = 5_000L
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TtsVoicesMultiEngineTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TtsVoicesMultiEngineTest.kt
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2026 Ashish Yadav <mailtoashish693@gmail.com>
+
+package com.ichi2.anki
+
+import android.speech.tts.TextToSpeech
+import android.speech.tts.Voice
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Locale
+
+/**
+ * Regression tests for #18737: voices should be listed from every installed TTS engine,
+ * not only the user's default engine.
+ *
+ * @see TtsVoices.loadVoicesFromEngines
+ */
+@RunWith(AndroidJUnit4::class)
+class TtsVoicesMultiEngineTest {
+    @Test
+    fun `voices are aggregated across multiple engines`() =
+        runBlocking {
+            val ttsA =
+                fakeTts(
+                    engineVoices = setOf(fakeVoice("a-voice", Locale.forLanguageTag("en-US"))),
+                    engineLanguages = setOf(Locale.forLanguageTag("en-US")),
+                )
+            val ttsB =
+                fakeTts(
+                    engineVoices = setOf(fakeVoice("b-voice", Locale.forLanguageTag("fr-FR"))),
+                    engineLanguages = setOf(Locale.forLanguageTag("fr-FR")),
+                )
+
+            val (voices, _) =
+                TtsVoices.loadVoicesFromEngines(listOf(ENGINE_A, ENGINE_B)) { engine ->
+                    when (engine) {
+                        ENGINE_A -> ttsA
+                        ENGINE_B -> ttsB
+                        else -> null
+                    }
+                }
+
+            // both engines contribute their voices, each tagged with the owning engine
+            assertThat(voices.map { it.engine }.toSet(), equalTo(setOf(ENGINE_A, ENGINE_B)))
+            assertThat(voices.any { it.engine == ENGINE_A && it.voice.name == "a-voice" }, equalTo(true))
+            assertThat(voices.any { it.engine == ENGINE_B && it.voice.name == "b-voice" }, equalTo(true))
+        }
+
+    @Test
+    fun `an engine which fails to initialise is skipped`() =
+        runBlocking {
+            val workingTts =
+                fakeTts(
+                    engineVoices = setOf(fakeVoice("ok-voice", Locale.forLanguageTag("de-DE"))),
+                    engineLanguages = setOf(Locale.forLanguageTag("de-DE")),
+                )
+
+            val (voices, _) =
+                TtsVoices.loadVoicesFromEngines(listOf(ENGINE_A, ENGINE_B)) { engine ->
+                    // ENGINE_A 'fails' to initialise (returns null) and must not abort the scan
+                    if (engine == ENGINE_B) workingTts else null
+                }
+
+            assertThat(voices.map { it.engine }.toSet(), equalTo(setOf(ENGINE_B)))
+        }
+
+    private fun fakeVoice(
+        voiceName: String,
+        voiceLocale: Locale,
+    ): Voice =
+        mockk(relaxed = true) {
+            every { name } returns voiceName
+            every { locale } returns voiceLocale
+            every { features } returns emptySet()
+        }
+
+    private fun fakeTts(
+        engineVoices: Set<Voice>,
+        engineLanguages: Set<Locale>,
+    ): TextToSpeech =
+        mockk(relaxed = true) {
+            every { voices } returns engineVoices
+            every { availableLanguages } returns engineLanguages
+        }
+
+    companion object {
+        private const val ENGINE_A = "com.example.engine.a"
+        private const val ENGINE_B = "com.example.engine.b"
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.8 (all tests and 2nd commit initial iteration/some portion)

<!--- Please fill the necessary details below -->
## Purpose / Description
AnkiDroid only ever talked to the device's default TTS engine. Voices from any other installed engine were never listed and could not be played, so a card using a voice or language that only exists on a non-default engine failed at review time with `APP_MISSING_VOICE` (shown via the TTS playback error dialog), even though a capable engine was installed.

This is common in practice:
* Samsung phones ship a limited default engine but usually have Google TTS installed, whose voices were unreachable.
* Meta Quest gives no usable UI to change the system default engine, so users were locked to whatever was default.


## Fixes
* Fixes #18737

## Approach
Make both voice discovery and the playback engine-aware instead of default-engine-only. 

## How Has This Been Tested?
On Pixel 10 and unit tests

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->