### PR TITLE
fix(stats): recreate statistics and card info on rotation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CardInfoDestination.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CardInfoDestination.kt
@@ -19,10 +19,10 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import com.ichi2.anki.R
-import com.ichi2.anki.SingleFragmentActivity
 import com.ichi2.anki.libanki.CardId
 import com.ichi2.anki.libanki.withoutUnicodeIsolation
 import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.utils.ConfigAwareSingleFragmentActivity
 import com.ichi2.anki.utils.Destination
 
 data class CardInfoDestination(
@@ -44,7 +44,7 @@ data class CardInfoDestination(
                 putString(CardInfoFragment.KEY_TITLE, cardInfoTitle)
                 putLong(CardInfoFragment.KEY_CARD_ID, cardId)
             }
-        return SingleFragmentActivity.getIntent(
+        return ConfigAwareSingleFragmentActivity.getIntent(
             context,
             fragmentClass = CardInfoFragment::class,
             arguments = arguments,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
@@ -130,6 +130,16 @@ class Statistics : PageFragment(R.layout.page_statistics) {
         webViewLayout.evaluateJavascript(javascriptCode, null)
     }
 
+    override fun onCreateWebViewClient(savedInstanceState: Bundle?): PageWebViewClient =
+        super.onCreateWebViewClient(savedInstanceState).apply {
+            onPageFinishedCallbacks.add {
+                val deckName = binding.deckName.text.toString()
+                if (deckName.isNotEmpty()) {
+                    changeDeck(deckName)
+                }
+            }
+        }
+
     companion object {
         private const val KEY_DECK_NAME = "key_deck_name"
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/StatisticsDestination.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/StatisticsDestination.kt
@@ -17,9 +17,10 @@ package com.ichi2.anki.pages
 
 import android.content.Context
 import android.content.Intent
-import com.ichi2.anki.SingleFragmentActivity
+import com.ichi2.anki.utils.ConfigAwareSingleFragmentActivity
 import com.ichi2.anki.utils.Destination
 
 class StatisticsDestination : Destination {
-    override fun toIntent(context: Context): Intent = SingleFragmentActivity.getIntent(context, fragmentClass = Statistics::class)
+    override fun toIntent(context: Context): Intent =
+        ConfigAwareSingleFragmentActivity.getIntent(context, fragmentClass = Statistics::class)
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/pages/StatisticsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/pages/StatisticsTest.kt
@@ -28,8 +28,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
-import com.ichi2.anki.SingleFragmentActivity
 import com.ichi2.anki.dialogs.DeckSelectionDialog
+import com.ichi2.anki.utils.ConfigAwareSingleFragmentActivity
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.Test
 import org.junit.jupiter.api.assertNotNull
@@ -43,7 +43,7 @@ class StatisticsTest : RobolectricTest() {
     fun `shows 'Default' deck when collection is empty`() =
         runTest {
             ActivityScenario
-                .launch<SingleFragmentActivity>(
+                .launch<ConfigAwareSingleFragmentActivity>(
                     StatisticsDestination().toIntent(
                         targetContext,
                     ),
@@ -62,7 +62,7 @@ class StatisticsTest : RobolectricTest() {
             withCol { decks.select(testDeck1) }
             addDeck(testDeckName2)
             ActivityScenario
-                .launch<SingleFragmentActivity>(
+                .launch<ConfigAwareSingleFragmentActivity>(
                     StatisticsDestination().toIntent(
                         targetContext,
                     ),
@@ -84,7 +84,7 @@ class StatisticsTest : RobolectricTest() {
             // the statistics screen doesn't allow the selection of 'All Decks' and filtered decks,
             // also 'Default' deck should be enabled no matter its status(empty/not empty)
             ActivityScenario
-                .launch<SingleFragmentActivity>(StatisticsDestination().toIntent(targetContext))
+                .launch<ConfigAwareSingleFragmentActivity>(StatisticsDestination().toIntent(targetContext))
                 .onActivity { activity ->
                     val statisticsFragment =
                         activity.supportFragmentManager.findFragmentById(R.id.fragment_container)


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
When viewing charts in the Statistics or Card Info screens, tapping on a bar opens a popup tooltip. If the device orientation changes while this popup is active, the popup remains on the screen and goes "out of bounds" instead of updating its position or being dismissed.

## Fixes
* Fixes #18358

## Approach
## Approach
* Switched the hosting activity for `Statistics` and `CardInfoFragment` destinations from `SingleFragmentActivity` to `ConfigAwareSingleFragmentActivity`. Unlike `SingleFragmentActivity`, `ConfigAwareSingleFragmentActivity` recreates on configuration changes (such as device rotation), ensuring the hosting Activity and Fragment are rebuilt and the WebView page is cleanly re-rendered to fit the new screen dimensions.

* Overrode `onCreateWebViewClient` in `Statistics` to re-apply the currently selected deck via `changeDeck` once the WebView finishes loading (using `onPageFinishedCallbacks`) to preserve the user's selected deck across rotation.


## How Has This Been Tested?

### Automated Tests
- Updated and ran the local Robolectric unit tests for the statistics screen:
  `./gradlew :AnkiDroid:testPlayDebugUnitTest --tests "com.ichi2.anki.pages.StatisticsTest"`
  (Tests pass successfully)

### Manual Verification
1. Open the Statistics or Card Info screen.
2. Rotate the device to landscape mode.
3. Tap on a chart bar to display the tooltip popup.
4. Rotate the device back to portrait mode.
5. Verified that the layout re-fits correctly and the out-of-bounds popup is cleared/dismissed.


https://github.com/user-attachments/assets/81a8d3da-3625-4f59-a183-0f2928f593c7


*Configuration: Tested using Robolectric and on an Android Emulator running SDK 33.*

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
