### PR TITLE
refactor: remove 9 duplicated translations from TranslationTest

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -636,6 +636,9 @@ open class CardTemplateEditor : AnkiActivity(R.layout.activity_card_template_edi
             }
 
             binding.bottomNavigation.menu
+                .findItem(R.id.front_edit)
+                .title = TR.notetypesFrontField()
+            binding.bottomNavigation.menu
                 .findItem(R.id.styling_edit)
                 .title = TR.cardTemplatesTemplateStyling()
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -848,6 +848,7 @@ open class Reviewer :
 
         // Anki Desktop Translations
         menu.findItem(R.id.action_flag)?.title = TR.sentenceCase.flagCard
+        menu.findItem(R.id.action_open_deck_options)?.title = TR.sentenceCase.deckOptions
         menu.findItem(R.id.action_reschedule_card).title = TR.sentenceCase.setDueDate
         menu.findItem(R.id.action_card_info)?.title = TR.sentenceCase.cardInfo
         menu.findItem(R.id.action_previous_card_info)?.title = TR.sentenceCase.previousCardInfo

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -286,7 +286,7 @@ class StudyOptionsFragment :
                 menu.findItem(R.id.action_rebuild)?.isVisible = false
                 menu.findItem(R.id.action_empty)?.isVisible = false
                 menu.findItem(R.id.action_custom_study)?.isVisible = true
-                menu.findItem(R.id.action_deck_or_study_options)?.setTitle(R.string.menu__deck_options)
+                menu.findItem(R.id.action_deck_or_study_options)?.title = TR.sentenceCase.deckOptions
             }
             // Don't show custom study icon if congrats shown
             if (currentContentView == CONTENT_CONGRATS) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
@@ -36,6 +36,7 @@ import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.utils.listItemsAndMessage
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.show
@@ -123,6 +124,7 @@ class CongratsPage :
 
         with(view.findViewById<MaterialToolbar>(R.id.toolbar)) {
             inflateMenu(R.menu.congrats)
+            menu.findItem(R.id.action_open_deck_options)?.title = TR.sentenceCase.deckOptions
             setOnMenuItemClickListener { item ->
                 if (item.itemId == R.id.action_open_deck_options) {
                     viewModel.onDeckOptions()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
@@ -199,6 +199,15 @@ class ControlsSettingsFragment :
         findPreference<ControlPreference>(getString(R.string.delete_command_key))?.let {
             it.title = TR.sentenceCase.deleteNote
         }
+        findPreference<ControlPreference>(getString(R.string.answer_again_command_key))?.let {
+            it.title = TR.sentenceCase.answerAgain
+        }
+        findPreference<ControlPreference>(getString(R.string.answer_hard_command_key))?.let {
+            it.title = TR.sentenceCase.answerHard
+        }
+        findPreference<ControlPreference>(getString(R.string.answer_good_command_key))?.let {
+            it.title = TR.sentenceCase.answerGood
+        }
     }
 
     private fun setupNewStudyScreenSettings() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomButtonsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomButtonsSettingsFragment.kt
@@ -55,6 +55,7 @@ class CustomButtonsSettingsFragment : SettingsFragment() {
         findPreference<ListPreference>(getString(R.string.custom_button_card_info_key))?.title = TR.sentenceCase.cardInfo
         findPreference<ListPreference>(getString(R.string.custom_button_bury_key))?.title = TR.studyingBury()
         findPreference<ListPreference>(getString(R.string.custom_button_suspend_key))?.title = TR.studyingSuspend()
+        findPreference<ListPreference>(getString(R.string.custom_button_deck_options_key))?.title = TR.sentenceCase.deckOptions
         findPreference<ListPreference>(getString(R.string.custom_button_mark_card_key))?.title = TR.sentenceCase.markNote
         findPreference<ListPreference>(getString(R.string.custom_button_previous_card_info_key))?.title = TR.sentenceCase.previousCardInfo
         findPreference<ListPreference>(getString(R.string.custom_button_delete_key))?.title = TR.sentenceCase.deleteNote

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/GeneralSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/GeneralSettingsFragment.kt
@@ -21,6 +21,7 @@ import androidx.preference.ListPreference
 import androidx.preference.SwitchPreferenceCompat
 import anki.config.ConfigKey
 import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
 import com.ichi2.anki.common.crashreporting.CrashReportService
@@ -59,6 +60,7 @@ class GeneralSettingsFragment : SettingsFragment() {
         // Represents in the collection's pref "pastePNG" , i.e.
         // whether to convert clipboard uri to png format or not.
         requirePreference<SwitchPreferenceCompat>(R.string.paste_png_key).apply {
+            title = TR.preferencesPasteClipboardImagesAsPng()
             launchCatchingTask { isChecked = withCol { config.getBool(ConfigKey.Bool.PASTE_IMAGES_AS_PNG) } }
             setOnPreferenceChangeListener { newValue ->
                 launchCatchingTask { withCol { config.setBool(ConfigKey.Bool.PASTE_IMAGES_AS_PNG, newValue) } }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
@@ -271,7 +271,7 @@ enum class ViewerAction(
                 SUSPEND_MENU -> TR.studyingSuspend()
                 DELETE -> TR.sentenceCase.deleteNote
                 TOGGLE_WHITEBOARD -> getString(R.string.gesture_toggle_whiteboard)
-                DECK_OPTIONS -> getString(R.string.menu__deck_options)
+                DECK_OPTIONS -> TR.sentenceCase.deckOptions
                 CARD_INFO -> TR.sentenceCase.cardInfo
                 ADD_NOTE -> getString(R.string.menu_add_note)
                 TAG -> getString(R.string.menu_edit_tags)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
@@ -155,6 +155,9 @@ object SentenceCase {
     context(_: Context)
     val deckOptions get() = TR.deckConfigTitle().toSentenceCase(R.string.sentence_deck_options)
 
+    context(_: Fragment)
+    val deckOptions get() = TR.deckConfigTitle().toSentenceCase(R.string.sentence_deck_options)
+
     context(_: Context)
     val deleteDeck get() = TR.decksDeleteDeck().toSentenceCase(R.string.sentence_delete_deck)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
@@ -275,6 +275,16 @@ object SentenceCase {
 
     context(_: Fragment)
     val selectImage get() = TR.notetypesIoSelectImage().toSentenceCase(R.string.sentence_select_image)
+
+    // 'Answer easy' is not provided by the backend
+    context(_: Fragment)
+    val answerAgain get() = TR.deckConfigAnswerAgain().toSentenceCase(R.string.sentence_answer_again)
+
+    context(_: Fragment)
+    val answerHard get() = TR.deckConfigAnswerHard().toSentenceCase(R.string.sentence_answer_hard)
+
+    context(_: Fragment)
+    val answerGood get() = TR.deckConfigAnswerGood().toSentenceCase(R.string.sentence_answer_good)
 }
 
 /**

--- a/AnkiDroid/src/main/res/menu/card_template_editor_navigation_bar_menu.xml
+++ b/AnkiDroid/src/main/res/menu/card_template_editor_navigation_bar_menu.xml
@@ -6,7 +6,7 @@
     <item
         android:id="@+id/front_edit"
         android:icon="@drawable/ic_card_question"
-        android:title="@string/front_field_name" />
+        tools:title="Front" />
     <item
         android:id="@+id/back_edit"
         android:icon="@drawable/ic_card_answer"

--- a/AnkiDroid/src/main/res/menu/congrats.xml
+++ b/AnkiDroid/src/main/res/menu/congrats.xml
@@ -5,11 +5,12 @@
   -->
 
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <item
         android:id="@+id/action_open_deck_options"
-        android:title="@string/menu__deck_options"
+        tools:title="Deck options"
         android:icon="@drawable/ic_tune_white"
         app:showAsAction="ifRoom"/>
 </menu>

--- a/AnkiDroid/src/main/res/menu/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu/reviewer.xml
@@ -204,7 +204,7 @@
     <item
         android:id="@+id/action_open_deck_options"
         android:icon="@drawable/ic_tune_white"
-        android:title="@string/menu__deck_options" />
+        tools:title="Deck options" />
     <item
         android:id="@+id/action_toggle_auto_advance"
         android:icon="@drawable/ic_fast_forward"

--- a/AnkiDroid/src/main/res/menu/study_options_fragment.xml
+++ b/AnkiDroid/src/main/res/menu/study_options_fragment.xml
@@ -30,7 +30,7 @@
     <!-- the title for the following option will be set dynamically -->
     <item
         android:id="@+id/action_deck_or_study_options"
-        android:title="@string/menu__deck_options"
+        tools:title="Deck options"
         android:icon="@drawable/ic_tune_white"
         ankidroid:showAsAction="always"/>
     <item

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -173,7 +173,6 @@
     <string name="export_choice_save_to">Save to</string>
     <string name="export_saving_exported_collection">Saving exported file&#8230;</string>
     <string name="study_options" comment="Name for a preference category in Filtered deck (aka Cram deck, aka Custom study) options" maxLength="28">Options</string>
-    <string name="menu__deck_options" maxLength="28">Deck options</string>
     <string name="menu__study_options" comment="Menu item that opens options for a Filtered deck (aka Cram deck, aka Custom study)">Study options</string>
     <string name="select_tts" maxLength="28">Set TTS language</string>
     <string name="dyn_deck_desc">This is a special deck for studying outside of the normal schedule. Cards will be automatically returned to their original decks after you review them. Deleting this deck from the deck list will return all remaining cards to their original deck.</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -178,8 +178,6 @@
     <string name="pref_cat_reviewer" maxLength="41">Study Screen</string>
     <string name="show_deck_title" maxLength="41">Show deck title</string>
     <string name="accessibility" maxLength="41">Accessibility</string>
-    <!-- Paste clipboard image as png option -->
-    <string name="paste_as_png" maxLength="41">Paste clipboard images as PNG</string>
     <string name="exit_via_double_tap_back" maxLength="41">Press back twice to go back/exit</string>
     <string name="exit_via_double_tap_back_summ">To avoid accidentally leaving the study screen or the app</string>
     <!-- Allow all files in media imports -->

--- a/AnkiDroid/src/main/res/values/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values/11-arrays.xml
@@ -41,10 +41,7 @@
     <string name="html_size_code_xx_large">xx-large</string>
 
     <!-- gestures_labels -->
-    <string name="answer_again" maxLength="41">Answer again</string>
-    <string name="answer_hard" maxLength="41">Answer hard</string>
-    <string name="answer_good" maxLength="41">Answer good</string>
-    <string name="answer_easy" maxLength="41">Answer easy</string>
+    <string name="answer_easy" comment="Match Anki's translations: deckConfigAnswerAgain" maxLength="41">Answer easy</string>
     <string name="gesture_abort_learning" maxLength="41">Close study screen</string>
     <string name="gesture_flag_red" maxLength="41">Toggle red flag</string>
     <string name="gesture_flag_orange" maxLength="41">Toggle orange flag</string>

--- a/AnkiDroid/src/main/res/values/18-standard-models.xml
+++ b/AnkiDroid/src/main/res/values/18-standard-models.xml
@@ -4,6 +4,5 @@
 <resources>
 
     <!--Fields-->
-    <string name="front_field_name" maxLength="28">Front</string>
     <string name="back_field_name" maxLength="28" comment="Name of the back field of a card">Back</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/sentence-case.xml
+++ b/AnkiDroid/src/main/res/values/sentence-case.xml
@@ -88,4 +88,7 @@ undoActionUndone()
     <string name="sentence_select_deck">Select deck</string>
     <string name="sentence_flag_card" maxLength="28">Flag card</string>
     <string name="sentence_select_image" maxLength="41">Select image</string>
+    <string name="sentence_answer_again" maxLength="41">Answer again</string>
+    <string name="sentence_answer_hard" maxLength="41">Answer hard</string>
+    <string name="sentence_answer_good" maxLength="41">Answer good</string>
 </resources>

--- a/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
@@ -116,7 +116,7 @@ TODO: Add a unit test
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_deck_options_key"
-            android:title="@string/menu__deck_options"
+            tools:title="Deck options"
             app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="1"

--- a/AnkiDroid/src/main/res/xml/preferences_general.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_general.xml
@@ -52,7 +52,7 @@
     <PreferenceCategory android:title="@string/pref_cat_editing">
         <SwitchPreferenceCompat
             android:defaultValue="true"
-            android:title="@string/paste_as_png"
+            tools:title="Paste clipboard images as PNG"
             android:maxLength="41"
             android:key="@string/paste_png_key"/>
     </PreferenceCategory>

--- a/AnkiDroid/src/main/res/xml/preferences_reviewer_controls.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewer_controls.xml
@@ -14,22 +14,23 @@
             />
         <com.ichi2.preferences.ReviewerControlPreference
             android:key="@string/answer_again_command_key"
-            android:title="@string/answer_again"
+            tools:title="Answer again"
             android:icon="@drawable/ic_ease_again"
             app:cardSide="answer"
             />
         <com.ichi2.preferences.ReviewerControlPreference
             android:key="@string/answer_hard_command_key"
-            android:title="@string/answer_hard"
+            tools:title="Answer hard"
             android:icon="@drawable/ic_ease_hard"
             app:cardSide="answer"
             />
         <com.ichi2.preferences.ReviewerControlPreference
             android:key="@string/answer_good_command_key"
-            android:title="@string/answer_good"
+            tools:title="Answer good"
             android:icon="@drawable/ic_ease_good"
             app:cardSide="answer"
             />
+        <!-- 'Answer easy' is not provided by the backend -->
         <com.ichi2.preferences.ReviewerControlPreference
             android:key="@string/answer_easy_command_key"
             android:title="@string/answer_easy"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
@@ -334,10 +334,7 @@ class TranslationTest : RobolectricTest() {
                 //                       // TR.mediaCheckCheckMediaAction()
                 //                       // TR.mediaCheckWindowTitle()
                 "Add note", // R.string.menu_add_note | TR.actionsAddNote()
-                "Answer again", // R.string.answer_again | TR.deckConfigAnswerAgain()
                 "Answer buttons", // R.string.answer_buttons | TR.statisticsAnswerButtonsTitle()
-                "Answer good", // R.string.answer_good | TR.deckConfigAnswerGood()
-                "Answer hard", // R.string.answer_hard | TR.deckConfigAnswerHard()
                 "Deck options", // R.string.menu__deck_options | TR.deckConfigTitle()
                 "Follow system", // R.string.theme_follow_system | TR.preferencesThemeFollowSystem()
                 "Manage note types", // R.string.model_browser_label

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
@@ -23,6 +23,7 @@ import com.ichi2.anki.TranslationTest.Companion.BASELINE_CASE_INSENSITIVE_DUPLIC
 import com.ichi2.anki.TranslationTest.Companion.BASELINE_DUPLICATES
 import com.ichi2.testutils.BackendTranslation
 import com.ichi2.testutils.XmlStringResource
+import com.ichi2.testutils.getAndroidManifestStringResourceNames
 import com.ichi2.testutils.getBackendNonArgStrings
 import com.ichi2.testutils.getTranslatableXmlStrings
 import org.junit.Test
@@ -44,9 +45,13 @@ class TranslationTest : RobolectricTest() {
             val backendByTextLower = backendStrings.groupBy { it.text.lowercase() }
             val xmlStrings = getTranslatableXmlStrings()
 
+            // strings referenced from AndroidManifest.xml cannot be converted to use the backend
+            val manifestStringsLower = ANDROID_MANIFEST_STRINGS.mapTo(mutableSetOf()) { it.lowercase() }
+
             val exactDuplicates =
                 xmlStrings
                     .filter { it.text !in BASELINE_DUPLICATES }
+                    .filter { it.text.lowercase() !in manifestStringsLower }
                     .filter { it.text in backendByText }
 
             if (exactDuplicates.isNotEmpty()) {
@@ -62,6 +67,7 @@ class TranslationTest : RobolectricTest() {
                 fail(
                     "${exactDuplicates.size} XML string(s) duplicate a backend translation.\n" +
                         "If caused by a backend update, add to BASELINE_DUPLICATES:\n$entries\n\n" +
+                        "If referenced from AndroidManifest.xml, add to ANDROID_MANIFEST_STRINGS.\n" +
                         "If manually added, use a string from `TR`.",
                 )
             }
@@ -72,6 +78,7 @@ class TranslationTest : RobolectricTest() {
                 xmlStrings
                     .filter { it.text !in BASELINE_DUPLICATES }
                     .filter { it.text.lowercase() !in caseInsensitiveBaseline }
+                    .filter { it.text.lowercase() !in manifestStringsLower }
                     .filter { it.text !in backendByText } // not an exact match
                     .filter { it.text.lowercase() in backendByTextLower }
 
@@ -88,6 +95,7 @@ class TranslationTest : RobolectricTest() {
                 fail(
                     "${caseInsensitiveDuplicates.size} XML string(s) case-insensitively duplicate a backend translation.\n" +
                         "If caused by a backend update, add to BASELINE_CASE_INSENSITIVE_DUPLICATES:\n$entries\n\n" +
+                        "If referenced from AndroidManifest.xml, add to ANDROID_MANIFEST_STRINGS.\n" +
                         "If caused by a manually added XML string, use TR instead of defining a new string resource.",
                 )
             }
@@ -100,7 +108,15 @@ class TranslationTest : RobolectricTest() {
                 BASELINE_CASE_INSENSITIVE_DUPLICATES.filter {
                     it.lowercase() !in xmlTextsLower || it.lowercase() !in backendByTextLower
                 }
-            if (unusedExact.isNotEmpty() || unusedCaseInsensitive.isNotEmpty()) {
+            val manifestXmlTextsLower =
+                xmlStrings
+                    .filter { it.name in getAndroidManifestStringResourceNames() }
+                    .mapTo(mutableSetOf()) { it.text.lowercase() }
+            val unusedManifest =
+                ANDROID_MANIFEST_STRINGS.filter {
+                    it.lowercase() !in manifestXmlTextsLower || it.lowercase() !in backendByTextLower
+                }
+            if (unusedExact.isNotEmpty() || unusedCaseInsensitive.isNotEmpty() || unusedManifest.isNotEmpty()) {
                 val details =
                     buildString {
                         if (unusedExact.isNotEmpty()) {
@@ -110,6 +126,10 @@ class TranslationTest : RobolectricTest() {
                         if (unusedCaseInsensitive.isNotEmpty()) {
                             appendLine("Unused BASELINE_CASE_INSENSITIVE_DUPLICATES (remove these):")
                             unusedCaseInsensitive.sorted().forEach { appendLine("  \"$it\"") }
+                        }
+                        if (unusedManifest.isNotEmpty()) {
+                            appendLine("Unused ANDROID_MANIFEST_STRINGS (remove these):")
+                            unusedManifest.sorted().forEach { appendLine("  \"$it\"") }
                         }
                     }
                 fail(details.trim())
@@ -240,7 +260,6 @@ class TranslationTest : RobolectricTest() {
                 "Good", // R.string.ease_button_good | TR.studyingGood()
                 "Hard", // R.string.ease_button_hard | TR.studyingHard()
                 "Help", // R.string.help | TR.actionsHelp()
-                "Image Occlusion", // R.string.image_occlusion | TR.notetypesImageOcclusionName()
                 "Import", // R.string.menu_import | TR.actionsImport()
                 "Language", // R.string.language | TR.preferencesLanguage()
                 "Later", // R.string.button_backup_later | TR.schedulingUpdateLaterButton()
@@ -333,17 +352,32 @@ class TranslationTest : RobolectricTest() {
                 // "Check media",        // R.string.check_media
                 //                       // TR.mediaCheckCheckMediaAction()
                 //                       // TR.mediaCheckWindowTitle()
-                "Add note", // R.string.menu_add_note | TR.actionsAddNote()
                 "Answer buttons", // R.string.answer_buttons | TR.statisticsAnswerButtonsTitle()
                 "Deck options", // R.string.menu__deck_options | TR.deckConfigTitle()
                 "Follow system", // R.string.theme_follow_system | TR.preferencesThemeFollowSystem()
-                "Manage note types", // R.string.model_browser_label
-                // TR.browsingManageNoteTypes()
-                // TR.qtMiscManageNoteTypes()
                 "Select all", // R.string.card_browser_select_all | TR.editingImageOcclusionSelectAll()
                 "Show answer", // R.string.show_answer
                 // TR.studyingShowAnswer()
                 // TR.deckConfigQuestionActionShowAnswer()
+            )
+
+        /**
+         * English string values which match a [GeneratedTranslations] value, but are referenced
+         * from `AndroidManifest.xml`.
+         *
+         * These cannot be converted until we extract the backend resources at build time/
+         *
+         *
+         * ept for reference, alternate framing of [getAndroidManifestStringResourceNames].
+         *
+         */
+        private val ANDROID_MANIFEST_STRINGS =
+            setOf(
+                "Add note", // R.string.menu_add_note | TR.actionsAddNote()
+                "Image Occlusion", // R.string.image_occlusion | TR.notetypesImageOcclusionName()
+                "Manage note types", // R.string.model_browser_label
+                // TR.browsingManageNoteTypes()
+                // TR.qtMiscManageNoteTypes()
             )
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
@@ -353,7 +353,6 @@ class TranslationTest : RobolectricTest() {
                 //                       // TR.mediaCheckCheckMediaAction()
                 //                       // TR.mediaCheckWindowTitle()
                 "Answer buttons", // R.string.answer_buttons | TR.statisticsAnswerButtonsTitle()
-                "Deck options", // R.string.menu__deck_options | TR.deckConfigTitle()
                 "Follow system", // R.string.theme_follow_system | TR.preferencesThemeFollowSystem()
                 "Select all", // R.string.card_browser_select_all | TR.editingImageOcclusionSelectAll()
                 "Show answer", // R.string.show_answer

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
@@ -253,7 +253,6 @@ class TranslationTest : RobolectricTest() {
                 // TR.changeNotetypeFields()
                 "Flags", // R.string.filter_by_flags | TR.browsingSidebarFlags()
                 "Flip", // R.string.image_cropper_action_flip | TR.cardTemplatesFlip()
-                "Front", // R.string.front_field_name | TR.notetypesFrontField()
                 "General", // R.string.deck_conf_general, R.string.pref_cat_general
                 // TR.preferencesGeneral()
                 // TR.schedulingGeneral()
@@ -287,7 +286,6 @@ class TranslationTest : RobolectricTest() {
                 // TR.actionsOptions()
                 // TR.notetypesOptions()
                 // TR.cardTemplatesPreviewSettings()
-                "Paste clipboard images as PNG", // R.string.paste_as_png | TR.preferencesPasteClipboardImagesAsPng()
                 "Preview", // R.string.card_editor_preview_card
                 // TR.actionsPreview()
                 // TR.cardTemplatesPreviewBox()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
@@ -108,7 +108,7 @@ class DeckPickerContextMenuTest {
                 fragment.assertOptionPresent(R.string.menu_add)
                 fragment.assertOptionPresent(R.string.browse_cards)
                 fragment.assertOptionPresent(TR.sentenceCase.renameDeck)
-                fragment.assertOptionPresent(R.string.menu__deck_options)
+                fragment.assertOptionPresent(TR.sentenceCase.deckOptions)
                 fragment.assertOptionPresent(R.string.export_deck)
                 fragment.assertOptionPresent(R.string.create_shortcut)
                 fragment.assertOptionPresent(TR.sentenceCase.deleteDeck)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
@@ -56,6 +56,7 @@ class SentenceCaseTest : RobolectricTest() {
                     assertThat(TR.sentenceCase.changeDeck, equalTo("Change deck"))
                     assertThat(TR.sentenceCase.toggleMark, equalTo("Toggle mark"))
                     assertThat(TR.sentenceCase.selectImage, equalTo("Select image"))
+                    assertThat(TR.sentenceCase.deckOptions, equalTo("Deck options"))
                     assertThat(TR.sentenceCase.answerAgain, equalTo("Answer again"))
                     assertThat(TR.sentenceCase.answerHard, equalTo("Answer hard"))
                     assertThat(TR.sentenceCase.answerGood, equalTo("Answer good"))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
@@ -56,6 +56,9 @@ class SentenceCaseTest : RobolectricTest() {
                     assertThat(TR.sentenceCase.changeDeck, equalTo("Change deck"))
                     assertThat(TR.sentenceCase.toggleMark, equalTo("Toggle mark"))
                     assertThat(TR.sentenceCase.selectImage, equalTo("Select image"))
+                    assertThat(TR.sentenceCase.answerAgain, equalTo("Answer again"))
+                    assertThat(TR.sentenceCase.answerHard, equalTo("Answer hard"))
+                    assertThat(TR.sentenceCase.answerGood, equalTo("Answer good"))
                 }
             }.close()
 

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TranslationUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TranslationUtils.kt
@@ -59,6 +59,15 @@ fun getBackendNonArgStrings(): List<BackendTranslation> {
 }
 
 /**
+ * Returns the names of the string resources referenced from `AndroidManifest.xml`
+ * (`@string/app_name` -> `app_name`).
+ */
+fun getAndroidManifestStringResourceNames(): Set<String> =
+    Regex("@string/(\\w+)")
+        .findAll(File("src/main/AndroidManifest.xml").readText())
+        .mapTo(mutableSetOf()) { it.groupValues[1] }
+
+/**
  * Parses all translatable XML files from `res/values/` and extracts
  * `<string>` element names and their text values.
  */


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5 - all

## Purpose / Description
Another minor reduction in app size and translator effort

## How Has This Been Tested?
⚠️ Taking this on trust

A subset of these changes was ignoring translations used in the Manifest

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)