### PR TITLE
refactor: replace 'bundleOf' with Bundle()

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateNotetype.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateNotetype.kt
@@ -20,7 +20,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Parcel
 import android.os.Parcelable
-import androidx.core.os.bundleOf
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.annotations.NeedsTest
@@ -55,10 +54,10 @@ class CardTemplateNotetype(
         private set
 
     fun toBundle(): Bundle =
-        bundleOf(
-            INTENT_MODEL_FILENAME to saveTempNoteType(appContext, notetype),
-            "mTemplateChanges" to templateChanges,
-        )
+        Bundle().apply {
+            putString(INTENT_MODEL_FILENAME, saveTempNoteType(appContext, notetype))
+            putSerializable("mTemplateChanges", templateChanges)
+        }
 
     private fun loadTemplateChanges(bundle: Bundle) {
         try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -30,7 +30,6 @@ import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.VisibleForTesting
 import androidx.constraintlayout.widget.Group
-import androidx.core.os.bundleOf
 import androidx.core.text.HtmlCompat
 import androidx.core.text.parseAsHtml
 import androidx.core.view.MenuProvider
@@ -100,7 +99,7 @@ class StudyOptionsFragment :
                 if (currentContentView != CONTENT_CONGRATS) {
                     parentFragmentManager.setFragmentResult(
                         REQUEST_STUDY_OPTIONS_STUDY,
-                        bundleOf(),
+                        Bundle(),
                     )
                 } else {
                     showCustomStudyContextMenu()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -27,7 +27,6 @@ import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.core.app.ActivityCompat
 import androidx.core.os.BundleCompat
-import androidx.core.os.bundleOf
 import androidx.lifecycle.lifecycleScope
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.BackupManager
@@ -736,9 +735,9 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
             Message.obtain().apply {
                 what = this@ShowDatabaseErrorDialog.what
                 data =
-                    bundleOf(
-                        ARG_DIALOG to dialogType,
-                    )
+                    Bundle().apply {
+                        putParcelable(ARG_DIALOG, dialogType)
+                    }
             }
 
         companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EditDeckDescriptionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EditDeckDescriptionDialog.kt
@@ -21,7 +21,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AlertDialog
-import androidx.core.os.bundleOf
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.widget.doAfterTextChanged
@@ -213,9 +212,9 @@ class EditDeckDescriptionDialog : DialogFragment() {
         fun newInstance(deckId: DeckId): EditDeckDescriptionDialog =
             EditDeckDescriptionDialog().apply {
                 arguments =
-                    bundleOf(
-                        EditDeckDescriptionDialogViewModel.ARG_DECK_ID to deckId,
-                    )
+                    Bundle().apply {
+                        putLong(EditDeckDescriptionDialogViewModel.ARG_DECK_ID, deckId)
+                    }
             }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.kt
@@ -19,7 +19,6 @@ package com.ichi2.anki.dialogs
 import android.os.Bundle
 import androidx.annotation.CheckResult
 import androidx.appcompat.app.AlertDialog
-import androidx.core.os.bundleOf
 import com.ichi2.anki.R
 import com.ichi2.anki.dialogs.ImportDialog.Type.DIALOG_IMPORT_ADD_CONFIRM
 import com.ichi2.anki.dialogs.ImportDialog.Type.DIALOG_IMPORT_REPLACE_CONFIRM
@@ -121,10 +120,10 @@ class ImportDialog : AsyncDialogFragment() {
         ): ImportDialog =
             ImportDialog().apply {
                 arguments =
-                    bundleOf(
-                        IMPORT_DIALOG_TYPE_KEY to dialogType.code,
-                        IMPORT_DIALOG_PACKAGE_PATH_KEY to packagePath,
-                    )
+                    Bundle().apply {
+                        putInt(IMPORT_DIALOG_TYPE_KEY, dialogType.code)
+                        putString(IMPORT_DIALOG_PACKAGE_PATH_KEY, packagePath)
+                    }
             }
 
         private fun filenameFromPath(path: String): String = path.split("/").toTypedArray()[path.split("/").toTypedArray().size - 1]

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
@@ -26,7 +26,6 @@ import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.core.os.BundleCompat
-import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.R
@@ -139,7 +138,7 @@ class ImportFileSelectionFragment : DialogFragment() {
 
         fun newInstance(options: ImportOptions) =
             ImportFileSelectionFragment().apply {
-                arguments = bundleOf(ARG_IMPORT_OPTIONS to options)
+                arguments = Bundle().apply { putParcelable(ARG_IMPORT_OPTIONS, options) }
             }
 
         /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/InsertFieldDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/InsertFieldDialog.kt
@@ -25,7 +25,6 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.annotation.CheckResult
 import androidx.annotation.StringRes
-import androidx.core.os.bundleOf
 import androidx.core.text.HtmlCompat
 import androidx.core.text.parseAsHtml
 import androidx.fragment.app.DialogFragment
@@ -114,7 +113,7 @@ class InsertFieldDialog : DialogFragment(R.layout.dialog_insert_field) {
                 if (field == null) return@collect
                 parentFragmentManager.setFragmentResult(
                     requestKey,
-                    bundleOf(KEY_INSERTED_FIELD to field.renderToTemplateTag()),
+                    Bundle().apply { putString(KEY_INSERTED_FIELD, field.renderToTemplateTag()) },
                 )
                 dismiss()
             }
@@ -143,11 +142,11 @@ class InsertFieldDialog : DialogFragment(R.layout.dialog_insert_field) {
         ): InsertFieldDialog =
             InsertFieldDialog().apply {
                 arguments =
-                    bundleOf(
-                        KEY_FIELD_ITEMS to ArrayList(fieldItems),
-                        KEY_INSERT_FIELD_METADATA to metadata,
-                        KEY_REQUEST_KEY to requestKey,
-                    )
+                    Bundle().apply {
+                        putStringArrayList(KEY_FIELD_ITEMS, ArrayList(fieldItems))
+                        putParcelable(KEY_INSERT_FIELD_METADATA, metadata)
+                        putString(KEY_REQUEST_KEY, requestKey)
+                    }
             }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LoadingDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LoadingDialogFragment.kt
@@ -21,7 +21,6 @@ import android.os.Bundle
 import android.widget.TextView
 import androidx.annotation.MainThread
 import androidx.appcompat.app.AlertDialog
-import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.commitNow
 import com.google.android.material.loadingindicator.LoadingIndicator
@@ -65,10 +64,10 @@ class LoadingDialogFragment : DialogFragment() {
             cancellable: Boolean = true,
         ) = LoadingDialogFragment().apply {
             arguments =
-                bundleOf(
-                    KEY_MESSAGE to message,
-                    KEY_CANCELLABLE to cancellable,
-                )
+                Bundle().apply {
+                    putString(KEY_MESSAGE, message)
+                    putBoolean(KEY_CANCELLABLE, cancellable)
+                }
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.kt
@@ -27,7 +27,6 @@ import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
-import androidx.core.os.bundleOf
 import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
@@ -95,7 +94,7 @@ class LocaleSelectionDialog : AnalyticsDialogFragment() {
     private fun sendSelectionResult(locale: Locale? = null) {
         parentFragmentManager.setFragmentResult(
             REQUEST_HINT_LOCALE_SELECTION,
-            bundleOf(KEY_SELECTED_LOCALE to locale),
+            Bundle().apply { putSerializable(KEY_SELECTED_LOCALE, locale) },
         )
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/NoteTypeFieldEditorContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/NoteTypeFieldEditorContextMenu.kt
@@ -8,7 +8,6 @@ import android.os.Bundle
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
-import androidx.core.os.bundleOf
 import com.ichi2.anki.NoteTypeFieldEditor
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
@@ -49,7 +48,7 @@ class NoteTypeFieldEditorContextMenu : AnalyticsDialogFragment() {
 
         fun newInstance(label: String): NoteTypeFieldEditorContextMenu =
             NoteTypeFieldEditorContextMenu().apply {
-                arguments = bundleOf(KEY_LABEL to label)
+                arguments = Bundle().apply { putString(KEY_LABEL, label) }
             }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SaveBrowserSearchDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SaveBrowserSearchDialogFragment.kt
@@ -18,7 +18,6 @@ package com.ichi2.anki.dialogs
 import android.app.Dialog
 import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
-import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.setFragmentResult
@@ -65,10 +64,10 @@ class SaveBrowserSearchDialogFragment : DialogFragment() {
                 Timber.d("Saving user search: %s with given name %s", searchQuery, name)
                 setFragmentResult(
                     REQUEST_SAVE_SEARCH,
-                    bundleOf(
-                        ARG_SEARCH_QUERY to searchQuery,
-                        ARG_SEARCH_QUERY_NAME to name,
-                    ),
+                    Bundle().apply {
+                        putString(ARG_SEARCH_QUERY, searchQuery)
+                        putCharSequence(ARG_SEARCH_QUERY_NAME, name)
+                    },
                 )
                 dialog.dismiss()
             }
@@ -90,9 +89,9 @@ class SaveBrowserSearchDialogFragment : DialogFragment() {
         fun newInstance(searchQuery: String): SaveBrowserSearchDialogFragment =
             SaveBrowserSearchDialogFragment().apply {
                 arguments =
-                    bundleOf(
-                        ARG_SEARCH_QUERY to searchQuery,
-                    )
+                    Bundle().apply {
+                        putString(ARG_SEARCH_QUERY, searchQuery)
+                    }
             }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SavedBrowserSearchesDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SavedBrowserSearchesDialogFragment.kt
@@ -19,7 +19,6 @@ import android.app.Dialog
 import android.os.Bundle
 import android.view.ViewGroup
 import androidx.appcompat.app.AlertDialog
-import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.CardBrowser
@@ -64,10 +63,10 @@ class SavedBrowserSearchesDialogFragment : AnalyticsDialogFragment() {
                     Timber.d("Saved search clicked: %s", searchName)
                     parentFragmentManager.setFragmentResult(
                         REQUEST_SAVED_SEARCH_ACTION,
-                        bundleOf(
-                            ARG_TYPE to TYPE_SEARCH_SELECTED,
-                            ARG_SAVED_SEARCH to searchName,
-                        ),
+                        Bundle().apply {
+                            putInt(ARG_TYPE, TYPE_SEARCH_SELECTED)
+                            putString(ARG_SAVED_SEARCH, searchName)
+                        },
                     )
                     dismiss()
                 },
@@ -90,10 +89,10 @@ class SavedBrowserSearchesDialogFragment : AnalyticsDialogFragment() {
             positiveButton(android.R.string.ok) {
                 parentFragmentManager.setFragmentResult(
                     REQUEST_SAVED_SEARCH_ACTION,
-                    bundleOf(
-                        ARG_TYPE to TYPE_SEARCH_REMOVED,
-                        ARG_SAVED_SEARCH to searchName,
-                    ),
+                    Bundle().apply {
+                        putInt(ARG_TYPE, TYPE_SEARCH_REMOVED)
+                        putString(ARG_SAVED_SEARCH, searchName)
+                    },
                 )
                 dialog?.dismiss() // Dismiss the root dialog
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
@@ -332,8 +332,8 @@ class SyncErrorDialog : AsyncDialogFragment() {
     }
 
     class SyncErrorDialogMessageHandler(
-        private val dialogType: Type,
-        private val dialogMessage: String?,
+        val dialogType: Type,
+        val dialogMessage: String?,
     ) : DialogHandlerMessage(WhichDialogHandler.MSG_SHOW_SYNC_ERROR_DIALOG, "SyncErrorDialog") {
         override fun handleAsyncMessage(activity: AnkiActivity) {
             // we may be called via any AnkiActivity but media check is a DeckPicker thing
@@ -347,7 +347,7 @@ class SyncErrorDialog : AsyncDialogFragment() {
                 what = this@SyncErrorDialogMessageHandler.what
                 data =
                     Bundle().apply {
-                        putSerializable(SYNC_ERROR_DIALOG_TYPE_KEY, dialogType)
+                        putInt(SYNC_ERROR_DIALOG_TYPE_KEY, dialogType.code)
                         putString(DIALOG_MESSAGE_KEY, dialogMessage)
                     }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
@@ -21,7 +21,6 @@ import android.os.Bundle
 import android.os.Message
 import androidx.annotation.CheckResult
 import androidx.appcompat.app.AlertDialog
-import androidx.core.os.bundleOf
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.ConflictResolution
@@ -325,10 +324,10 @@ class SyncErrorDialog : AsyncDialogFragment() {
             dialogMessage: String?,
         ) = SyncErrorDialog().apply {
             arguments =
-                bundleOf(
-                    SYNC_ERROR_DIALOG_TYPE_KEY to dialogType.code,
-                    DIALOG_MESSAGE_KEY to dialogMessage,
-                )
+                Bundle().apply {
+                    putInt(SYNC_ERROR_DIALOG_TYPE_KEY, dialogType.code)
+                    putString(DIALOG_MESSAGE_KEY, dialogMessage)
+                }
         }
     }
 
@@ -347,10 +346,10 @@ class SyncErrorDialog : AsyncDialogFragment() {
             Message.obtain().apply {
                 what = this@SyncErrorDialogMessageHandler.what
                 data =
-                    bundleOf(
-                        SYNC_ERROR_DIALOG_TYPE_KEY to dialogType,
-                        DIALOG_MESSAGE_KEY to dialogMessage,
-                    )
+                    Bundle().apply {
+                        putSerializable(SYNC_ERROR_DIALOG_TYPE_KEY, dialogType)
+                        putString(DIALOG_MESSAGE_KEY, dialogMessage)
+                    }
             }
 
         companion object {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/SyncErrorDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/SyncErrorDialogTest.kt
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.dialogs
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.dialogs.SyncErrorDialog.SyncErrorDialogMessageHandler
+import com.ichi2.anki.dialogs.SyncErrorDialog.Type
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SyncErrorDialogTest {
+    @Test
+    fun `SyncErrorDialogMessageHandler serialization`() {
+        val handler = SyncErrorDialogMessageHandler(Type.DIALOG_MEDIA_SYNC_ERROR, "message")
+        val message = handler.toMessage()
+        val deserialized = SyncErrorDialogMessageHandler.fromMessage(message)
+        assertThat(deserialized.dialogType, equalTo(Type.DIALOG_MEDIA_SYNC_ERROR))
+        assertThat(deserialized.dialogMessage, equalTo("message"))
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5 - all

## Fixes
* Another round for https://github.com/ankidroid/Anki-Android/pull/21219 
  * split out for easier reviews

## How Has This Been Tested?

Manually tested each mentioned dialog, all appears to work as expected.

API 29 phone emulator


> [!NOTE]
> Claude provided these patches for a couple of dialogs

```patch
Index: AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt	(revision c0160171de22ba74c2bb57ef850cf2d10ac5e489)
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt	(date 1781123082588)
@@ -15,6 +15,8 @@
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.databinding.ActivityHomescreenBinding
 import com.ichi2.anki.databinding.IncludeFloatingAddButtonBinding
+import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType
+import com.ichi2.anki.dialogs.DatabaseErrorDialog.ShowDatabaseErrorDialog
 import com.ichi2.anki.ui.DoubleTapListener
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import timber.log.Timber
@@ -407,7 +409,10 @@
      * @see DeckPicker.addNote
      */
     private fun addNote() {
-        deckPicker.addNote()
+        // TEMP DEBUG: trigger the ShowDatabaseErrorDialog Message path instead of adding a note
+        deckPicker.dialogHandler.sendMessage(
+            ShowDatabaseErrorDialog(DatabaseErrorDialogType.DIALOG_DB_ERROR).toMessage(),
+        )
     }
 
     /**
```

```patch
 Index: AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt	(revision c0160171de22ba74c2bb57ef850cf2d10ac5e489)
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt	(date 1781123243579)
@@ -15,6 +15,8 @@
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.databinding.ActivityHomescreenBinding
 import com.ichi2.anki.databinding.IncludeFloatingAddButtonBinding
+import com.ichi2.anki.dialogs.SyncErrorDialog
+import com.ichi2.anki.dialogs.SyncErrorDialog.SyncErrorDialogMessageHandler
 import com.ichi2.anki.ui.DoubleTapListener
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import timber.log.Timber
@@ -407,7 +409,10 @@
      * @see DeckPicker.addNote
      */
     private fun addNote() {
-        deckPicker.addNote()
+        // TEMP DEBUG: trigger the SyncErrorDialogMessageHandler Message path instead of adding a note
+        deckPicker.dialogHandler.sendMessage(
+            SyncErrorDialogMessageHandler(SyncErrorDialog.Type.DIALOG_MEDIA_SYNC_ERROR, "sent via toMessage()").toMessage(),
+        )
     }
 
     /**

```

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)