### PR TITLE
refactor: encapsulate `R.string.sentence_` references into `SentenceCase.kt`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/FindAndReplaceDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/FindAndReplaceDialogFragment.kt
@@ -45,7 +45,7 @@ import com.ichi2.anki.databinding.FragmentFindReplaceBinding
 import com.ichi2.anki.libanki.NoteId
 import com.ichi2.anki.notetype.ManageNotetypes
 import com.ichi2.anki.snackbar.showSnackbar
-import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.anki.utils.openUrl
 import com.ichi2.utils.customView
@@ -84,7 +84,7 @@ class FindAndReplaceDialogFragment : AnalyticsDialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         binding = FragmentFindReplaceBinding.inflate(layoutInflater)
         setupLabels()
-        val title = TR.browsingFindAndReplace().toSentenceCase(R.string.sentence_find_and_replace)
+        val title = TR.sentenceCase.findAndReplace
         return AlertDialog
             .Builder(requireContext())
             .show {
@@ -129,7 +129,7 @@ class FindAndReplaceDialogFragment : AnalyticsDialogFragment() {
             binding.onlySelectedNotesCheckBox.isEnabled = noteIds.isNotEmpty()
             val fieldsNames =
                 buildList {
-                    add(TR.browsingAllFields().toSentenceCase(R.string.sentence_all_fields))
+                    add(TR.sentenceCase.allFields)
                     add(TR.editingTags())
                     addAll(withCol { fieldNamesForNoteIds(noteIds) })
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/RepositionCardFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/RepositionCardFragment.kt
@@ -28,7 +28,7 @@ import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.databinding.FragmentRepositionCardBinding
-import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.utils.create
 import com.ichi2.utils.customView
 import com.ichi2.utils.negativeButton
@@ -74,7 +74,7 @@ class RepositionCardFragment : DialogFragment() {
             text = TR.browsingShiftPositionOfExistingCards()
             isChecked = requireArguments().getBoolean(ARG_SHIFT)
         }
-        val title = TR.browsingRepositionNewCards().toSentenceCase(R.string.sentence_reposition_new_cards)
+        val title = TR.sentenceCase.repositionNewCards
         val dialog =
             AlertDialog.Builder(requireContext()).create {
                 title(text = title)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -67,7 +67,6 @@ import com.ichi2.anki.requireAnkiActivity
 import com.ichi2.anki.servicelayer.DebugInfoService
 import com.ichi2.anki.showImportDialog
 import com.ichi2.anki.ui.internationalization.sentenceCase
-import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
 import com.ichi2.utils.UiUtil.makeBold
 import com.ichi2.utils.cancelable
@@ -641,7 +640,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                 DIALOG_REPAIR_COLLECTION -> res().getString(R.string.dialog_positive_repair)
                 DIALOG_RESTORE_BACKUP -> res().getString(R.string.backup_restore)
                 DIALOG_NEW_COLLECTION -> res().getString(R.string.backup_new_collection)
-                DIALOG_CONFIRM_DATABASE_CHECK -> TR.databaseCheckTitle().toSentenceCase(res(), R.string.sentence_check_db)
+                DIALOG_CONFIRM_DATABASE_CHECK -> TR.sentenceCase.checkDatabase
                 DIALOG_CONFIRM_RESTORE_BACKUP -> res().getString(R.string.restore_backup_title)
                 DIALOG_ONE_WAY_SYNC_FROM_SERVER -> res().getString(R.string.backup_one_way_sync_from_server)
                 DIALOG_DB_LOCKED -> res().getString(R.string.database_locked_title)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/GradeNowDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/GradeNowDialog.kt
@@ -33,7 +33,7 @@ import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.CardId
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.snackbar.showSnackbar
-import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.undoAndShowSnackbar
 import com.ichi2.anki.utils.ext.setCompoundDrawablesRelativeWithIntrinsicBoundsKt
 import com.ichi2.anki.withProgress
@@ -68,7 +68,7 @@ object GradeNowDialog {
         val adapter = GradeNowListAdapter(context, Grade.entries)
 
         MaterialAlertDialogBuilder(context).show {
-            title(text = TR.actionsGradeNow().toSentenceCase(context, R.string.sentence_grade_now))
+            title(text = with(context) { TR.sentenceCase.gradeNow })
             negativeButton(R.string.dialog_cancel)
             setAdapter(adapter) { dialog, which ->
                 val selectedGrade = adapter.getItem(which)!!

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -57,7 +57,6 @@ import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.internationalization.sentenceCase
-import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
 import com.ichi2.anki.utils.ext.getIntOrNull
 import com.ichi2.anki.utils.ext.sharedPrefs
@@ -322,7 +321,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
         }
         val positiveBtnLabel =
             if (contextMenuOption == STUDY_TAGS) {
-                TR.customStudyChooseTags().toSentenceCase(R.string.sentence_choose_tags)
+                TR.sentenceCase.chooseTags
             } else {
                 getString(R.string.dialog_ok)
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/TagLimitFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/TagLimitFragment.kt
@@ -31,7 +31,7 @@ import com.ichi2.anki.dialogs.customstudy.IncludedExcludedTagsAdapter.TagsSelect
 import com.ichi2.anki.dialogs.customstudy.IncludedExcludedTagsAdapter.TagsSelectionMode.Include
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.snackbar.showSnackbar
-import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.utils.customView
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
@@ -76,14 +76,10 @@ class TagLimitFragment : DialogFragment() {
             }
         binding.excludeLabel.text =
             TR.customStudySelectTagsToExclude()
-        val title =
-            TR
-                .customStudySelectiveStudy()
-                .toSentenceCase(R.string.sentence_selective_study)
         val dialog =
             AlertDialog
                 .Builder(requireContext())
-                .title(text = title)
+                .title(text = TR.sentenceCase.selectiveStudy)
                 .customView(binding.root)
                 .negativeButton(R.string.dialog_cancel)
                 .positiveButton(R.string.dialog_ok, null)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/mediacheck/MediaCheckFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/mediacheck/MediaCheckFragment.kt
@@ -39,7 +39,6 @@ import com.ichi2.anki.SingleFragmentActivity
 import com.ichi2.anki.databinding.FragmentMediaCheckBinding
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.ui.internationalization.sentenceCase
-import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.withProgress
 import com.ichi2.utils.cancelable
 import com.ichi2.utils.message
@@ -110,7 +109,7 @@ class MediaCheckFragment : Fragment(R.layout.fragment_media_check) {
                     }
                     menu.findItem(R.id.action_empty_trash).apply {
                         isVisible = true
-                        title = TR.mediaCheckEmptyTrash().toSentenceCase(R.string.sentence_empty_trash)
+                        title = TR.sentenceCase.emptyTrash
                     }
                 }
 
@@ -150,10 +149,7 @@ class MediaCheckFragment : Fragment(R.layout.fragment_media_check) {
     private fun setupButtonListeners() {
         binding.tagMissingMediaButton.apply {
             // mediaCheckAddTag => "Tag Missing"
-            text =
-                TR
-                    .mediaCheckAddTag()
-                    .toSentenceCase(R.string.sentence_tag_missing)
+            text = TR.sentenceCase.tagMissing
 
             setOnClickListener {
                 launchCatchingTask {
@@ -169,7 +165,7 @@ class MediaCheckFragment : Fragment(R.layout.fragment_media_check) {
         }
 
         binding.deleteUsedMediaButton.apply {
-            text = TR.mediaCheckDeleteUnused().toSentenceCase(R.string.sentence_check_media_delete_unused)
+            text = TR.sentenceCase.checkMediaDeleteUnused
 
             setOnClickListener {
                 deleteConfirmationDialog()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CardInfoDestination.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CardInfoDestination.kt
@@ -6,18 +6,16 @@ package com.ichi2.anki.pages
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import androidx.annotation.StringRes
 import com.ichi2.anki.CollectionManager.TR
-import com.ichi2.anki.R
 import com.ichi2.anki.SingleFragmentActivity
 import com.ichi2.anki.common.destinations.CardInfoDestination
 import com.ichi2.anki.common.destinations.CardInfoDestination.EntryPoint
 import com.ichi2.anki.libanki.withoutUnicodeIsolation
-import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.ui.internationalization.sentenceCase
 
 /** Builds the [Intent] that opens the card info screen for this destination. */
 fun CardInfoDestination.toIntent(context: Context): Intent {
-    val title = entryPoint.title(TR).toCardInfoTitle(context, entryPoint.sentenceCaseResId)
+    val title = entryPoint.toCardInfoTitle(context)
     val arguments =
         Bundle().apply {
             putString(CardInfoFragment.KEY_TITLE, title)
@@ -30,28 +28,23 @@ fun CardInfoDestination.toIntent(context: Context): Intent {
     )
 }
 
-/** The sentence case resource matching this entry point's backend [EntryPoint.title]. */
-@get:StringRes
-private val EntryPoint.sentenceCaseResId: Int
-    get() =
-        when (this) {
-            EntryPoint.CURRENT_CARD_STUDY -> R.string.sentence_card_stats_current_card_study
-            EntryPoint.CURRENT_CARD_BROWSE -> R.string.sentence_card_stats_current_card_browse
-            EntryPoint.PREVIOUS_CARD_STUDY -> R.string.sentence_card_stats_previous_card_study
-        }
-
 /**
- * Converts a backend card-stats title to AnkiDroid's sentence-cased form when it matches [resId].
- *
- * @see toSentenceCase
+ * Converts a backend card-stats title to AnkiDroid's sentence-cased form when it matches the
+ * entry point's sentence-case resource.
  */
-private fun String.toCardInfoTitle(
-    context: Context,
-    @StringRes resId: Int,
-): String {
+// TODO: Move this into EntryPoint once sentenceCase is in anki-common
+private fun EntryPoint.toCardInfoTitle(context: Context): String {
+    val title = this.title(TR)
     // The title contains FSI and PDI character types - these need to be stripped for the comparison
-    val simplifiedTitle = withoutUnicodeIsolation(this)
-    val sentenceCased = simplifiedTitle.toSentenceCase(context, resId)
+    val simplifiedTitle = withoutUnicodeIsolation(title)
+    val sentenceCased =
+        with(context) {
+            when (this@toCardInfoTitle) {
+                EntryPoint.CURRENT_CARD_STUDY -> TR.sentenceCase.cardStatsCurrentCardStudy(simplifiedTitle)
+                EntryPoint.CURRENT_CARD_BROWSE -> TR.sentenceCase.cardStatsCurrentCardBrowse(simplifiedTitle)
+                EntryPoint.PREVIOUS_CARD_STUDY -> TR.sentenceCase.cardStatsPreviousCardStudy(simplifiedTitle)
+            }
+        }
     // Do not return the stripped title if there's no match
-    return if (sentenceCased != simplifiedTitle) sentenceCased else this
+    return if (sentenceCased != simplifiedTitle) sentenceCased else title
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
@@ -36,7 +36,6 @@ import com.ichi2.anki.reviewer.MappableAction
 import com.ichi2.anki.reviewer.MappableBinding.Companion.toPreferenceString
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ui.internationalization.sentenceCase
-import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.utils.ext.sharedPrefs
 import com.ichi2.preferences.ControlPreference
 import com.ichi2.preferences.ReviewerControlPreference
@@ -146,31 +145,31 @@ class ControlsSettingsFragment :
             it.dialogTitle = preferenceTitle
         }
         findPreference<ControlPreference>(getString(R.string.toggle_whiteboard_command_key))?.let {
-            it.title = getString(R.string.gesture_toggle_whiteboard).toSentenceCase(R.string.sentence_gesture_toggle_whiteboard)
+            it.title = TR.sentenceCase.gestureToggleWhiteboard(getString(R.string.gesture_toggle_whiteboard))
         }
         findPreference<ControlPreference>(getString(R.string.flag_red_command_key))?.let {
-            it.title = getString(R.string.gesture_flag_red).toSentenceCase(R.string.sentence_gesture_flag_red)
+            it.title = TR.sentenceCase.gestureFlagRed(getString(R.string.gesture_flag_red))
         }
         findPreference<ControlPreference>(getString(R.string.flag_orange_command_key))?.let {
-            it.title = getString(R.string.gesture_flag_orange).toSentenceCase(R.string.sentence_gesture_flag_orange)
+            it.title = TR.sentenceCase.gestureFlagOrange(getString(R.string.gesture_flag_orange))
         }
         findPreference<ControlPreference>(getString(R.string.flag_green_command_key))?.let {
-            it.title = getString(R.string.gesture_flag_green).toSentenceCase(R.string.sentence_gesture_flag_green)
+            it.title = TR.sentenceCase.gestureFlagGreen(getString(R.string.gesture_flag_green))
         }
         findPreference<ControlPreference>(getString(R.string.flag_blue_command_key))?.let {
-            it.title = getString(R.string.gesture_flag_blue).toSentenceCase(R.string.sentence_gesture_flag_blue)
+            it.title = TR.sentenceCase.gestureFlagBlue(getString(R.string.gesture_flag_blue))
         }
         findPreference<ControlPreference>(getString(R.string.flag_pink_command_key))?.let {
-            it.title = getString(R.string.gesture_flag_pink).toSentenceCase(R.string.sentence_gesture_flag_pink)
+            it.title = TR.sentenceCase.gestureFlagPink(getString(R.string.gesture_flag_pink))
         }
         findPreference<ControlPreference>(getString(R.string.flag_turquoise_command_key))?.let {
-            it.title = getString(R.string.gesture_flag_turquoise).toSentenceCase(R.string.sentence_gesture_flag_turquoise)
+            it.title = TR.sentenceCase.gestureFlagTurquoise(getString(R.string.gesture_flag_turquoise))
         }
         findPreference<ControlPreference>(getString(R.string.flag_purple_command_key))?.let {
-            it.title = getString(R.string.gesture_flag_purple).toSentenceCase(R.string.sentence_gesture_flag_purple)
+            it.title = TR.sentenceCase.gestureFlagPurple(getString(R.string.gesture_flag_purple))
         }
         findPreference<ControlPreference>(getString(R.string.remove_flag_command_key))?.let {
-            it.title = getString(R.string.gesture_flag_remove).toSentenceCase(R.string.sentence_gesture_flag_remove)
+            it.title = TR.sentenceCase.gestureFlagRemove(getString(R.string.gesture_flag_remove))
         }
         findPreference<ControlPreference>(getString(R.string.bury_card_command_key))?.let {
             it.title = TR.sentenceCase.buryCard

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/ForgetCardsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/ForgetCardsDialog.kt
@@ -114,7 +114,6 @@ class ForgetCardsDialog : DialogFragment() {
 
         return MaterialAlertDialogBuilder(requireContext()).create {
             // BUG: this is 'Reset Card'/'Forget Card' in Anki Desktop (24.04)
-            // title(text = TR.actionsForgetCard().toSentenceCase(R.string.sentence_forget_cards))
             // "Reset card progress" is less explicit on the singular/plural dimension
             titleWithHelpIcon(stringRes = R.string.reset_card_dialog_title) {
                 requireContext().openUrl(R.string.link_help_forget_cards)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
@@ -111,6 +111,9 @@ object SentenceCase {
     context(_: Fragment)
     val emptyTrash get() = TR.mediaCheckEmptyTrash().toSentenceCase(R.string.sentence_empty_trash)
 
+    context(_: Context)
+    val gradeNow get() = TR.actionsGradeNow().toSentenceCase(R.string.sentence_grade_now)
+
     context(_: Fragment)
     val gradeNow get() = TR.actionsGradeNow().toSentenceCase(R.string.sentence_grade_now)
 
@@ -288,6 +291,67 @@ object SentenceCase {
 
     context(_: Fragment)
     val answerGood get() = TR.deckConfigAnswerGood().toSentenceCase(R.string.sentence_answer_good)
+
+    context(_: Fragment)
+    val selectiveStudy get() = TR.customStudySelectiveStudy().toSentenceCase(R.string.sentence_selective_study)
+
+    context(_: Fragment)
+    val chooseTags get() = TR.customStudyChooseTags().toSentenceCase(R.string.sentence_choose_tags)
+
+    context(_: Fragment)
+    val repositionNewCards get() = TR.browsingRepositionNewCards().toSentenceCase(R.string.sentence_reposition_new_cards)
+
+    context(_: Context)
+    val allFields get() = TR.browsingAllFields().toSentenceCase(R.string.sentence_all_fields)
+
+    context(_: Fragment)
+    val allFields get() = TR.browsingAllFields().toSentenceCase(R.string.sentence_all_fields)
+
+    context(_: Fragment)
+    val tagMissing get() = TR.mediaCheckAddTag().toSentenceCase(R.string.sentence_tag_missing)
+
+    context(_: Fragment)
+    val checkMediaDeleteUnused get() = TR.mediaCheckDeleteUnused().toSentenceCase(R.string.sentence_check_media_delete_unused)
+
+    // gesture preference titles: the (localized) title is provided by the caller; only the
+    // sentence-case resource is owned here.
+    // TODO: These AnkiDroid resources should be fixed
+    context(_: Fragment)
+    fun gestureToggleWhiteboard(title: String) = title.toSentenceCase(R.string.sentence_gesture_toggle_whiteboard)
+
+    context(_: Fragment)
+    fun gestureFlagRed(title: String) = title.toSentenceCase(R.string.sentence_gesture_flag_red)
+
+    context(_: Fragment)
+    fun gestureFlagOrange(title: String) = title.toSentenceCase(R.string.sentence_gesture_flag_orange)
+
+    context(_: Fragment)
+    fun gestureFlagGreen(title: String) = title.toSentenceCase(R.string.sentence_gesture_flag_green)
+
+    context(_: Fragment)
+    fun gestureFlagBlue(title: String) = title.toSentenceCase(R.string.sentence_gesture_flag_blue)
+
+    context(_: Fragment)
+    fun gestureFlagPink(title: String) = title.toSentenceCase(R.string.sentence_gesture_flag_pink)
+
+    context(_: Fragment)
+    fun gestureFlagTurquoise(title: String) = title.toSentenceCase(R.string.sentence_gesture_flag_turquoise)
+
+    context(_: Fragment)
+    fun gestureFlagPurple(title: String) = title.toSentenceCase(R.string.sentence_gesture_flag_purple)
+
+    context(_: Fragment)
+    fun gestureFlagRemove(title: String) = title.toSentenceCase(R.string.sentence_gesture_flag_remove)
+
+    // card stats window titles: the (localized) title is provided by the caller.
+    context(_: Context)
+    fun cardStatsCurrentCardStudy(title: String) = title.toSentenceCase(R.string.sentence_card_stats_current_card_study)
+
+    context(_: Context)
+    fun cardStatsCurrentCardBrowse(title: String) = title.toSentenceCase(R.string.sentence_card_stats_current_card_browse)
+
+    context(_: Context)
+    fun cardStatsPreviousCardStudy(title: String) = title.toSentenceCase(R.string.sentence_card_stats_previous_card_study)
 }
 
 /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -99,7 +99,7 @@ import com.ichi2.anki.servicelayer.PreferenceUpgradeService
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService.PreferenceUpgrade.UpgradeBrowserColumns.Companion.LEGACY_COLUMN1_KEYS
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService.PreferenceUpgrade.UpgradeBrowserColumns.Companion.LEGACY_COLUMN2_KEYS
 import com.ichi2.anki.settings.Prefs
-import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.testutils.IntentAssert
 import com.ichi2.testutils.common.Flaky
 import com.ichi2.testutils.common.OS
@@ -1312,7 +1312,7 @@ class CardBrowserTest : RobolectricTest() {
             assertNotNull(fieldSelectorAdapter, "Fields adapter was not set")
             assertEquals(2, fieldSelectorAdapter.count)
             assertEquals(
-                TR.browsingAllFields().toSentenceCase(targetContext, R.string.sentence_all_fields),
+                with(targetContext) { TR.sentenceCase.allFields },
                 fieldSelectorAdapter.getItem(0),
             )
             assertEquals(TR.editingTags(), fieldSelectorAdapter.getItem(1))
@@ -1339,7 +1339,7 @@ class CardBrowserTest : RobolectricTest() {
             assertEquals(4, fieldSelectorAdapter.count)
             val defaultFields =
                 listOf(
-                    TR.browsingAllFields().toSentenceCase(targetContext, R.string.sentence_all_fields),
+                    with(targetContext) { TR.sentenceCase.allFields },
                     TR.editingTags(),
                 )
             assertEquals(defaultFields + listOf("Bfield0", "Bfield1"), fieldSelectorAdapter.getAdapterData())

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/FindAndReplaceDialogFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/FindAndReplaceDialogFragmentTest.kt
@@ -35,7 +35,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.libanki.Note
 import com.ichi2.anki.libanki.NoteId
-import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
@@ -167,7 +167,7 @@ class FindAndReplaceDialogFragmentTest : RobolectricTest() {
 
     private fun Context.getDefaultTargets() =
         listOf(
-            TR.browsingAllFields().toSentenceCase(this, R.string.sentence_all_fields),
+            with(this) { TR.sentenceCase.allFields },
             TR.editingTags(),
         )
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/GradeNowDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/GradeNowDialogTest.kt
@@ -25,9 +25,8 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.CollectionManager.TR
-import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
-import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -40,10 +39,7 @@ class GradeNowDialogTest : RobolectricTest() {
         val cardId = addBasicNote().firstCard().id
         val cardBrowser = super.startRegularActivity<CardBrowser>()
 
-        val translatedTitle =
-            TR
-                .actionsGradeNow()
-                .toSentenceCase(cardBrowser, R.string.sentence_grade_now)
+        val translatedTitle = with(cardBrowser) { TR.sentenceCase.gradeNow }
 
         GradeNowDialog.showDialog(cardBrowser, listOf(cardId))
 
@@ -81,10 +77,7 @@ class GradeNowDialogTest : RobolectricTest() {
         val cardId = addBasicNote().firstCard().id
         val cardBrowser = super.startRegularActivity<CardBrowser>()
 
-        val translatedTitle =
-            TR
-                .actionsGradeNow()
-                .toSentenceCase(cardBrowser, R.string.sentence_grade_now)
+        val translatedTitle = with(cardBrowser) { TR.sentenceCase.gradeNow }
 
         GradeNowDialog.showDialog(cardBrowser, listOf(cardId))
 
@@ -99,10 +92,7 @@ class GradeNowDialogTest : RobolectricTest() {
     @Test
     fun dialogNotShownIfNoCardsSelected() {
         val cardBrowser = super.startRegularActivity<CardBrowser>()
-        val translatedTitle =
-            TR
-                .actionsGradeNow()
-                .toSentenceCase(cardBrowser, R.string.sentence_grade_now)
+        val translatedTitle = with(cardBrowser) { TR.sentenceCase.gradeNow }
 
         GradeNowDialog.showDialog(cardBrowser, emptyList())
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
@@ -60,6 +60,24 @@ class SentenceCaseTest : RobolectricTest() {
                     assertThat(TR.sentenceCase.answerAgain, equalTo("Answer again"))
                     assertThat(TR.sentenceCase.answerHard, equalTo("Answer hard"))
                     assertThat(TR.sentenceCase.answerGood, equalTo("Answer good"))
+                    assertThat(TR.sentenceCase.selectiveStudy, equalTo("Selective study"))
+                    assertThat(TR.sentenceCase.chooseTags, equalTo("Choose tags"))
+                    assertThat(TR.sentenceCase.repositionNewCards, equalTo("Reposition new cards"))
+                    assertThat(TR.sentenceCase.allFields, equalTo("All fields"))
+                    assertThat(TR.sentenceCase.tagMissing, equalTo("Tag missing"))
+                    assertThat(TR.sentenceCase.checkMediaDeleteUnused, equalTo("Delete unused"))
+
+                    // input-taking accessors: a Title Case input only maps to the sentence form
+                    // if the correct sentence-case resource is wired
+                    assertThat(TR.sentenceCase.gestureToggleWhiteboard("Toggle Whiteboard"), equalTo("Toggle whiteboard"))
+                    assertThat(TR.sentenceCase.gestureFlagRed("Toggle Red Flag"), equalTo("Toggle red flag"))
+                    assertThat(TR.sentenceCase.gestureFlagOrange("Toggle Orange Flag"), equalTo("Toggle orange flag"))
+                    assertThat(TR.sentenceCase.gestureFlagGreen("Toggle Green Flag"), equalTo("Toggle green flag"))
+                    assertThat(TR.sentenceCase.gestureFlagBlue("Toggle Blue Flag"), equalTo("Toggle blue flag"))
+                    assertThat(TR.sentenceCase.gestureFlagPink("Toggle Pink Flag"), equalTo("Toggle pink flag"))
+                    assertThat(TR.sentenceCase.gestureFlagTurquoise("Toggle Turquoise Flag"), equalTo("Toggle turquoise flag"))
+                    assertThat(TR.sentenceCase.gestureFlagPurple("Toggle Purple Flag"), equalTo("Toggle purple flag"))
+                    assertThat(TR.sentenceCase.gestureFlagRemove("Remove Flag"), equalTo("Remove flag"))
                 }
             }.close()
 
@@ -98,6 +116,10 @@ class SentenceCaseTest : RobolectricTest() {
                     assertThat(TR.sentenceCase.copyDebugInfo, equalTo("Copy debug info"))
                     assertThat(TR.sentenceCase.addField, equalTo("Add field"))
                     assertThat(TR.sentenceCase.allDecks, equalTo("All decks"))
+                    assertThat(TR.sentenceCase.cardStatsCurrentCardStudy("Current Card (Study)"), equalTo("Current card (study)"))
+                    assertThat(TR.sentenceCase.cardStatsCurrentCardBrowse("Current Card (Browse)"), equalTo("Current card (browse)"))
+                    assertThat(TR.sentenceCase.cardStatsPreviousCardStudy("Previous Card (Study)"), equalTo("Previous card (study)"))
+                    assertThat(TR.sentenceCase.gradeNow, equalTo("Grade now"))
 
                     assertThat("syncMediaLogTitle", TR.syncMediaLogTitle(), equalTo("Media Sync Log"))
                     assertThat(TR.sentenceCase.mediaSyncLog, equalTo("Media sync log"))


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.8

## Purpose / Description
This allows a future extraction of SentenceCase into anki-common, as the `R.string.sentece_` resources would not need to be referenced with a non-transitive `R` class.

## Fixes
* Part of #20737

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)