### PR TITLE
refactor(reminders): stop passing ReviewReminder in intent extras

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -597,6 +597,10 @@ private fun Activity.showError(
  * [AnkiBroadcastReceiver.goAsync] extends the lifetime of the `onReceiveBroadcast` method and tells
  * the OS not to kill the process prematurely.
  *
+ * Theoretically, an expedited Worker could also be used to run a suspending function from `onReceiveBroadcast`.
+ * However, AnkiDroid is only allotted a fixed number of expedited Worker calls per day
+ * and those expedited calls are also used by the sync service, so it's best to conserve them.
+ *
  * Do not call [AnkiBroadcastReceiver.goAsync] directly before calling this function.
  *
  * @param timeout Just in case the block hangs. Cannot exceed 8 seconds, because an ANR may occur if

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewRemindersDatabase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewRemindersDatabase.kt
@@ -395,27 +395,31 @@ object ReviewRemindersDatabase {
         }
 
     /**
-     * Given a [ReviewReminder] which is about to fire a notification, retrieves the latest up-to-date version
+     * Given the ID of a [ReviewReminder] which is about to fire a recurring notification, atomically retrieves the latest up-to-date version
      * of that reminder from the database and performs validation and bookkeeping on it before returning it to the caller.
      * This is done in the database's scope so that we can re-use the [mutex] and hence be safe from
-     * race conditions.
+     * race conditions during the consecutive read and write.
      *
-     * @param reminder The reminder which will have a refreshed and validated copy returned.
+     * @param id The ID of the reminder which is about to fire a notification.
+     * @param scope The scope that the review reminder ID is stored within.
      *
-     * @return The [reminder] with its [ReviewReminder.latestNotifTime] updated, or null
+     * @return The retrieved reminder with its [ReviewReminder.latestNotifTime] updated, or null
      * if the notification has already been delivered or does not exist in the database.
      */
-    suspend fun retrieveRefreshedReminder(reminder: ReviewReminder): ReviewReminder? =
+    suspend fun retrieveRefreshedReminder(
+        id: ReviewReminderId,
+        scope: ReviewReminderScope,
+    ): ReviewReminder? =
         mutex.withLock {
             var reminderToReturn: ReviewReminder? = null
-            editRemindersForScope(reminder.scope) { reminders: ReviewReminderGroup ->
+            editRemindersForScope(scope) { reminders: ReviewReminderGroup ->
                 reminders.apply {
-                    val storedReminder = this[reminder.id]
+                    val storedReminder = this[id]
                     if (storedReminder == null) {
                         // The reminder should always be present as recurring notification alarms are unscheduled when
                         // a reminder is deleted, so this should never happen, but we fail gracefully just in case
                         Timber.e(
-                            "Returning null for retrieveRefreshedReminder for reminder ${reminder.id} because it was not found in the database.",
+                            "Returning null for retrieveRefreshedReminder for reminder $id because it was not found in the database.",
                         )
                         return@apply
                     }
@@ -423,7 +427,7 @@ object ReviewRemindersDatabase {
                     if (storedReminder.latestNotifDelivered()) {
                         // Do not proceed if the notification has already been delivered
                         Timber.i(
-                            "Returning null for retrieveRefreshedReminder for reminder ${storedReminder.id}: " +
+                            "Returning null for retrieveRefreshedReminder for reminder $id: " +
                                 "Latest already delivered at ${storedReminder.latestNotifTime}",
                         )
                         return@apply
@@ -431,7 +435,7 @@ object ReviewRemindersDatabase {
 
                     // Update and save this latest routine notification-firing attempt's timestamp
                     storedReminder.updateLatestNotifTime()
-                    this[reminder.id] = storedReminder
+                    this[id] = storedReminder
                     reminderToReturn = storedReminder
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/AlarmManagerService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/AlarmManagerService.kt
@@ -29,12 +29,16 @@ import com.ichi2.anki.common.android.AnkiBroadcastReceiver
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.utils.android.showThemedToast
 import com.ichi2.anki.reviewreminders.ReviewReminder
+import com.ichi2.anki.reviewreminders.ReviewReminderId
+import com.ichi2.anki.reviewreminders.ReviewReminderScope
 import com.ichi2.anki.reviewreminders.ReviewRemindersDatabase
+import com.ichi2.anki.runGloballyWithTimeout
 import com.ichi2.anki.utils.ext.getParcelableCompat
 import timber.log.Timber
 import java.util.Calendar
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Schedules review reminder notifications.
@@ -47,19 +51,35 @@ import kotlin.time.Duration.Companion.minutes
  * trigger the [onReceiveBroadcast] method of this BroadcastReceiver. This service handles the snooze delay,
  * after which it dispatches a one-time [NotificationService.NotificationServiceAction.SnoozeNotification]
  * request to [NotificationService].
+ *
+ * TODO: This class has two responsibilities
+ * The companion object contains code for scheduling review reminder notifications while the class itself
+ * serves as a BroadcastReceiver for snoozing review reminder notifications. While this is useful for keeping
+ * all the alarm scheduling code in one place, it may be cleaner to split the snoozing functionality into a separate
+ * SnoozeService BroadcastReceiver and turn this into a singleton object rather than a BroadcastReceiver class.
  */
 class AlarmManagerService : AnkiBroadcastReceiver() {
     companion object {
         /**
-         * Extra key for sending a review reminder as an extra to this BroadcastReceiver.
+         * Extra key for sending a [ReviewReminderId] as an extra to this BroadcastReceiver.
          */
-        private const val EXTRA_REVIEW_REMINDER = "alarm_manager_service_review_reminder"
+        private const val EXTRA_REVIEW_REMINDER_ID = "alarm_manager_service_review_reminder_id"
+
+        /**
+         * Extra key for sending a [ReviewReminderScope] as an extra to this BroadcastReceiver.
+         */
+        private const val EXTRA_REVIEW_REMINDER_SCOPE = "alarm_manager_service_review_reminder_scope"
 
         /**
          * Extra key for sending a snooze delay interval as an extra to this BroadcastReceiver.
          * The stored value is an integer number of minutes.
          */
         private const val EXTRA_SNOOZE_INTERVAL = "alarm_manager_service_snooze_interval"
+
+        /**
+         * Timeout for the process of snoozing a review reminder notification.
+         */
+        private val SNOOZE_REVIEW_REMINDER_TIMEOUT = 8.seconds
 
         /**
          * Interval passed to [AlarmManager.setWindow], in milliseconds. The OS is allowed to delay AnkiDroid's notifications
@@ -104,26 +124,41 @@ class AlarmManagerService : AnkiBroadcastReceiver() {
         }
 
         /**
-         * Gets the pending intent of a review reminder's scheduled notifications, either the normal recurring ones
-         * (if the action is set to [NotificationService.NotificationServiceAction.ScheduleRecurringNotifications])
-         * or the one-time snoozed ones (if the action is set to [NotificationService.NotificationServiceAction.SnoozeNotification]).
+         * Gets the pending intent of a review reminder's scheduled notifications.
          * This pending intent can then be used to either schedule those notifications or cancel them.
          *
          * If a review reminder with an identical ID has already had notifications scheduled via the pending intent
          * returned by this method, new notifications scheduled using this pending intent will update the existing
          * notifications rather than create duplicate new ones.
          *
+         * @param context
+         * @param reviewReminderId The ID of the review reminder whose notification pending intent should be retrieved.
+         * @param reviewReminderScope The scope that the review reminder ID is stored within.
+         * @param intentAction Schedules normal recurring notifications if set to
+         * [NotificationService.NotificationServiceAction.ScheduleRecurringNotifications] or one-time snoozed
+         * notifications if set to [NotificationService.NotificationServiceAction.SnoozeNotification].
+         *
          * @see NotificationService.NotificationServiceAction
          */
         private fun getReviewReminderNotificationPendingIntent(
             context: Context,
-            reviewReminder: ReviewReminder,
+            reviewReminderId: ReviewReminderId,
+            reviewReminderScope: ReviewReminderScope,
             intentAction: NotificationService.NotificationServiceAction,
         ): PendingIntent? {
-            val intent = NotificationService.getIntent(context, reviewReminder, intentAction)
+            val intent =
+                NotificationService.getIntent(
+                    context,
+                    reviewReminderId,
+                    reviewReminderScope,
+                    intentAction,
+                )
+            Timber.v(
+                "Created reminder notif intent with action ${intent.action} for review reminder ID $reviewReminderId",
+            )
             return PendingIntentCompat.getBroadcast(
                 context,
-                reviewReminder.id.value,
+                reviewReminderId.value,
                 intent,
                 PendingIntent.FLAG_UPDATE_CURRENT,
                 false,
@@ -170,7 +205,8 @@ class AlarmManagerService : AnkiBroadcastReceiver() {
             val pendingIntent =
                 getReviewReminderNotificationPendingIntent(
                     context,
-                    reviewReminder,
+                    reviewReminder.id,
+                    reviewReminder.scope,
                     NotificationService.NotificationServiceAction.ScheduleRecurringNotifications,
                 ) ?: return
             Timber.v("Pending intent for ${reviewReminder.id} is $pendingIntent")
@@ -181,7 +217,8 @@ class AlarmManagerService : AnkiBroadcastReceiver() {
                 val immediateNotificationIntent =
                     NotificationService.getIntent(
                         context,
-                        reviewReminder,
+                        reviewReminder.id,
+                        reviewReminder.scope,
                         NotificationService.NotificationServiceAction.ScheduleRecurringNotifications,
                     )
                 context.sendBroadcast(immediateNotificationIntent)
@@ -225,7 +262,8 @@ class AlarmManagerService : AnkiBroadcastReceiver() {
             val pendingIntent =
                 getReviewReminderNotificationPendingIntent(
                     context,
-                    reviewReminder,
+                    reviewReminder.id,
+                    reviewReminder.scope,
                     NotificationService.NotificationServiceAction.ScheduleRecurringNotifications,
                 ) ?: return
             Timber.v("Pending intent for ${reviewReminder.id} is $pendingIntent")
@@ -260,6 +298,44 @@ class AlarmManagerService : AnkiBroadcastReceiver() {
         }
 
         /**
+         * Triggered by [onReceiveBroadcast]. Retrieves the review reminder associated with the provided ID.
+         * Cancels the currently shown notification for the review reminder and then begins the process
+         * of scheduling the next notification for the review reminder.
+         *
+         * Extracted from the body of [onReceiveBroadcast] to allow for easier testing and to keep
+         * the receiver method concise.
+         *
+         * @param context
+         * @param reviewReminderId The ID of the review reminder to snooze.
+         * @param reviewReminderScope The scope that the review reminder ID is stored within.
+         * @param snoozeIntervalInMinutes The number of minutes to delay the review reminder notification by.
+         */
+        @VisibleForTesting
+        suspend fun handleSnoozeReviewReminder(
+            context: Context,
+            reviewReminderId: ReviewReminderId,
+            reviewReminderScope: ReviewReminderScope,
+            snoozeIntervalInMinutes: Int,
+        ) {
+            Timber.d(
+                "handleSnoozeReviewReminder for review reminder ID $reviewReminderId with snooze interval $snoozeIntervalInMinutes minutes",
+            )
+
+            // Dismiss the snoozed notification when the snooze button is clicked
+            val manager = context.getSystemService<NotificationManager>()
+            manager?.cancel(NotificationService.REVIEW_REMINDER_NOTIFICATION_TAG, reviewReminderId.value)
+
+            val retrievedReminder = ReviewRemindersDatabase.getRemindersForScope(reviewReminderScope)[reviewReminderId]
+            if (retrievedReminder == null) {
+                Timber.i(
+                    "Cancelling snoozed notification scheduling for reminder $reviewReminderId because it was not found in the database.",
+                )
+                return
+            }
+            scheduleSnoozedNotification(context, retrievedReminder, snoozeIntervalInMinutes)
+        }
+
+        /**
          * Schedules a one-time notification for a review reminder after a set amount of minutes.
          * Used for snoozing functionality.
          *
@@ -281,7 +357,8 @@ class AlarmManagerService : AnkiBroadcastReceiver() {
             val pendingIntent =
                 getReviewReminderNotificationPendingIntent(
                     context,
-                    reviewReminder,
+                    reviewReminder.id,
+                    reviewReminder.scope,
                     NotificationService.NotificationServiceAction.SnoozeNotification,
                 ) ?: return
             Timber.v("Pending intent for ${reviewReminder.id} is $pendingIntent")
@@ -315,14 +392,16 @@ class AlarmManagerService : AnkiBroadcastReceiver() {
          */
         fun getIntent(
             context: Context,
-            reviewReminder: ReviewReminder,
+            reviewReminderId: ReviewReminderId,
+            reviewReminderScope: ReviewReminderScope,
             snoozeInterval: Duration,
         ) = Intent(context, AlarmManagerService::class.java).apply {
             val snoozeIntervalInMinutes = snoozeInterval.inWholeMinutes.toInt()
             // Includes the snooze interval in the action string so that the pending intents for different snooze interval
             // buttons on review reminder notifications are different.
             action = "com.ichi2.anki.ACTION_START_REMINDER_SNOOZING_$snoozeIntervalInMinutes"
-            putExtra(EXTRA_REVIEW_REMINDER, reviewReminder)
+            putExtra(EXTRA_REVIEW_REMINDER_ID, reviewReminderId)
+            putExtra(EXTRA_REVIEW_REMINDER_SCOPE, reviewReminderScope)
             putExtra(EXTRA_SNOOZE_INTERVAL, snoozeIntervalInMinutes)
         }
     }
@@ -335,21 +414,25 @@ class AlarmManagerService : AnkiBroadcastReceiver() {
         context: Context,
         intent: Intent,
     ) {
-        Timber.d("onReceive")
-        // Get the request type
+        Timber.d("onReceiveBroadcast")
         val extras = intent.extras ?: return
-        val reviewReminder =
-            extras.getParcelableCompat<ReviewReminder>(EXTRA_REVIEW_REMINDER) ?: return
-        // Dismiss the snoozed notification when the snooze button is clicked
-        val manager = context.getSystemService<NotificationManager>()
-        manager?.cancel(NotificationService.REVIEW_REMINDER_NOTIFICATION_TAG, reviewReminder.id.value)
+        val reviewReminderId =
+            extras.getParcelableCompat<ReviewReminderId>(EXTRA_REVIEW_REMINDER_ID) ?: return
+        val reviewReminderScope =
+            extras.getParcelableCompat<ReviewReminderScope>(EXTRA_REVIEW_REMINDER_SCOPE) ?: return
+
         // The following returns 0 if the key is not found, meaning the snooze interval is 0 minutes,
         // which is an acceptable error fallback case.
         val snoozeIntervalInMinutes = extras.getInt(EXTRA_SNOOZE_INTERVAL)
-        scheduleSnoozedNotification(
-            context,
-            reviewReminder,
-            snoozeIntervalInMinutes,
-        )
+        Timber.d("onReceiveBroadcast: reminder: $reviewReminderId, scope: $reviewReminderScope, interval: $snoozeIntervalInMinutes")
+
+        runGloballyWithTimeout(SNOOZE_REVIEW_REMINDER_TIMEOUT) {
+            handleSnoozeReviewReminder(
+                context,
+                reviewReminderId,
+                reviewReminderScope,
+                snoozeIntervalInMinutes,
+            )
+        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
@@ -19,7 +19,6 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.graphics.Color
-import android.os.BadParcelableException
 import androidx.annotation.VisibleForTesting
 import androidx.core.app.NotificationCompat
 import androidx.core.app.PendingIntentCompat
@@ -38,6 +37,7 @@ import com.ichi2.anki.libanki.Decks
 import com.ichi2.anki.libanki.EpochMilliseconds
 import com.ichi2.anki.preferences.PENDING_NOTIFICATIONS_ONLY
 import com.ichi2.anki.reviewreminders.ReviewReminder
+import com.ichi2.anki.reviewreminders.ReviewReminderId
 import com.ichi2.anki.reviewreminders.ReviewReminderScope
 import com.ichi2.anki.reviewreminders.ReviewRemindersDatabase
 import com.ichi2.anki.runGloballyWithTimeout
@@ -74,50 +74,76 @@ class NotificationService : AnkiBroadcastReceiver() {
         const val REVIEW_REMINDER_NOTIFICATION_TAG = "com.ichi2.anki.review_reminder_notification_tag"
 
         /**
-         * Extra key for sending a review reminder as an extra to this broadcast receiver.
+         * Extra key for sending a [ReviewReminderId] as an extra to this broadcast receiver.
          */
         @VisibleForTesting
-        const val EXTRA_REVIEW_REMINDER = "notification_service_review_reminder"
+        const val EXTRA_REVIEW_REMINDER_ID = "notification_service_review_reminder_id"
+
+        /**
+         * Extra key for sending a [ReviewReminderScope] as an extra to this broadcast receiver.
+         */
+        @VisibleForTesting
+        const val EXTRA_REVIEW_REMINDER_SCOPE = "notification_service_review_reminder_scope"
 
         /**
          * Timeout for the process of sending a review reminder notification.
-         * Should be below 10 seconds as BroadcastReceivers may ANR when onReceiveBroadcast takes longer than 10 seconds.
-         * See [the docs](https://developer.android.com/reference/android/content/BroadcastReceiver#goAsync()).
          */
         private val SEND_REVIEW_REMINDER_TIMEOUT = 8.seconds
 
         /**
-         * Triggered by [onReceiveBroadcast]. Does some bookkeeping if the triggered notification is of the recurring type
+         * Triggered by [onReceiveBroadcast]. Retrieves the review reminder associated with the provided ID.
+         * Schedules the next notification and updates the latest firing time if the triggered notification is of the recurring type
          * or does nothing if it is a snoozed one, and then begins the process of sending the notification.
+         *
+         * Extracted from the body of [onReceiveBroadcast] to allow for easier testing and to keep
+         * the receiver method concise.
+         *
+         * @param context
+         * @param reviewReminderId The ID of the review reminder the notification is for.
+         * @param reviewReminderScope The scope that the review reminder ID is stored within.
+         * @param isRecurringNotification If true, the fetched review reminder does not have its next
+         * firing scheduled, nor is its latest firing time updated.
          */
         @VisibleForTesting
         suspend fun handleReviewReminderNotification(
             context: Context,
-            reviewReminder: ReviewReminder,
+            reviewReminderId: ReviewReminderId,
+            reviewReminderScope: ReviewReminderScope,
             isRecurringNotification: Boolean,
         ) {
             val reminderForNotification =
                 if (isRecurringNotification) {
-                    val refreshedReminder = ReviewRemindersDatabase.retrieveRefreshedReminder(reviewReminder)
-                    if (refreshedReminder == null) {
-                        Timber.i("Aborting notification and not scheduling next one, notification not required at this time")
-                        return
-                    }
-
-                    // Schedule the next routine notification-firing
-                    Timber.d("Scheduling next review reminder notification")
-                    // Because this scheduling is already the result of a notification, we do not trigger an immediate notification.
-                    AlarmManagerService.scheduleReviewReminderNotification(
-                        context,
-                        refreshedReminder,
-                        attemptImmediateNotification = false,
+                    ReviewRemindersDatabase.retrieveRefreshedReminder(
+                        reviewReminderId,
+                        reviewReminderScope,
                     )
-
-                    refreshedReminder
                 } else {
-                    // No need to perform any bookkeeping for snoozed notifications, just immediately fire
-                    reviewReminder
+                    ReviewRemindersDatabase.getRemindersForScope(reviewReminderScope)[reviewReminderId]
                 }
+            if (reminderForNotification == null) {
+                Timber.i(
+                    "Aborting notification for review reminder $reviewReminderId (recurring: $isRecurringNotification) due to database validation failure.",
+                )
+                return
+            }
+            if (!reminderForNotification.enabled) {
+                // This should never happen for recurring notifications because disabling a reminder should cancel all of its notification alarms, but we check just in case
+                // It can happen for snoozed notifications if the user disables the reminder after snoozing it
+                Timber.i(
+                    "Aborting notification for review reminder $reviewReminderId (recurring: $isRecurringNotification) because it is not enabled.",
+                )
+                return
+            }
+
+            if (isRecurringNotification) {
+                Timber.d("Scheduling next review reminder notification for review reminder $reviewReminderId")
+                // Because this scheduling is already the result of a notification, we do not trigger an immediate notification
+                AlarmManagerService.scheduleReviewReminderNotification(
+                    context,
+                    reminderForNotification,
+                    attemptImmediateNotification = false,
+                )
+            }
 
             // Send the notification
             try {
@@ -132,7 +158,13 @@ class NotificationService : AnkiBroadcastReceiver() {
         }
 
         /**
-         * Sends a notification for a review reminder.
+         * (Attempts to) send a notification for a review reminder.
+         * Specifically, performs validation and content + description hydration, then triggers the firing of the notification.
+         * May abort sending the notification depending on certain fields of the review reminder.
+         *
+         * Does not handle scheduling the next occurrence of the notification if the review reminder is recurring; that is handled by [handleReviewReminderNotification].
+         * Does not handle big-picture validation of the review reminder (i.e. is it in the database, is it enabled);
+         * that is handled by [handleReviewReminderNotification].
          */
         private suspend fun sendReviewReminderNotification(
             context: Context,
@@ -221,8 +253,8 @@ class NotificationService : AnkiBroadcastReceiver() {
                     )
 
             // Create intents for snooze buttons
-            val fiveMinuteSnooze = createSnoozePendingIntent(context, reviewReminder, 5.minutes)
-            val oneHourSnooze = createSnoozePendingIntent(context, reviewReminder, 1.hours)
+            val fiveMinuteSnooze = getSnoozePendingIntent(context, reviewReminder.id, reviewReminder.scope, 5.minutes)
+            val oneHourSnooze = getSnoozePendingIntent(context, reviewReminder.id, reviewReminder.scope, 1.hours)
 
             val builder =
                 NotificationCompat
@@ -251,25 +283,35 @@ class NotificationService : AnkiBroadcastReceiver() {
         }
 
         /**
-         * Creates review reminder snoozing pending intent for a given review reminder and snooze interval.
+         * Gets the review reminder snoozing pending intent for the review reminder with the given ID.
          * If this method is run twice for the same review reminder ID and snooze interval, it will return the same
          * pending intent.
+         *
+         * @param context
+         * @param reviewReminderId the ID of the review reminder the snooze intent is for.
+         * @param reviewReminderScope The scope that the review reminder ID is stored within.
+         * @param snoozeInterval the amount of time before the review reminder fires again,
+         * used to create a unique pending intent for each snooze option.
          */
-        private fun createSnoozePendingIntent(
+        private fun getSnoozePendingIntent(
             context: Context,
-            reviewReminder: ReviewReminder,
+            reviewReminderId: ReviewReminderId,
+            reviewReminderScope: ReviewReminderScope,
             snoozeInterval: Duration,
         ): PendingIntent? {
             val intent =
                 AlarmManagerService.getIntent(
                     context,
-                    reviewReminder,
+                    reviewReminderId,
+                    reviewReminderScope,
                     snoozeInterval,
                 )
-            Timber.v("Created snooze intent with action ${intent.action}")
+            Timber.v(
+                "Created snooze intent with action ${intent.action} for review reminder ID $reviewReminderId",
+            )
             return PendingIntentCompat.getBroadcast(
                 context,
-                reviewReminder.id.value,
+                reviewReminderId.value,
                 intent,
                 PendingIntent.FLAG_UPDATE_CURRENT,
                 false,
@@ -399,10 +441,11 @@ class NotificationService : AnkiBroadcastReceiver() {
 
         /**
          * Method for getting an intent for this service.
-         * When broadcasted, fires a notification for the provided review reminder.
+         * When broadcasted, fires a notification for the review reminder associated with the provided review reminder ID.
          *
          * @param context
-         * @param reviewReminder
+         * @param reviewReminderId
+         * @param reviewReminderScope Scope to search for the review reminder ID in.
          * @param intentAction If this is [NotificationServiceAction.ScheduleRecurringNotifications],
          * this intent (once fired) will also schedule the next upcoming instance of the review reminder
          * notification via [AlarmManagerService.scheduleReviewReminderNotification].
@@ -411,11 +454,13 @@ class NotificationService : AnkiBroadcastReceiver() {
          */
         fun getIntent(
             context: Context,
-            reviewReminder: ReviewReminder,
+            reviewReminderId: ReviewReminderId,
+            reviewReminderScope: ReviewReminderScope,
             intentAction: NotificationServiceAction,
         ) = Intent(context, NotificationService::class.java).apply {
             action = intentAction.actionString
-            putExtra(EXTRA_REVIEW_REMINDER, reviewReminder)
+            putExtra(EXTRA_REVIEW_REMINDER_ID, reviewReminderId)
+            putExtra(EXTRA_REVIEW_REMINDER_SCOPE, reviewReminderScope)
         }
     }
 
@@ -429,8 +474,7 @@ class NotificationService : AnkiBroadcastReceiver() {
      * Additionally, when this service is directed to fire a notification, we can check if the intent action
      * is [ScheduleRecurringNotifications] to determine whether we should also schedule the next upcoming
      * instance of the review reminder notification. If the intent is instead [SnoozeNotification],
-     * then we can be sure that the next instance has already been scheduled when the user initially
-     * pressed snooze.
+     * then we can be sure that the next instance has already been scheduled.
      *
      * @see AlarmManagerService.getReviewReminderNotificationPendingIntent
      * @see onReceiveBroadcast
@@ -462,30 +506,17 @@ class NotificationService : AnkiBroadcastReceiver() {
             Timber.d("onReceiveBroadcast")
             val action = intent.action ?: return
             val extras = intent.extras ?: return
+            val reviewReminderId =
+                extras.getParcelableCompat<ReviewReminderId>(EXTRA_REVIEW_REMINDER_ID) ?: return
+            val reviewReminderScope =
+                extras.getParcelableCompat<ReviewReminderScope>(EXTRA_REVIEW_REMINDER_SCOPE) ?: return
+            Timber.d("onReceiveBroadcast: reminder: $reviewReminderId, scope: $reviewReminderScope, action: $action")
 
-            // We must run some suspending functions. Hence we mark this onReceiveBroadcast function as long-running
-            // and use the global scope for simplicity's sake. Theoretically, we could also use an expedited Worker,
-            // but AnkiDroid is only allotted a fixed number of expedited Worker calls per day
-            // and those expedited calls are also used by the sync service, so it's best to conserve them.
             runGloballyWithTimeout(SEND_REVIEW_REMINDER_TIMEOUT) {
-                val reviewReminder =
-                    try {
-                        extras.getParcelableCompat<ReviewReminder>(EXTRA_REVIEW_REMINDER)
-                            ?: return@runGloballyWithTimeout
-                    } catch (e: BadParcelableException) {
-                        // #20782: If the extra's review reminder has an invalid schema, attempt a full re-schedule of all
-                        // review reminder notifications, as that will retrieve reminders from Shared Preferences
-                        // and handle any necessary schema updates. It will also trigger immediate notifications
-                        // (and thus this onReceiveBroadcast again for an uncorrupted version of this corrupted review reminder) as necessary.
-                        Timber.w(e, "Failed to get review reminder from intent extras, triggering full re-schedule")
-                        AlarmManagerService.scheduleAllEnabledReviewReminderNotifications(context)
-                        return@runGloballyWithTimeout
-                    }
-                Timber.d("onReceiveBroadcast: ${reviewReminder.id}")
-
                 handleReviewReminderNotification(
                     context,
-                    reviewReminder,
+                    reviewReminderId,
+                    reviewReminderScope,
                     isRecurringNotification = (action == NotificationServiceAction.ScheduleRecurringNotifications.actionString),
                 )
             }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersDatabaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersDatabaseTest.kt
@@ -225,7 +225,7 @@ class ReviewRemindersDatabaseTest : RobolectricTest() {
             ReviewRemindersDatabase.insertReminder(reviewReminder)
 
             TimeManager.resetWith(today)
-            val returnedReminder = ReviewRemindersDatabase.retrieveRefreshedReminder(reviewReminder)
+            val returnedReminder = ReviewRemindersDatabase.retrieveRefreshedReminder(reviewReminder.id, reviewReminder.scope)
 
             assertThat(returnedReminder, notNullValue())
             assertThat(returnedReminder!!.latestNotifTime, not(equalTo(creationTime)))
@@ -245,7 +245,7 @@ class ReviewRemindersDatabaseTest : RobolectricTest() {
                 )
             ReviewRemindersDatabase.insertReminder(reviewReminder)
 
-            val returnedReminder = ReviewRemindersDatabase.retrieveRefreshedReminder(reviewReminder)
+            val returnedReminder = ReviewRemindersDatabase.retrieveRefreshedReminder(reviewReminder.id, reviewReminder.scope)
 
             assertThat(returnedReminder, nullValue())
             val storedReminder = ReviewRemindersDatabase.getRemindersForScope(scope1)[reviewReminder.id]!!
@@ -255,7 +255,7 @@ class ReviewRemindersDatabaseTest : RobolectricTest() {
     @Test
     fun `retrieveRefreshedReminder with review reminder not found in database should fail gracefully`() =
         runTest {
-            val returnedReminder = ReviewRemindersDatabase.retrieveRefreshedReminder(reviewReminderOne)
+            val returnedReminder = ReviewRemindersDatabase.retrieveRefreshedReminder(reviewReminderOne.id, reviewReminderOne.scope)
             assertThat(returnedReminder, nullValue())
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/AlarmManagerServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/AlarmManagerServiceTest.kt
@@ -8,20 +8,20 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.os.Bundle
 import androidx.core.app.PendingIntentCompat
 import androidx.core.content.edit
 import androidx.core.content.getSystemService
-import androidx.core.os.BundleCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.common.time.MockTime
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.reviewreminders.ReviewReminder
+import com.ichi2.anki.reviewreminders.ReviewReminderId
 import com.ichi2.anki.reviewreminders.ReviewReminderScope
 import com.ichi2.anki.reviewreminders.ReviewReminderTime
 import com.ichi2.anki.reviewreminders.ReviewRemindersDatabase
-import com.ichi2.anki.services.NotificationService.Companion.EXTRA_REVIEW_REMINDER
+import com.ichi2.anki.services.NotificationService.Companion.EXTRA_REVIEW_REMINDER_ID
+import com.ichi2.anki.services.NotificationService.Companion.EXTRA_REVIEW_REMINDER_SCOPE
 import com.ichi2.anki.utils.ext.getParcelableCompat
 import io.mockk.every
 import io.mockk.mockk
@@ -36,6 +36,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.Calendar
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
 @RunWith(AndroidJUnit4::class)
@@ -153,8 +154,10 @@ class AlarmManagerServiceTest : RobolectricTest() {
         verify(exactly = 1) {
             context.sendBroadcast(capture(slot))
         }
-        val firedReminder = slot.captured.extras!!.getParcelableCompat<ReviewReminder>(EXTRA_REVIEW_REMINDER)!!
-        assertThat(firedReminder, equalTo(reviewReminder))
+        val firedReminderId = slot.captured.extras!!.getParcelableCompat<ReviewReminderId>(EXTRA_REVIEW_REMINDER_ID)!!
+        val firedReminderScope = slot.captured.extras!!.getParcelableCompat<ReviewReminderScope>(EXTRA_REVIEW_REMINDER_SCOPE)!!
+        assertThat(firedReminderId, equalTo(reviewReminder.id))
+        assertThat(firedReminderScope, equalTo(reviewReminder.scope))
     }
 
     @Test
@@ -233,37 +236,71 @@ class AlarmManagerServiceTest : RobolectricTest() {
                 }
             }
 
-            val expectedFiredReminders = reviewReminders.filter { it.enabled }.toSet()
+            val expectedFiredReminderIds = reviewReminders.filter { it.enabled }.map { it.id }.toSet()
             val capturedIntents = mutableListOf<Intent>()
-            verify(exactly = expectedFiredReminders.size) {
+            verify(exactly = expectedFiredReminderIds.size) {
                 context.sendBroadcast(capture(capturedIntents))
             }
-            val firedReminders =
+            val firedReminderIds =
                 capturedIntents
                     .map { intent ->
-                        intent.extras!!.getParcelableCompat<ReviewReminder>(EXTRA_REVIEW_REMINDER)!!
+                        intent.extras!!.getParcelableCompat<ReviewReminderId>(EXTRA_REVIEW_REMINDER_ID)!!
                     }.toSet()
-            assertThat(firedReminders, equalTo(expectedFiredReminders))
+            assertThat(firedReminderIds, equalTo(expectedFiredReminderIds))
         }
 
     @Test
-    fun `onReceive schedules snoozed notification and cancels clicked notification`() {
-        val extras = mockk<Bundle>()
-        every { extras.getInt(any()) } returns 5
-        val intent = mockk<Intent>()
-        every { intent.extras } returns extras
-        mockkStatic(BundleCompat::class)
-        every { BundleCompat.getParcelable(extras, any(), ReviewReminder::class.java) } returns reviewReminder
+    fun `triggering schedules snoozed notification and cancels clicked notification`() =
+        runTest {
+            ReviewRemindersDatabase.insertReminder(reviewReminder)
 
-        AlarmManagerService().onReceive(context, intent)
-        verify {
+            attemptSnooze(reviewReminder, 5.minutes)
+
+            verifyNotifSnoozed(5.minutes)
+            verifyPastNotifCleared(reviewReminder)
+        }
+
+    @Test
+    fun `triggering only clears past notif if review reminder is not in database`() =
+        runTest {
+            attemptSnooze(reviewReminder, 5.minutes)
+
+            verifyNoNotifSnoozed()
+            verifyPastNotifCleared(reviewReminder)
+        }
+
+    private suspend fun attemptSnooze(
+        reviewReminder: ReviewReminder,
+        delay: Duration,
+    ) {
+        AlarmManagerService.handleSnoozeReviewReminder(
+            context,
+            reviewReminder.id,
+            reviewReminder.scope,
+            snoozeIntervalInMinutes = delay.inWholeMinutes.toInt(),
+        )
+    }
+
+    private fun verifyNotifSnoozed(delay: Duration) {
+        verify(exactly = 1) {
             alarmManager.setWindow(
                 AlarmManager.RTC_WAKEUP,
-                mockTime.intTimeMS() + 5.minutes.inWholeMilliseconds,
+                mockTime.intTimeMS() + delay.inWholeMilliseconds,
                 AlarmManagerService.WINDOW_LENGTH_MS,
                 any(),
             )
         }
-        verify { notificationManager.cancel(NotificationService.REVIEW_REMINDER_NOTIFICATION_TAG, reviewReminder.id.value) }
+    }
+
+    private fun verifyNoNotifSnoozed() {
+        verify(exactly = 0) {
+            alarmManager.setWindow(AlarmManager.RTC_WAKEUP, any(), any(), any())
+        }
+    }
+
+    private fun verifyPastNotifCleared(reviewReminder: ReviewReminder) {
+        verify(exactly = 1) {
+            notificationManager.cancel(NotificationService.REVIEW_REMINDER_NOTIFICATION_TAG, reviewReminder.id.value)
+        }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NotificationServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NotificationServiceTest.kt
@@ -159,6 +159,33 @@ class NotificationServiceTest : RobolectricTest() {
         }
 
     @Test
+    fun `triggering with reminder which is not present in database should not fire notification nor schedule next`() =
+        runTest {
+            val did1 = addDeck("Deck", setAsSelected = true).withNotes(count = 2)
+            val reviewReminder = createTestReminder(deckId = did1)
+
+            TimeManager.resetWith(today)
+            attemptNotif(reviewReminder)
+
+            verifyNoNotifsSent()
+            verifyNextNotifNotScheduled()
+        }
+
+    @Test
+    fun `triggering with reminder which is disabled should not fire notification nor schedule next`() =
+        runTest {
+            val did1 = addDeck("Deck", setAsSelected = true).withNotes(count = 2)
+            val reviewReminder = createTestReminder(deckId = did1, enabled = false)
+            ReviewRemindersDatabase.insertReminder(reviewReminder)
+
+            TimeManager.resetWith(today)
+            attemptNotif(reviewReminder)
+
+            verifyNoNotifsSent()
+            verifyNextNotifNotScheduled()
+        }
+
+    @Test
     fun `triggering with scheduled time in the future should not fire notification nor schedule next`() =
         runTest {
             val did1 = addDeck("Deck", setAsSelected = true).withNotes(count = 2)
@@ -308,6 +335,33 @@ class NotificationServiceTest : RobolectricTest() {
         }
 
     @Test
+    fun `triggering with snoozed notification not stored in database should not fire notification nor schedule next`() =
+        runTest {
+            val did1 = addDeck("Deck", setAsSelected = true).withNotes(count = 2)
+            val reviewReminder = createTestReminder(deckId = did1, scheduledTimeOffsetFromNow = (-1).minutes)
+
+            TimeManager.resetWith(today)
+            attemptNotif(reviewReminder, isRecurring = false)
+
+            verifyNoNotifsSent()
+            verifyNextNotifNotScheduled()
+        }
+
+    @Test
+    fun `triggering with snoozed notification which is disabled should not fire notification nor schedule next`() =
+        runTest {
+            val did1 = addDeck("Deck", setAsSelected = true).withNotes(count = 2)
+            val reviewReminder = createTestReminder(deckId = did1, enabled = false, scheduledTimeOffsetFromNow = (-1).minutes)
+            ReviewRemindersDatabase.insertReminder(reviewReminder)
+
+            TimeManager.resetWith(today)
+            attemptNotif(reviewReminder, isRecurring = false)
+
+            verifyNoNotifsSent()
+            verifyNextNotifNotScheduled()
+        }
+
+    @Test
     fun `snooze actions of different notifications and different intervals should be different`() =
         runTest {
             val did1 = addDeck("Deck1").withNotes(count = 2)
@@ -343,7 +397,8 @@ class NotificationServiceTest : RobolectricTest() {
     ) {
         NotificationService.handleReviewReminderNotification(
             context,
-            reviewReminder,
+            reviewReminder.id,
+            reviewReminder.scope,
             isRecurringNotification = isRecurring,
         )
     }
@@ -356,6 +411,7 @@ class NotificationServiceTest : RobolectricTest() {
     private fun createTestReminder(
         deckId: DeckId? = null,
         thresholdInt: Int = 1,
+        enabled: Boolean = true,
         onlyNotifyIfNoReviews: Boolean = false,
         scheduledTimeOffsetFromNow: Duration = (-1).minutes,
     ): ReviewReminder {
@@ -370,6 +426,7 @@ class NotificationServiceTest : RobolectricTest() {
                 ),
             cardTriggerThreshold = ReviewReminderCardTriggerThreshold(thresholdInt),
             scope = if (deckId != null) DeckSpecific(deckId) else Global,
+            enabled = enabled,
             onlyNotifyIfNoReviews = onlyNotifyIfNoReviews,
         )
     }


### PR DESCRIPTION
## Purpose / Description
I've refactored both the notification path and the snooze path to only pass around review reminder IDs in intent extras and to refer to the database when actually retrieving review reminder details.

Created thanks to @criticalAY 's comments at:
- https://github.com/ankidroid/Anki-Android/pull/20755

## Fixes
For some reason, my past self thought it was a good idea to pass around ReviewReminders as a Parcelable extra within an intent. This violates the single-source-of-truth nature of the stored review reminders, as when a notification tries to fire, it passes in a ReviewReminder that might be stale and has been updated on disk since the intent was created. There's no bugs caused by this, as editing review reminders via the UI deletes all pending intents and recreates them, but it's still bad design.

## How Has This Been Tested?
- normal notifications: work
- normally snoozing a reminder: the snoozed notification should appear
- snoozing a reminder and then deleting it: the snoozed notification should not appear
- opening app during window when notification should fire: notification should immediately fire
- opening app again after notification has fired: notification should not immediately fire again
- unit tests
- tested on a physical Samsung S23, API 36

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->