### PR TITLE
feat: Add wiring and analytics for bottom nav bar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/BottomNavController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BottomNavController.kt
@@ -47,11 +47,29 @@ class BottomNavController(
         fun onMoreSelected()
     }
 
-    enum class NavigationItem {
-        HOME,
-        BROWSER,
-        STATS,
-        MORE,
+    enum class NavigationItem(
+        @IdRes val id: Int,
+        /** Fragment tag used to find and reuse this destination's fragment across tab switches. */
+        val tag: String,
+    ) {
+        HOME(R.id.nav_home, "home"),
+        BROWSER(R.id.nav_browser, "browser"),
+        STATS(R.id.nav_stats, "stats"),
+        MORE(R.id.nav_more, "more"),
+        ;
+
+        companion object {
+            fun fromId(
+                @IdRes id: Int,
+            ): NavigationItem? =
+                when (id) {
+                    R.id.nav_home -> HOME
+                    R.id.nav_browser -> BROWSER
+                    R.id.nav_stats -> STATS
+                    R.id.nav_more -> MORE
+                    else -> null
+                }
+        }
     }
 
     private var currentNavigationItem: NavigationItem = NavigationItem.HOME

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -509,6 +509,8 @@ open class DeckPicker :
 
         // create inherited navigation drawer layout here so that it can be used by parent class
         initNavigationDrawer()
+        if (Prefs.devBottomNavEnabled && !fragmented) disableDrawerSwipe()
+        setupBottomNavigation()
         setupEdgeToEdge()
         title = resources.getString(R.string.app_name)
 
@@ -639,7 +641,9 @@ open class DeckPicker :
 
             // hack for Roborazzi screenshot tests
             val fabBottomOffset = if (isRobolectric) 12.dp.toPx(this) else -12.dp.toPx(this)
-            floatingActionButtonBinding.root.updatePadding(bottom = bars.bottom + fabBottomOffset)
+            val bottomNavView = findViewById<View?>(R.id.bottom_navigation)
+            val bottomNavOffset = if (bottomNavView?.isVisible == true) BOTTOM_NAV_HEIGHT_DP.dp.toPx(this) else 0
+            floatingActionButtonBinding.root.updatePadding(bottom = bars.bottom + fabBottomOffset + bottomNavOffset)
 
             setRecyclerViewBottomPaddingAbove(floatingActionButtonBinding.fabMain)
             insets
@@ -2242,6 +2246,15 @@ open class DeckPicker :
             )
 
     companion object {
+        /**
+         * Material 3 BottomNavigationView content height in dp, *excluding* the system
+         * navigation-bar inset (that inset is added separately here via `bars.bottom`).
+         * Used to offset the FAB above the bar. The hosted-fragment container instead uses
+         * the bar's measured height, which already includes the inset so the two must not
+         * be swapped for one another.
+         */
+        private const val BOTTOM_NAV_HEIGHT_DP = 80
+
         /**
          * Result codes from other activities
          */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/HomeScreenNavigation.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/HomeScreenNavigation.kt
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+package com.ichi2.anki
+
+import android.os.Bundle
+import android.view.View
+import androidx.activity.OnBackPressedCallback
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat.Type.navigationBars
+import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentTransaction
+import androidx.fragment.app.commit
+import androidx.lifecycle.ViewModelProvider
+import com.google.android.material.bottomnavigation.BottomNavigationView
+import com.ichi2.anki.BottomNavController.NavigationItem
+import com.ichi2.anki.browser.CardBrowserFragment
+import com.ichi2.anki.browser.CardBrowserViewModel
+import com.ichi2.anki.common.annotations.NeedsTest
+import com.ichi2.anki.pages.Statistics
+import com.ichi2.anki.settings.Prefs
+
+/**
+ * Manages the bottom navigation bar for the home screen.
+ *
+ * On tablets (fragmented), this is a no-op because tablets use the navigation
+ * drawer with a split pane.
+ */
+@NeedsTest("tab switches show/hide correct fragments")
+@NeedsTest("back press returns to Home tab before exiting")
+context(deckPicker: DeckPicker)
+fun setupBottomNavigation() {
+    if (!Prefs.devBottomNavEnabled || deckPicker.fragmented) return
+
+    val bottomNav = deckPicker.findViewById<BottomNavigationView>(R.id.bottom_navigation)
+    val fragmentContainer = deckPicker.findViewById<View>(R.id.bottom_nav_fragment_container)
+    val contentWrapper = deckPicker.findViewById<View>(R.id.deck_picker_content_wrapper)
+    bottomNav.isVisible = true
+
+    // Return to Home tab on back press when on a non-Home tab
+    val bottomNavBackCallback =
+        object : OnBackPressedCallback(enabled = false) {
+            override fun handleOnBackPressed() {
+                bottomNav.selectedItemId = NavigationItem.HOME.id
+            }
+        }
+    deckPicker.onBackPressedDispatcher.addCallback(deckPicker, bottomNavBackCallback)
+
+    // Handle system navigation bar insets for the bottom nav
+    ViewCompat.setOnApplyWindowInsetsListener(bottomNav) { view, insets ->
+        val navBars = insets.getInsets(navigationBars())
+        view.updatePadding(bottom = navBars.bottom)
+        insets
+    }
+
+    bottomNav.setOnItemSelectedListener { item ->
+        val navItem = NavigationItem.fromId(item.itemId) ?: return@setOnItemSelectedListener false
+        handleNavigationItemSelected(navItem, contentWrapper, fragmentContainer, bottomNavBackCallback)
+    }
+}
+
+context(deckPicker: DeckPicker)
+private fun handleNavigationItemSelected(
+    item: NavigationItem,
+    contentWrapper: View,
+    fragmentContainer: View,
+    backCallback: OnBackPressedCallback,
+): Boolean =
+    when (item) {
+        NavigationItem.HOME -> {
+            fragmentContainer.isVisible = false
+            deckPicker.supportFragmentManager.commit { hideBottomNavFragments() }
+            contentWrapper.isVisible = true
+            deckPicker.floatingActionMenu.showFloatingActionButton()
+            backCallback.isEnabled = false
+            true
+        }
+        NavigationItem.BROWSER -> {
+            backCallback.isEnabled = true
+            ensureBrowserViewModel()
+            showBottomNavFragment(::CardBrowserFragment, item.tag, contentWrapper, fragmentContainer)
+            true
+        }
+        NavigationItem.STATS -> {
+            backCallback.isEnabled = true
+            showBottomNavFragment(
+                {
+                    Statistics().apply {
+                        arguments = Bundle().apply { putBoolean(Statistics.ARG_HIDE_BACK_BUTTON, true) }
+                    }
+                },
+                item.tag,
+                contentWrapper,
+                fragmentContainer,
+            )
+            true
+        }
+        NavigationItem.MORE -> {
+            backCallback.isEnabled = true
+            showBottomNavFragment(::MoreFragment, item.tag, contentWrapper, fragmentContainer)
+            true
+        }
+    }
+
+/** Create CardBrowserViewModel before the fragment accesses it via activityViewModels() */
+context(deckPicker: DeckPicker)
+private fun ensureBrowserViewModel() {
+    ViewModelProvider(
+        deckPicker.viewModelStore,
+        CardBrowserViewModel.factory(
+            lastDeckIdRepository = AnkiDroidApp.instance.sharedPrefsLastDeckIdRepository,
+            cacheDir = deckPicker.cacheDir,
+            options = null,
+            isFragmented = false,
+        ),
+        deckPicker.defaultViewModelCreationExtras,
+    )[CardBrowserViewModel::class.java]
+}
+
+context(deckPicker: DeckPicker)
+private fun showBottomNavFragment(
+    newFragment: () -> Fragment,
+    tag: String,
+    contentWrapper: View,
+    fragmentContainer: View,
+) {
+    contentWrapper.isVisible = false
+    deckPicker.floatingActionMenu.hideFloatingActionButton()
+    val bottomNav = deckPicker.findViewById<View>(R.id.bottom_navigation)
+    (fragmentContainer.layoutParams as? CoordinatorLayout.LayoutParams)?.let { lp ->
+        lp.topMargin = 0
+        lp.bottomMargin = bottomNav.height
+        fragmentContainer.layoutParams = lp
+    }
+    deckPicker.supportFragmentManager.commit {
+        hideBottomNavFragments()
+        val existing = deckPicker.supportFragmentManager.findFragmentByTag(tag)
+        if (existing != null) {
+            show(existing)
+        } else {
+            add(R.id.bottom_nav_fragment_container, newFragment(), tag)
+        }
+    }
+    fragmentContainer.isVisible = true
+}
+
+/** Hides any fragments currently hosted in the bottom-nav container. */
+context(deckPicker: DeckPicker)
+private fun FragmentTransaction.hideBottomNavFragments() {
+    deckPicker.supportFragmentManager.fragments.forEach { fragment ->
+        if (fragment.id == R.id.bottom_nav_fragment_container) hide(fragment)
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MoreFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MoreFragment.kt
@@ -8,6 +8,9 @@ import android.view.View
 import androidx.annotation.StringRes
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
+import com.ichi2.anki.analytics.AnalyticsConstants.Actions
+import com.ichi2.anki.analytics.AnalyticsConstants.Category
+import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.common.destinations.PreferencesDestination
 import com.ichi2.anki.common.destinations.navigate
 import com.ichi2.anki.databinding.FragmentMoreBinding
@@ -25,8 +28,6 @@ import dev.androidbroadcast.vbpd.viewBinding
  *
  * Help items open the existing [HelpDialog] focused on their subsection.
  * Support items directly open their respective URLs.
- *
- * TODO: add UsageAnalytics calls matching AnalyticsConstants.Actions before wiring
  */
 class MoreFragment : Fragment(R.layout.fragment_more) {
     private val binding by viewBinding(FragmentMoreBinding::bind)
@@ -45,37 +46,47 @@ class MoreFragment : Fragment(R.layout.fragment_more) {
 
         // Help section: each opens HelpDialog with the relevant sub-items
         binding.moreHelpManual.setOnClickListener {
+            UsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_USING_ANKIDROID)
             openHelpSection(R.string.help_title_using_ankidroid)
         }
         binding.moreHelpGetHelp.setOnClickListener {
+            UsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_GET_HELP)
             openHelpSection(R.string.help_title_get_help)
         }
         binding.moreHelpCommunity.setOnClickListener {
+            UsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_COMMUNITY)
             openHelpSection(R.string.help_title_community)
         }
         binding.moreHelpPrivacy.setOnClickListener {
+            UsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_PRIVACY)
             openHelpSection(R.string.help_title_privacy)
         }
 
         // Support section: direct URL actions
         binding.moreSupportDonate.setOnClickListener {
+            UsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_DONATE)
             openUrl(getString(R.string.link_opencollective_donate))
         }
         binding.moreSupportTranslate.setOnClickListener {
+            UsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_TRANSLATE)
             openUrl(getString(R.string.link_translation))
         }
         binding.moreSupportDevelop.setOnClickListener {
+            UsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_DEVELOP)
             openUrl(getString(R.string.link_ankidroid_development_guide))
         }
         binding.moreSupportRate.setOnClickListener {
+            UsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_RATE)
             if (IntentUtil.canOpenIntent(requireContext(), marketIntent)) {
                 startActivity(marketIntent)
             }
         }
         binding.moreSupportOther.setOnClickListener {
+            UsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_OTHER)
             openUrl(getString(R.string.link_contribution))
         }
         binding.moreSupportFeedback.setOnClickListener {
+            UsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_SEND_FEEDBACK)
             openUrl(AnkiDroidApp.feedbackUrl)
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -222,6 +222,9 @@ open class Reviewer :
         if (!ensureStoragePermissions()) {
             return
         }
+        if (Prefs.devBottomNavEnabled) {
+            showBackIcon()
+        }
         colorPalette = findViewById(R.id.whiteboard_editor)
         answerTimer = AnswerTimer(findViewById(R.id.card_time))
         textBarNew = findViewById(R.id.new_number)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -70,6 +70,7 @@ import com.google.android.material.search.SearchView
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.AnkiActivityProvider
+import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.getColUnsafe
 import com.ichi2.anki.CollectionManager.withCol
@@ -221,8 +222,12 @@ class CardBrowserFragment :
     private var focusedRow: CardOrNoteId? = null
 
     // Dev option for Issue 18709
+    // The old layout's MenuProvider is coupled to the activity's toolbar, which causes
+    // menu bleeding when hosted in DeckPicker's bottom nav. The SearchView layout is
+    // self-contained and works in any host.
+    // TODO: decouple old layout via ContentHostFragment so this fallback isn't needed
     private val useSearchView: Boolean
-        get() = Prefs.devUsingCardBrowserSearchView
+        get() = Prefs.devUsingCardBrowserSearchView || activity !is CardBrowser
 
     /**
      * Returns the current deck name, "All Decks" if all decks are selected, or "Unknown"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
@@ -51,13 +51,14 @@ class Statistics : PageFragment(R.layout.page_statistics) {
     ) {
         super.onViewCreated(view, savedInstanceState)
 
+        // Hide the back arrow when requested (e.g. hosted in bottom nav)
+        if (arguments?.getBoolean(ARG_HIDE_BACK_BUTTON) == true) {
+            binding.toolbar.navigationIcon = null
+        }
+
         binding.deckName.setOnClickListener {
             startDeckSelection(allowAll = false, allowFiltered = false, skipEmptyDefault = true)
         }
-        binding.appBar
-            .addLiftOnScrollListener { _, backgroundColor ->
-                activity?.window?.statusBarColor = backgroundColor
-            }
 
         binding.toolbar.apply {
             menu.findItem(R.id.action_export_stats).title = CollectionManager.TR.statisticsSavePdf()
@@ -131,6 +132,7 @@ class Statistics : PageFragment(R.layout.page_statistics) {
     }
 
     companion object {
+        const val ARG_HIDE_BACK_BUTTON = "hideBackButton"
         private const val KEY_DECK_NAME = "key_deck_name"
     }
 }

--- a/AnkiDroid/src/main/res/layout/activity_homescreen.xml
+++ b/AnkiDroid/src/main/res/layout/activity_homescreen.xml
@@ -5,6 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
     <LinearLayout
+        android:id="@+id/deck_picker_content_wrapper"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">
@@ -35,7 +36,9 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
+        android:background="?attr/colorSurface"
         android:visibility="gone"
+        app:labelVisibilityMode="labeled"
         app:menu="@menu/bottom_nav_menu" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/main/res/layout/fragment_card_browser_searchview.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_card_browser_searchview.xml
@@ -51,7 +51,10 @@
 
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:background="?attr/colorSurface"
+        app:statusBarForeground="?attr/appBarColor"
+        android:fitsSystemWindows="true">
         <com.google.android.material.search.SearchBar
             android:id="@+id/search_bar"
             android:layout_width="match_parent"

--- a/AnkiDroid/src/main/res/layout/fragment_more.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_more.xml
@@ -10,12 +10,21 @@
     android:orientation="vertical"
     android:background="?android:attr/colorBackground">
 
-    <com.google.android.material.appbar.MaterialToolbar
-        android:id="@+id/toolbar"
+    <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        app:title="@string/bottom_nav_more"
-        app:titleTextAppearance="?attr/textAppearanceTitleLarge" />
+        android:layout_height="wrap_content"
+        android:background="?attr/colorSurface"
+        app:statusBarForeground="?attr/appBarColor"
+        android:fitsSystemWindows="true"
+        app:elevation="0dp">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:title="@string/bottom_nav_more"
+            app:titleTextAppearance="?attr/textAppearanceTitleLarge" />
+    </com.google.android.material.appbar.AppBarLayout>
 
     <ScrollView
         android:layout_width="match_parent"

--- a/AnkiDroid/src/main/res/layout/page_statistics.xml
+++ b/AnkiDroid/src/main/res/layout/page_statistics.xml
@@ -9,6 +9,8 @@
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="?attr/colorSurface"
+        app:statusBarForeground="?attr/appBarColor"
         android:fitsSystemWindows="true">
 
         <com.google.android.material.appbar.MaterialToolbar
@@ -19,7 +21,6 @@
             app:navigationContentDescription="@string/abc_action_bar_up_description"
             app:navigationIcon="?attr/homeAsUpIndicator"
             app:layout_scrollFlags="scroll|enterAlways|snap"
-            android:fitsSystemWindows="true"
             app:menu="@menu/statistics">
 
             <com.ichi2.ui.FixedTextView

--- a/AnkiDroid/src/main/res/menu/bottom_nav_menu.xml
+++ b/AnkiDroid/src/main/res/menu/bottom_nav_menu.xml
@@ -13,7 +13,7 @@
     <item
         android:id="@+id/nav_browser"
         android:icon="@drawable/ic_flashcard_black"
-        android:title="@string/card_browser" />
+        android:title="@string/bottom_nav_browse" />
     <item
         android:id="@+id/nav_stats"
         android:icon="@drawable/ic_bar_chart_black"

--- a/AnkiDroid/src/main/res/values/12-dont-translate.xml
+++ b/AnkiDroid/src/main/res/values/12-dont-translate.xml
@@ -34,5 +34,6 @@ If you want to use a string in your code that can't be translated, please use:
     <string name="review_reminders_do_not_translate" comment="Do not translate this string, this feature is still in development. Name of the notification channel for review reminders.">Review Reminders</string>
     <!-- Bottom Nav Bar: In progress for GSoC 2026 -->
     <string name="bottom_nav_more" maxLength="28">More</string>
+    <string name="bottom_nav_browse" maxLength="28">Browse</string>
 </resources>
 


### PR DESCRIPTION
> [!NOTE]  
> Assisted by Opus 4.6 for general research.
<!--- Please fill the necessary details below -->
## Purpose / Description
This PR adds wiring to the bottom nav bar instantiated in the previous PRs (#21186). It also adds analytics to the More fragment.

## Fixes
* For GSoC 2026: Redesign Deck Picker

## Approach
The main changes lie in DeckPicker.kt where setupBottomNav() method shows the bar, disables the drawer swipe, and handles tab selection. Each tab hides the deck list content and shows the corresponding fragment using show/hide so we can have state preservation. The CardBrowserFragment's ViewModel is lazily created the first time that the browser tab is tapped since otherwise the app would crash. There were some padding changed to be done to the fab to account for the nav bar height. Minor bugs will be fixed in a follow-up refinement PR along with removing the nav drawer altogether, I've kept it usable for now as a fallback but that will be removed.

## How Has This Been Tested?
Compiles successfully, all the features work as intended.
[Screen_recording_20260612_120332.webm](https://github.com/user-attachments/assets/2057509c-ed1e-4cb4-8430-df373d6ebfdd)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->