### PR TITLE
fix: show permission screen for missing storage access

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractIntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractIntentHandler.kt
@@ -17,7 +17,9 @@
 package com.ichi2.anki
 
 import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
+import com.ichi2.anki.ui.windows.permissions.PermissionsActivity
 import com.ichi2.themes.Themes
 import com.ichi2.themes.Themes.disableXiaomiForceDarkMode
 
@@ -32,4 +34,25 @@ abstract class AbstractIntentHandler : Activity() {
         disableXiaomiForceDarkMode(this)
         setContentView(R.layout.activity_progress_bar)
     }
+
+    fun requestPermissionsThenStartThroughDeckPicker(targetIntent: Intent) {
+        val ankiDroidFolder = selectAnkiDroidFolder(this)
+        val continueIntent =
+            DeckPicker.getIntentToStartAfterStartup(
+                this,
+                targetIntent.withoutTaskClearingFlags(),
+            )
+        startActivity(PermissionsActivity.getIntent(this, ankiDroidFolder.permissionSet, continueIntent))
+        finish()
+    }
+
+    fun hasCollectionStoragePermissions(): Boolean {
+        val ankiDroidFolder = selectAnkiDroidFolder(this)
+        return ankiDroidFolder.hasRequiredPermissions(this)
+    }
+
+    private fun Intent.withoutTaskClearingFlags(): Intent =
+        Intent(this).apply {
+            flags = flags and (Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK).inv()
+        }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -83,6 +83,7 @@ import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.receiver.SdCardReceiver
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.ui.windows.permissions.PermissionsActivity
 import com.ichi2.anki.utils.ext.requireString
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.workarounds.AppLoadedFromBackupWorkaround.showedActivityFailedScreen
@@ -680,7 +681,7 @@ open class AnkiActivity(
     }
 
     /**
-     * If storage permissions are not granted, shows a toast message and finishes the activity.
+     * If storage permissions are not granted, shows the permission screen and postpones activity startup.
      *
      * This should be called AFTER a call to `super.`[onCreate]
      *
@@ -690,13 +691,21 @@ open class AnkiActivity(
      * @throws SystemStorageException if `getExternalFilesDir` returns null
      */
     fun ensureStoragePermissions(): Boolean {
-        if (IntentHandler.grantedStoragePermissions(this, showToast = true)) {
+        val ankiDroidFolder = selectAnkiDroidFolder(this)
+        if (ankiDroidFolder.hasRequiredPermissions(this)) {
             return true
         }
-        Timber.w("finishing activity. No storage permission")
+        Timber.i("${this.javaClass.simpleName}: postponing startup code - permission screen shown")
+        val continueIntent = DeckPicker.getIntentToStartAfterStartup(this, intent.withoutTaskClearingFlags())
+        startActivity(PermissionsActivity.getIntent(this, ankiDroidFolder.permissionSet, continueIntent))
         finish()
         return false
     }
+
+    private fun Intent.withoutTaskClearingFlags(): Intent =
+        Intent(this).apply {
+            flags = flags and (Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK).inv()
+        }
 
     override val shortcuts
         get(): ShortcutGroup? = null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -52,6 +52,7 @@ import androidx.appcompat.widget.Toolbar
 import androidx.appcompat.widget.TooltipCompat
 import androidx.core.app.ActivityCompat
 import androidx.core.app.ActivityCompat.OnRequestPermissionsResultCallback
+import androidx.core.content.IntentCompat
 import androidx.core.content.edit
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
@@ -754,6 +755,7 @@ open class DeckPicker :
                     // Must stay here: clearing in ViewModel would break cold start (collector is only active at RESUMED).
                     viewModel.flowOfStartupResponse.value = null
                     showStartupScreensAndDialogs(sharedPrefs(), 0)
+                    startPendingIntentAfterStartup()
 
                     if (tryShowStudyOptionsPanel()) {
                         ResizablePaneManager(
@@ -924,6 +926,31 @@ open class DeckPicker :
             }
 
         viewModel.handleStartup(environment = environment)
+    }
+
+    private fun startPendingIntentAfterStartup() {
+        if (!colIsOpenUnsafe()) {
+            return
+        }
+        startPendingIntent()
+    }
+
+    private fun startPendingIntentIfCollectionIsOpen() {
+        if (colIsOpenUnsafe()) {
+            startPendingIntent()
+        }
+    }
+
+    private fun startPendingIntent() {
+        val pendingIntent =
+            IntentCompat.getParcelableExtra(intent, START_AFTER_STARTUP_INTENT_EXTRA, Intent::class.java)
+                ?: return
+        intent.removeExtra(START_AFTER_STARTUP_INTENT_EXTRA)
+        try {
+            startActivity(pendingIntent)
+        } catch (e: SecurityException) {
+            Timber.w(e, "Unable to start pending intent after permissions")
+        }
     }
 
     @VisibleForTesting
@@ -1330,6 +1357,7 @@ open class DeckPicker :
         super.onResume()
         if (navDrawerIsReady() && hasCollectionStoragePermissions()) {
             refreshState()
+            startPendingIntentIfCollectionIsOpen()
         }
         message?.let { dialogHandler.sendStoredMessage(it) }
     }
@@ -2174,6 +2202,7 @@ open class DeckPicker :
          * This is for the 'download existing collection from AnkiWeb' use case
          */
         const val INTENT_SYNC_FROM_LOGIN = "syncFromLogin"
+        private const val START_AFTER_STARTUP_INTENT_EXTRA = "startAfterStartupIntent"
 
         /**
          * Available options performed by other activities (request codes for onActivityResult())
@@ -2200,6 +2229,13 @@ open class DeckPicker :
                 putExtra(INTENT_SYNC_FROM_LOGIN, true)
             }
         }
+
+        fun getIntentToStartAfterStartup(
+            context: Context,
+            targetIntent: Intent,
+        ) = getIntent(context).apply {
+            putExtra(START_AFTER_STARTUP_INTENT_EXTRA, targetIntent)
+        }
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -2209,6 +2245,7 @@ open class DeckPicker :
             Timber.i("Sync requested from Login")
             this.syncOnResume = true
         }
+        startPendingIntentIfCollectionIsOpen()
     }
 
     override fun opExecuted(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -76,7 +76,7 @@ class IntentHandler : AbstractIntentHandler() {
         val action = intent.action
         // #6157 - We want to block actions that need permissions we don't have, but not the default case
         // as this requires nothing
-        val runIfStoragePermissions = { runnable: () -> Unit -> performActionIfStorageAccessible(reloadIntent, action) { runnable() } }
+        val runIfStoragePermissions = { runnable: () -> Unit -> performActionIfStorageAccessible(action) { runnable() } }
         val launchType = getLaunchType(intent)
         // TODO block the UI with some kind of ProgressDialog instead of cancelling the sync work
         if (requiresCollectionAccess(launchType)) {
@@ -138,16 +138,15 @@ class IntentHandler : AbstractIntentHandler() {
      */
     @NeedsTest("clicking a file in 'Files' to import")
     private fun performActionIfStorageAccessible(
-        reloadIntent: Intent,
         action: String?,
         block: () -> Unit,
     ) {
-        if (grantedStoragePermissions(this, showToast = true)) {
+        if (hasCollectionStoragePermissions()) {
             Timber.i("User has storage permissions. Running intent: %s", action)
             block()
         } else {
             Timber.i("No Storage Permission, cancelling intent '%s'", action)
-            launchDeckPickerIfNoOtherTasks(reloadIntent)
+            requestPermissionsThenStartThroughDeckPicker(Intent(intent).setClass(this, IntentHandler::class.java))
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler2.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler2.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.anki
 
+import android.content.Intent
 import android.os.Bundle
 import com.ichi2.anki.NoteEditorFragment.Companion.NoteEditorCaller
 import com.ichi2.anki.noteeditor.NoteEditorLauncher
@@ -35,6 +36,11 @@ class IntentHandler2 : AbstractIntentHandler() {
         if (NoteEditorFragment.intentLaunchedWithImage(intent)) {
             Timber.i("Intent contained an image")
             intent.putExtra(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.ADD_IMAGE.value)
+        }
+        if (!hasCollectionStoragePermissions()) {
+            Timber.i("No Storage Permission, postponing intent")
+            requestPermissionsThenStartThroughDeckPicker(Intent(intent).setClass(this, IntentHandler2::class.java))
+            return
         }
         if (intent.extras == null) {
             Timber.w("Intent unexpectedly has no extras. Notifying user, defaulting to add note.")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivity.kt
@@ -50,6 +50,7 @@ import timber.log.Timber
  */
 class PermissionsActivity : AnkiActivity(R.layout.activity_permissions) {
     private val binding by viewBinding(ActivityPermissionsBinding::bind)
+    private var continueIntent: Intent? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {
@@ -60,7 +61,11 @@ class PermissionsActivity : AnkiActivity(R.layout.activity_permissions) {
         Themes.setTheme(this)
         setTransparentStatusBar()
 
-        binding.continueButton.setOnClickListener { finish() }
+        continueIntent = IntentCompat.getParcelableExtra(intent, CONTINUE_INTENT_EXTRA, Intent::class.java)
+        binding.continueButton.setOnClickListener {
+            continueIntent?.let(::startActivity)
+            finish()
+        }
 
         // #20881: Activity should not be launchd without extras
         val permissionSet = IntentCompat.getParcelableExtra(intent, PERMISSIONS_SET_EXTRA, PermissionSet::class.java)
@@ -93,13 +98,16 @@ class PermissionsActivity : AnkiActivity(R.layout.activity_permissions) {
 
     companion object {
         const val PERMISSIONS_SET_EXTRA = "permissionsSet"
+        const val CONTINUE_INTENT_EXTRA = "continueIntent"
 
         fun getIntent(
             context: Context,
             permissionsSet: PermissionSet,
+            continueIntent: Intent? = null,
         ): Intent =
             Intent(context, PermissionsActivity::class.java).apply {
                 putExtra(PERMISSIONS_SET_EXTRA, permissionsSet as Parcelable)
+                putExtra(CONTINUE_INTENT_EXTRA, continueIntent)
             }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -15,6 +15,7 @@
  */
 package com.ichi2.anki
 
+import android.Manifest.permission.INTERNET
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Bundle
@@ -52,7 +53,6 @@ import anki.search.BrowserRow
 import anki.search.BrowserRow.Color
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
-import com.ichi2.anki.IntentHandler.Companion.grantedStoragePermissions
 import com.ichi2.anki.RobolectricTest.Companion.advanceRobolectricLooper
 import com.ichi2.anki.browser.BrowserMultiColumnAdapter
 import com.ichi2.anki.browser.BrowserMultiColumnAdapter.Companion.LINES_VISIBLE_WHEN_COLLAPSED
@@ -80,7 +80,6 @@ import com.ichi2.anki.browser.setColumn
 import com.ichi2.anki.browser.setSelectedDeck
 import com.ichi2.anki.browser.toRowSelection
 import com.ichi2.anki.common.time.TimeManager
-import com.ichi2.anki.common.utils.isRunningAsUnitTest
 import com.ichi2.anki.libanki.BrowserConfig
 import com.ichi2.anki.libanki.CardId
 import com.ichi2.anki.libanki.CardType
@@ -99,6 +98,7 @@ import com.ichi2.anki.servicelayer.PreferenceUpgradeService.PreferenceUpgrade.Up
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService.PreferenceUpgrade.UpgradeBrowserColumns.Companion.LEGACY_COLUMN2_KEYS
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.ui.windows.permissions.PermissionsActivity
 import com.ichi2.anki.utils.ext.getCurrentDialogFragment
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.testutils.IntentAssert
@@ -106,13 +106,9 @@ import com.ichi2.testutils.common.Flaky
 import com.ichi2.testutils.common.OS
 import com.ichi2.testutils.ext.menu
 import com.ichi2.testutils.getSharedPrefs
+import com.ichi2.testutils.withDeniedPermissions
 import com.ichi2.testutils.withSplitPaneUiAsync
 import com.ichi2.utils.LanguageUtil
-import io.mockk.every
-import io.mockk.mockkObject
-import io.mockk.mockkStatic
-import io.mockk.unmockkObject
-import io.mockk.unmockkStatic
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
@@ -472,24 +468,22 @@ class CardBrowserTest : RobolectricTest() {
     }
 
     @Test
-    fun startupFromCardBrowserActionItemShouldEndActivityIfNoPermissions() {
-        try {
-            mockkStatic(::isRunningAsUnitTest)
-            mockkObject(IntentHandler)
+    fun startupFromCardBrowserActionItemShouldOpenPermissionsActivityIfNoPermissions() =
+        runTest {
+            // Robolectric uses AppPrivateFolder here, so denying INTERNET simulates missing permission.
+            withDeniedPermissions(INTERNET) {
+                val browserController = Robolectric.buildActivity(CardBrowser::class.java).create()
+                val cardBrowser = browserController.get()
+                saveControllerForCleanup(browserController)
 
-            every { grantedStoragePermissions(any(), any()) } returns false
-            every { isRunningAsUnitTest } returns false
-
-            val browserController = Robolectric.buildActivity(CardBrowser::class.java).create()
-            val cardBrowser = browserController.get()
-            saveControllerForCleanup(browserController)
-
-            assertThat("Activity should be finishing", cardBrowser.isFinishing)
-        } finally {
-            unmockkStatic(::isRunningAsUnitTest)
-            unmockkObject(IntentHandler)
+                val intent = assertNotNull(shadowOf(cardBrowser).nextStartedActivity)
+                assertThat(
+                    intent.component?.className,
+                    equalTo(PermissionsActivity::class.java.name),
+                )
+                assertThat("Activity should be finishing", cardBrowser.isFinishing)
+            }
         }
-    }
 
     @Test
     fun tagWithBracketsDisplaysProperly() =

--- a/AnkiDroid/src/test/java/com/ichi2/anki/IntentHandlerPermissionTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/IntentHandlerPermissionTest.kt
@@ -1,0 +1,68 @@
+//noinspection MissingCopyrightHeader #8659
+package com.ichi2.anki
+
+import android.Manifest.permission.INTERNET
+import android.content.Intent
+import androidx.core.content.IntentCompat
+import androidx.core.net.toUri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.ui.windows.permissions.PermissionsActivity
+import com.ichi2.anki.ui.windows.permissions.PermissionsActivity.Companion.CONTINUE_INTENT_EXTRA
+import com.ichi2.testutils.withDeniedPermissions
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.Shadows.shadowOf
+import kotlin.test.assertNotNull
+
+@RunWith(AndroidJUnit4::class)
+class IntentHandlerPermissionTest : RobolectricTest() {
+    @Test
+    fun sharedTextWithoutPermissionOpensPermissionActivityWithDeckPickerContinuation() =
+        runTest {
+            withDeniedPermissions(INTERNET) {
+                val sharedTextIntent =
+                    Intent(Intent.ACTION_SEND).apply {
+                        type = "text/plain"
+                        putExtra(Intent.EXTRA_TEXT, "shared text")
+                    }
+
+                val controller = Robolectric.buildActivity(IntentHandler::class.java, sharedTextIntent).create()
+                val activity = controller.get()
+                saveControllerForCleanup(controller)
+
+                val permissionIntent = assertNotNull(shadowOf(activity).nextStartedActivity)
+                assertThat(permissionIntent.component?.className, equalTo(PermissionsActivity::class.java.name))
+
+                val continueIntent = permissionIntent.getContinueIntent()
+                assertThat(continueIntent.component?.className, equalTo(DeckPicker::class.java.name))
+            }
+        }
+
+    @Test
+    fun addImageWithoutPermissionOpensPermissionActivityWithDeckPickerContinuation() =
+        runTest {
+            withDeniedPermissions(INTERNET) {
+                val addImageIntent =
+                    Intent(Intent.ACTION_SEND).apply {
+                        type = "image/png"
+                        putExtra(Intent.EXTRA_STREAM, "content://image".toUri())
+                    }
+
+                val controller = Robolectric.buildActivity(IntentHandler2::class.java, addImageIntent).create()
+                val activity = controller.get()
+                saveControllerForCleanup(controller)
+
+                val permissionIntent = assertNotNull(shadowOf(activity).nextStartedActivity)
+                assertThat(permissionIntent.component?.className, equalTo(PermissionsActivity::class.java.name))
+
+                val continueIntent = permissionIntent.getContinueIntent()
+                assertThat(continueIntent.component?.className, equalTo(DeckPicker::class.java.name))
+            }
+        }
+
+    private fun Intent.getContinueIntent(): Intent =
+        assertNotNull(IntentCompat.getParcelableExtra(this, CONTINUE_INTENT_EXTRA, Intent::class.java))
+}


### PR DESCRIPTION
## Purpose / Description

Shortcuts and share intents can currently fail when AnkiDroid is missing the required collection storage permission. Instead of guiding the user through the existing permission screen, some flows show a toast or can crash when startup continues without permission.

This can happen after the permission is manually revoked, Android removes it after long inactivity, or the app is opened through a shortcut or share target before permission is granted again.

I saw that there is broader planned work in #21204 to improve collection creation and startup permission handling. That work should give this area a cleaner long term shape, but it is larger architecture work. This PR is a smaller fix that can stay in place until that refactor lands.

## Fixes

* Fixes #16786

## Approach

Replaced the toast only missing permission handling with the existing `PermissionsActivity` flow.

For activities that require collection access during startup, missing permission now opens the permission screen and postpones the original target intent through `DeckPicker` until startup completes.

The previous activity is finished immediately, which avoids partially initialized screens such as Card Browser continuing lifecycle work without the expected startup state.

Intent handlers now use the same folder permission check as startup and route missing permission cases through `PermissionsActivity`.

For external share intents with stale `content://` grants, `DeckPicker` now catches `SecurityException` when attempting to resume the deferred intent.

This prevents the app from crashing.

In that rare case the user may land on the home screen after granting permission and can retry the share action.

## How Has This Been Tested?

* Tested manually with app shortcut actions after revoking permission.
* Card Browser and Study shortcuts open the permission screen instead of crashing.
* Share and image intent stale URI crash no longer closes the app.
* Ran focused unit tests: `CardBrowserTest.startupFromCardBrowserActionItemShouldOpenPermissionsActivityIfNoPermissions`, `IntentHandlerPermissionTest`, `IntentHandlerTest`.
* Ran ktlint checks: `:AnkiDroid:ktlintMainSourceSetCheck`, `:AnkiDroid:ktlintTestSourceSetCheck`.
* Ran `git diff --check`.

## Screenshots

N/A. This uses the existing permission screen.

## Checklist

- [x] You have a descriptive commit message with a short title, first line max 50 chars.
- [x] You have commented your code, particularly in hard to understand areas.
- [x] You have performed a self review of your own code.
- [ ] UI changes include screenshots of all affected screens.
- [ ] UI changes have been tested using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor).
