### PR TITLE
fix: select next deck after deletion to prevent Default deck appearing in StudyOptionsFragment

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -39,7 +39,6 @@ import com.ichi2.anki.common.destinations.BrowserDestination
 import com.ichi2.anki.configureRenderingMode
 import com.ichi2.anki.launchCatchingIO
 import com.ichi2.anki.libanki.CardId
-import com.ichi2.anki.libanki.Consts
 import com.ichi2.anki.libanki.Consts.DEFAULT_DECK_ID
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.Decks
@@ -198,6 +197,34 @@ class DeckPickerViewModel :
     val flowOfOptionsMenuState = MutableStateFlow<OptionsMenuState?>(null)
 
     /**
+     * Calculates the next deck to select after deleting a deck.
+     *
+     * - If the deck has a previous sibling, select it
+     * - Otherwise, if it has a next sibling, select that
+     * - If it's the only child (no siblings), select the parent
+     * - If it's a top-level deck with no siblings, select Default
+     *
+     * @param did ID of the deck being deleted
+     * @return ID of the deck to select after deletion, or DEFAULT_DECK_ID as fallback
+     */
+    private fun calculateNextDeckAfterDeletion(did: DeckId): DeckId {
+        val tree = dueTree ?: return DEFAULT_DECK_ID
+
+        val node = tree.find(did) ?: return DEFAULT_DECK_ID
+        val parent = node.parent?.get() ?: tree
+
+        val siblings = parent.children
+        val currentIndex = siblings.indexOfFirst { it.did == did }
+
+        return when {
+            currentIndex > 0 -> siblings[currentIndex - 1].did // Previous sibling
+            currentIndex < siblings.size - 1 -> siblings[currentIndex + 1].did // Next sibling
+            parent != tree && parent.did != did -> parent.did // Parent (if not root)
+            else -> DEFAULT_DECK_ID // Fallback to Default
+        }
+    }
+
+    /**
      * Deletes the provided deck, child decks. and all cards inside.
      *
      * This is a slow operation and should be inside `withProgress`
@@ -207,14 +234,22 @@ class DeckPickerViewModel :
     @CheckResult // This is a slow operation and should be inside `withProgress`
     fun deleteDeck(did: DeckId) =
         viewModelScope.launch {
+            val nextDeckId = calculateNextDeckAfterDeletion(did)
             val deckName = withCol { decks.getLegacy(did)!!.name }
-            val changes = undoableOp { decks.remove(listOf(did)) }
-            // After deletion: decks.current() reverts to Default, necessitating `focusedDeck`
-            // to match and avoid unnecessary scrolls in `renderPage()`.
-            focusedDeck = Consts.DEFAULT_DECK_ID
+
+            val opResult =
+                undoableOp {
+                    val removeResult = decks.remove(listOf(did))
+                    // setCurrent must be called after remove to update current deck; result intentionally unused as undoableOp handles notification
+                    @Suppress("CheckResult")
+                    decks.setCurrent(nextDeckId)
+                    removeResult // Return OpChangesWithCount
+                }
+
+            focusedDeck = nextDeckId
 
             deckDeletedNotification.emit(
-                DeckDeletionResult(deckName = deckName, cardsDeleted = changes.count),
+                DeckDeletionResult(deckName = deckName, cardsDeleted = opResult.count),
             )
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -837,6 +837,161 @@ class DeckPickerTest : RobolectricTest() {
             }
         }
 
+    @Test
+    fun `Deck deletion - child with previous sibling selects previous sibling`() =
+        runTest {
+            // Create parent deck with three children: A, B, C
+            val parent = addDeck("Parent")
+            val childA = addDeck("Parent::A")
+            val childB = addDeck("Parent::B")
+            val childC = addDeck("Parent::C")
+
+            val deckPicker =
+                startActivityNormallyOpenCollectionWithIntent(
+                    DeckPicker::class.java,
+                    Intent(),
+                )
+
+            // Delete child B - should select A (previous sibling)
+            deckPicker.viewModel.deleteDeck(childB).join()
+
+            assertThat("current deck should be A (previous sibling)", col.decks.current().id, equalTo(childA))
+        }
+
+    @Test
+    fun `Deck deletion - child with next sibling selects next sibling when no previous`() =
+        runTest {
+            // Create parent deck with two children: A, B
+            val parent = addDeck("Parent")
+            val childA = addDeck("Parent::A")
+            val childB = addDeck("Parent::B")
+
+            val deckPicker =
+                startActivityNormallyOpenCollectionWithIntent(
+                    DeckPicker::class.java,
+                    Intent(),
+                )
+
+            // Delete child A - should select B (next sibling, as there's no previous)
+            deckPicker.viewModel.deleteDeck(childA).join()
+
+            assertThat("current deck should be B (next sibling)", col.decks.current().id, equalTo(childB))
+        }
+
+    @Test
+    fun `Deck deletion - only child selects parent`() =
+        runTest {
+            // Create parent with only one child
+            val parent = addDeck("Parent")
+            val child = addDeck("Parent::OnlyChild")
+
+            val deckPicker =
+                startActivityNormallyOpenCollectionWithIntent(
+                    DeckPicker::class.java,
+                    Intent(),
+                )
+
+            // Delete the only child - should select parent
+            deckPicker.viewModel.deleteDeck(child).join()
+
+            assertThat("current deck should be parent", col.decks.current().id, equalTo(parent))
+        }
+
+    @Test
+    fun `Deck deletion - top-level deck with no siblings selects Default`() =
+        runTest {
+            // Add a top-level deck
+            val topDeck = addDeck("TopLevel")
+
+            val deckPicker =
+                startActivityNormallyOpenCollectionWithIntent(
+                    DeckPicker::class.java,
+                    Intent(),
+                )
+
+            // Delete the top-level deck - should select Default
+            deckPicker.viewModel.deleteDeck(topDeck).join()
+
+            assertThat("current deck should be Default", col.decks.current().id, equalTo(1L))
+        }
+
+    @Test
+    fun `Deck deletion - focusedDeck is updated correctly`() =
+        runTest {
+            // Create parent with children: A, B
+            val parent = addDeck("Parent")
+            val childA = addDeck("Parent::A")
+            val childB = addDeck("Parent::B")
+
+            val deckPicker =
+                startActivityNormallyOpenCollectionWithIntent(
+                    DeckPicker::class.java,
+                    Intent(),
+                )
+
+            // Set focus to child B
+            deckPicker.viewModel.focusedDeck = childB
+            assertThat("focused deck set correctly", deckPicker.viewModel.focusedDeck, equalTo(childB))
+
+            // Delete child B - should select A
+            deckPicker.viewModel.deleteDeck(childB).join()
+
+            assertThat("focused deck should be A after deletion", deckPicker.viewModel.focusedDeck, equalTo(childA))
+            assertThat("current deck should be A", col.decks.current().id, equalTo(childA))
+        }
+
+    @Test
+    fun `Deck deletion - ACTIVE_DECKS is set correctly`() =
+        runTest {
+            // Create a deck with cards
+            val deck = addDeck("TestDeck")
+            col.notetypes.byName("Basic")!!.did = deck
+            addBasicNote("front", "back")
+
+            val deckPicker =
+                startActivityNormallyOpenCollectionWithIntent(
+                    DeckPicker::class.java,
+                    Intent(),
+                )
+
+            // Verify the deck is in active decks
+            assertThat("deck should be active", col.decks.active().contains(deck), equalTo(true))
+
+            // Delete the deck
+            deckPicker.viewModel.deleteDeck(deck).join()
+
+            // Verify Default deck (1) is now active
+            assertThat("Default should be active", col.decks.active().contains(1L), equalTo(true))
+            assertThat("deleted deck should not be active", col.decks.active().contains(deck), equalTo(false))
+        }
+
+    @Test
+    fun `Deck deletion - undo brings the deck back`() =
+        runTest {
+            // Create parent with two children: A, B
+            val parent = addDeck("Parent")
+            val childA = addDeck("Parent::A", setAsSelected = true)
+            val childB = addDeck("Parent::B")
+
+            val deckPicker =
+                startActivityNormallyOpenCollectionWithIntent(
+                    DeckPicker::class.java,
+                    Intent(),
+                )
+
+            // Delete child A
+            deckPicker.viewModel.deleteDeck(childA).join()
+
+            assertThat("current deck should be B after deletion", col.decks.current().id, equalTo(childB))
+            assertThat("deck A should be deleted", col.decks.get(childA), nullValue())
+
+            // Undo the deletion
+            deckPicker.undoAndShowSnackbar()
+
+            assertThat("current deck should be A after undo", col.decks.current().id, equalTo(childA))
+            assertThat("deck A should be restored", col.decks.get(childA), notNullValue())
+        }
+
     enum class CollectionType(
         val assetFile: String,
         private val deckName: String,

--- a/libanki/src/main/java/com/ichi2/anki/libanki/sched/Scheduler.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/sched/Scheduler.kt
@@ -57,6 +57,7 @@ import com.ichi2.anki.libanki.QueueType
 import com.ichi2.anki.libanki.Utils
 import com.ichi2.anki.libanki.utils.LibAnkiAlias
 import com.ichi2.anki.libanki.utils.NotInPyLib
+import net.ankiweb.rsdroid.BackendException.BackendDbException
 import net.ankiweb.rsdroid.RustCleanup
 import timber.log.Timber
 import kotlin.math.ceil
@@ -502,9 +503,6 @@ open class Scheduler(
     @CheckResult
     fun repositionDefaults(): RepositionDefaultsResponse = col.backend.repositionDefaults()
 
-    @LibAnkiAlias("active_decks")
-    fun activeDecks(): List<DeckId> = col.db.queryLongList("SELECT id FROM active_decks")
-
     /**
      * @return Number of new card in current deck and its descendants. Capped at [REPORT_LIMIT]
      */
@@ -689,6 +687,20 @@ open class Scheduler(
     fun learnAheadSeconds(): Int = col.config.get("collapseTime") ?: 1200
 
     fun timeboxSecs(): Int = col.config.get("timeLim") ?: 0
+
+    /*
+     * Other legacy
+     * *******************
+     */
+
+    // called by col.decks.active(), which add-ons are using
+    @LibAnkiAlias("active_decks")
+    fun activeDecks(): List<DeckId> =
+        try {
+            col.db.queryLongList("SELECT id FROM active_decks")
+        } catch (_: BackendDbException) {
+            emptyList()
+        }
 }
 
 const val REPORT_LIMIT = 99999


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.8

<!--- Please fill the necessary details below -->
## Purpose / Description
On tablets, deleting a deck causes `StudyOptionsFragment` to display the Default deck, even when other non-Default decks remain.

## Fixes
* Part of #21087

## Approach
call sched.deckDueTree() to find the first remaining non-Default deck and decks.select() it, so that when StudyOptionsFragment.opExecuted() subsequently calls withCol { decks.current() }, it reads the correct deck instead of the Default that the backend resets to after removal.

## How Has This Been Tested?
Medium Tablet API 35

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->