### PR TITLE
fix(startup): handle when the user has not decided the storage type (App-Private/Public)

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -26,6 +26,7 @@ import android.net.Uri
 import anki.cards.FsrsMemoryState
 import anki.collection.OpChanges
 import anki.notetypes.StockNotetype
+import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.FlashCardsContract
 import com.ichi2.anki.common.time.TimeManager
@@ -48,6 +49,7 @@ import com.ichi2.anki.libanki.getStockNotetype
 import com.ichi2.anki.libanki.sched.Scheduler
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.provider.pureAnswer
+import com.ichi2.anki.storage.StorageDecision
 import com.ichi2.anki.testutil.DatabaseUtils.cursorFillWindow
 import com.ichi2.anki.testutil.GrantStoragePermission.storagePermission
 import com.ichi2.anki.testutil.addNote
@@ -260,6 +262,21 @@ class ContentProviderTest : InstrumentedTest() {
 
         assertThrows<RuntimeException>("RuntimeException is thrown when deleting note") {
             addedNote.load(col)
+        }
+    }
+
+    @Test
+    fun queryFailsWhenStorageIsUndecided() {
+        // regression test: must be a type Binder can marshal to the calling app
+        // (IllegalStateException), not StorageNotConfiguredException, which would
+        // kill the AnkiDroid process when a third-party app calls the API
+        CollectionHelper.storageDecisionTestOverride = StorageDecision.Undecided
+        try {
+            assertThrows<IllegalStateException>("query() while storage is undecided") {
+                contentResolver.query(FlashCardsContract.Note.CONTENT_URI, null, null, null, null)?.close()
+            }
+        } finally {
+            CollectionHelper.storageDecisionTestOverride = null
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -86,7 +86,6 @@ import com.ichi2.anki.dialogs.ExportReadyDialog.Companion.REQUEST_EXPORT_SHARE
 import com.ichi2.anki.dialogs.SimpleMessageDialog
 import com.ichi2.anki.dialogs.handleExportReadyRequest
 import com.ichi2.anki.dialogs.viewmodel.ExportReadyViewModel
-import com.ichi2.anki.exception.SystemStorageException
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.receiver.SdCardReceiver
 import com.ichi2.anki.settings.Prefs
@@ -686,25 +685,6 @@ open class AnkiActivity(
             ).toShortcutGroup(this)
 
         return listOfNotNull(shortcuts?.toShortcutGroup(this), generalShortcutGroup)
-    }
-
-    /**
-     * If storage permissions are not granted, shows a toast message and finishes the activity.
-     *
-     * This should be called AFTER a call to `super.`[onCreate]
-     *
-     * @return `true`: activity may continue to start, `false`: [onCreate] should stop executing
-     * as storage permissions are mot granted
-     *
-     * @throws SystemStorageException if `getExternalFilesDir` returns null
-     */
-    fun ensureStoragePermissions(): Boolean {
-        if (IntentHandler.grantedStoragePermissions(this, showToast = true)) {
-            return true
-        }
-        Timber.w("finishing activity. No storage permission")
-        finish()
-        return false
     }
 
     override val shortcuts

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -81,6 +81,7 @@ import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.scheduling.registerOnForgetHandler
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.startup.ensureStoragePermissions
 import com.ichi2.anki.ui.ResizablePaneManager
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.ext.addPrepareMenuProvider

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -81,7 +81,7 @@ import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.scheduling.registerOnForgetHandler
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
-import com.ichi2.anki.startup.ensureStoragePermissions
+import com.ichi2.anki.startup.ensureStorageIsReady
 import com.ichi2.anki.ui.ResizablePaneManager
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.ext.addPrepareMenuProvider
@@ -192,7 +192,7 @@ open class CardBrowser :
         }
         super.onCreate(savedInstanceState)
         binding = ActivityCardBrowserBinding.inflate(layoutInflater)
-        if (!ensureStoragePermissions()) {
+        if (!ensureStorageIsReady()) {
             return
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorActivity.kt
@@ -32,7 +32,7 @@ import com.ichi2.anki.previewer.TemplatePreviewerFragment
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
-import com.ichi2.anki.startup.ensureStoragePermissions
+import com.ichi2.anki.startup.ensureStorageIsReady
 import com.ichi2.anki.ui.ResizablePaneManager
 import com.ichi2.anki.utils.ext.doOnTabSelected
 import kotlinx.coroutines.Job
@@ -87,7 +87,7 @@ class NoteEditorActivity :
             return
         }
         super.onCreate(savedInstanceState)
-        if (!ensureStoragePermissions()) {
+        if (!ensureStorageIsReady()) {
             return
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorActivity.kt
@@ -32,6 +32,7 @@ import com.ichi2.anki.previewer.TemplatePreviewerFragment
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
+import com.ichi2.anki.startup.ensureStoragePermissions
 import com.ichi2.anki.ui.ResizablePaneManager
 import com.ichi2.anki.utils.ext.doOnTabSelected
 import kotlinx.coroutines.Job

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -107,6 +107,7 @@ import com.ichi2.anki.servicelayer.NoteService.toggleMark
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.settings.enums.DayTheme
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.startup.ensureStoragePermissions
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.ui.windows.reviewer.ReviewerFragment
 import com.ichi2.anki.utils.ext.cardStatsNoCardClean

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -107,7 +107,7 @@ import com.ichi2.anki.servicelayer.NoteService.toggleMark
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.settings.enums.DayTheme
 import com.ichi2.anki.snackbar.showSnackbar
-import com.ichi2.anki.startup.ensureStoragePermissions
+import com.ichi2.anki.startup.ensureStorageIsReady
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.ui.windows.reviewer.ReviewerFragment
 import com.ichi2.anki.utils.ext.cardStatsNoCardClean
@@ -220,7 +220,7 @@ open class Reviewer :
             return
         }
         super.onCreate(savedInstanceState)
-        if (!ensureStoragePermissions()) {
+        if (!ensureStorageIsReady()) {
             return
         }
         colorPalette = findViewById(R.id.whiteboard_editor)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
@@ -28,6 +28,7 @@ import com.ichi2.anki.android.input.ShortcutGroupProvider
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
+import com.ichi2.anki.startup.ensureStoragePermissions
 import com.ichi2.anki.ui.windows.managespace.ManageSpaceActivity
 import com.ichi2.anki.utils.ConfigAwareSingleFragmentActivity
 import com.ichi2.anki.utils.ext.setFragmentResultListener

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
@@ -22,13 +22,12 @@ import android.view.KeyEvent
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentContainerView
 import androidx.fragment.app.commit
-import com.ichi2.anki.SingleFragmentActivity.Companion.getIntent
 import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.ShortcutGroupProvider
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
-import com.ichi2.anki.startup.ensureStoragePermissions
+import com.ichi2.anki.startup.ensureStorageIsReady
 import com.ichi2.anki.ui.windows.managespace.ManageSpaceActivity
 import com.ichi2.anki.utils.ConfigAwareSingleFragmentActivity
 import com.ichi2.anki.utils.ext.setFragmentResultListener
@@ -62,7 +61,7 @@ open class SingleFragmentActivity :
         }
 
         super.onCreate(savedInstanceState)
-        if (!ensureStoragePermissions()) {
+        if (!ensureStorageIsReady()) {
             return
         }
         setTransparentStatusBar()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
@@ -56,7 +56,7 @@ import com.ichi2.anki.libanki.NotetypeJson
 import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.servicelayer.NoteService
-import com.ichi2.anki.startup.ensureStoragePermissions
+import com.ichi2.anki.startup.ensureStorageIsReady
 import com.ichi2.anki.withProgress
 import com.ichi2.themes.setTransparentBackground
 import com.ichi2.utils.AndroidUiUtils.hideKeyboard
@@ -114,7 +114,7 @@ class InstantNoteEditorActivity : AnkiActivity(R.layout.activity_instant_note_ed
             return
         }
         super.onCreate(savedInstanceState)
-        if (!ensureStoragePermissions()) {
+        if (!ensureStorageIsReady()) {
             return
         }
         setTransparentBackground()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
@@ -56,6 +56,7 @@ import com.ichi2.anki.libanki.NotetypeJson
 import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.servicelayer.NoteService
+import com.ichi2.anki.startup.ensureStoragePermissions
 import com.ichi2.anki.withProgress
 import com.ichi2.themes.setTransparentBackground
 import com.ichi2.utils.AndroidUiUtils.hideKeyboard

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -38,6 +38,7 @@ import com.ichi2.anki.FlashCardsContract
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
+import com.ichi2.anki.exception.StorageNotConfiguredException
 import com.ichi2.anki.libanki.Card
 import com.ichi2.anki.libanki.CardId
 import com.ichi2.anki.libanki.CardTemplate
@@ -221,6 +222,20 @@ class CardContentProvider : ContentProvider() {
      */
     private fun shouldEnforceUpdateSecurity(uri: Uri): Boolean = true
 
+    /**
+     * The collection, opened if necessary.
+     *
+     * @throws IllegalStateException if the user has not yet chosen where the collection is
+     * stored.
+     */
+    private fun getColUnsafe(): Collection =
+        try {
+            CollectionManager.getColUnsafe()
+        } catch (e: StorageNotConfiguredException) {
+            // StorageNotConfiguredException is not supported by Parcel.writeException
+            throw IllegalStateException("AnkiDroid storage is not configured", e)
+        }
+
     override fun query(
         uri: Uri,
         projection: Array<String>?,
@@ -231,7 +246,7 @@ class CardContentProvider : ContentProvider() {
         if (!hasReadWritePermission() && shouldEnforceQueryOrInsertSecurity()) {
             throwSecurityException("query", uri)
         }
-        val col = CollectionManager.getColUnsafe()
+        val col = getColUnsafe()
         Timber.d(getLogMessage("query", uri))
 
         // Find out what data the user is requesting
@@ -485,7 +500,7 @@ class CardContentProvider : ContentProvider() {
         if (!hasReadWritePermission() && shouldEnforceUpdateSecurity(uri)) {
             throwSecurityException("update", uri)
         }
-        val col = CollectionManager.getColUnsafe()
+        val col = getColUnsafe()
         Timber.d(getLogMessage("update", uri))
 
         // Find out what data the user is requesting
@@ -748,7 +763,7 @@ class CardContentProvider : ContentProvider() {
         if (!hasReadWritePermission()) {
             throwSecurityException("delete", uri)
         }
-        val col = CollectionManager.getColUnsafe()
+        val col = getColUnsafe()
         Timber.d(getLogMessage("delete", uri))
 
         val deletedCount =
@@ -827,7 +842,7 @@ class CardContentProvider : ContentProvider() {
         if (valuesArr.isNullOrEmpty()) {
             return 0
         }
-        val col = CollectionManager.getColUnsafe()
+        val col = getColUnsafe()
         if (col.decks.isFiltered(deckId)) {
             throw IllegalArgumentException("A filtered deck cannot be specified as the deck in bulkInsertNotes")
         }
@@ -878,7 +893,7 @@ class CardContentProvider : ContentProvider() {
         if (!hasReadWritePermission() && shouldEnforceQueryOrInsertSecurity()) {
             throwSecurityException("insert", uri)
         }
-        val col = CollectionManager.getColUnsafe()
+        val col = getColUnsafe()
         Timber.d(getLogMessage("insert", uri))
 
         // Find out what data the user is requesting

--- a/AnkiDroid/src/main/java/com/ichi2/anki/startup/StartupGuards.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/startup/StartupGuards.kt
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.startup
+
+import android.app.Activity
+import com.ichi2.anki.IntentHandler
+import com.ichi2.anki.exception.SystemStorageException
+import timber.log.Timber
+
+/**
+ * If storage permissions are not granted, shows a toast message and finishes the activity.
+ *
+ * This should be called AFTER a call to `super.`[onCreate][Activity.onCreate]
+ *
+ * @return `true`: activity may continue to start, `false`: [onCreate][Activity.onCreate]
+ * should stop executing as storage permissions are mot granted
+ *
+ * @throws SystemStorageException if `getExternalFilesDir` returns null
+ */
+fun Activity.ensureStoragePermissions(): Boolean {
+    if (IntentHandler.grantedStoragePermissions(this, showToast = true)) {
+        return true
+    }
+    Timber.w("finishing activity. No storage permission")
+    finish()
+    return false
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/startup/StartupGuards.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/startup/StartupGuards.kt
@@ -3,25 +3,83 @@
 package com.ichi2.anki.startup
 
 import android.app.Activity
+import android.content.Intent
+import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.IntentHandler
 import com.ichi2.anki.exception.SystemStorageException
+import com.ichi2.anki.storage.StorageDecision
 import timber.log.Timber
 
 /**
- * If storage permissions are not granted, shows a toast message and finishes the activity.
+ * Ensures storage is ready for use, finishes the activity is otherwise.
+ *
+ * - the user has decided where the collection is stored
+ * - the app has permission to access
  *
  * This should be called AFTER a call to `super.`[onCreate][Activity.onCreate]
+ *
+ * @return `true`: activity may continue to start, `false`: [onCreate][Activity.onCreate]
+ * should stop executing
+ *
+ * @throws SystemStorageException if `getExternalFilesDir` returns null
+ */
+fun Activity.ensureStorageIsReady(): Boolean {
+    // The storage decision is checked first
+    // as the permissions required depend on the chosen folder
+    return ensureStorageIsConfigured() && ensureStoragePermissions()
+}
+
+/**
+ * If the user has not yet decided where the collection is stored, finishes the
+ * activity and redirects to the app start.
+ *
+ * Catches launches which bypass [IntentHandler]: pinned shortcuts, task restoration
+ * and internal navigation.
+ *
+ * @return `true`: activity may continue to start, `false`: [onCreate][Activity.onCreate]
+ * should stop executing as storage is not configured
+ *
+ * @see redirectToMainEntryPoint
+ */
+private fun Activity.ensureStorageIsConfigured(): Boolean {
+    if (CollectionHelper.storageDecision() == StorageDecision.Decided) {
+        return true
+    }
+    Timber.w("finishing activity. Storage is not configured")
+    redirectToMainEntryPoint()
+    return false
+}
+
+/**
+ * If storage permissions are not granted, shows a toast message and finishes the activity.
  *
  * @return `true`: activity may continue to start, `false`: [onCreate][Activity.onCreate]
  * should stop executing as storage permissions are mot granted
  *
  * @throws SystemStorageException if `getExternalFilesDir` returns null
  */
-fun Activity.ensureStoragePermissions(): Boolean {
+private fun Activity.ensureStoragePermissions(): Boolean {
     if (IntentHandler.grantedStoragePermissions(this, showToast = true)) {
         return true
     }
     Timber.w("finishing activity. No storage permission")
     finish()
     return false
+}
+
+/**
+ * Finishes this activity and opens the primary entry point.
+ *
+ * Use when an entry point cannot run (e.g. storage is not configured), the target screen handles
+ * the failures.
+ */
+fun Activity.redirectToMainEntryPoint() {
+    Timber.i("redirecting to app start")
+    startActivity(
+        Intent(this, IntentHandler::class.java).apply {
+            action = Intent.ACTION_MAIN
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        },
+    )
+    finish()
 }

--- a/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidgetConfig.kt
@@ -35,7 +35,7 @@ import com.ichi2.anki.dialogs.startDeckSelection
 import com.ichi2.anki.isCollectionEmpty
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.model.SelectableDeck
-import com.ichi2.anki.startup.ensureStoragePermissions
+import com.ichi2.anki.startup.ensureStorageIsReady
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.withProgress
 import com.ichi2.widget.AppWidgetId.Companion.INVALID_APPWIDGET_ID
@@ -74,7 +74,7 @@ class CardAnalysisWidgetConfig : AnkiActivity(R.layout.activity_card_analysis_wi
         }
         super.onCreate(savedInstanceState)
 
-        if (!ensureStoragePermissions()) {
+        if (!ensureStorageIsReady()) {
             return
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidgetConfig.kt
@@ -35,6 +35,7 @@ import com.ichi2.anki.dialogs.startDeckSelection
 import com.ichi2.anki.isCollectionEmpty
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.model.SelectableDeck
+import com.ichi2.anki.startup.ensureStoragePermissions
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.withProgress
 import com.ichi2.widget.AppWidgetId.Companion.INVALID_APPWIDGET_ID

--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
@@ -47,6 +47,7 @@ import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.startup.ensureStoragePermissions
 import com.ichi2.widget.AppWidgetId.Companion.INVALID_APPWIDGET_ID
 import com.ichi2.widget.AppWidgetId.Companion.getAppWidgetId
 import com.ichi2.widget.AppWidgetId.Companion.updateWidget

--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
@@ -47,7 +47,7 @@ import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
-import com.ichi2.anki.startup.ensureStoragePermissions
+import com.ichi2.anki.startup.ensureStorageIsReady
 import com.ichi2.widget.AppWidgetId.Companion.INVALID_APPWIDGET_ID
 import com.ichi2.widget.AppWidgetId.Companion.getAppWidgetId
 import com.ichi2.widget.AppWidgetId.Companion.updateWidget
@@ -89,7 +89,7 @@ class DeckPickerWidgetConfig :
 
         super.onCreate(savedInstanceState)
 
-        if (!ensureStoragePermissions()) {
+        if (!ensureStorageIsReady()) {
             return
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ExternalEntryPointsUndecidedStorageTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ExternalEntryPointsUndecidedStorageTest.kt
@@ -10,11 +10,9 @@ import android.content.ContentProvider
 import android.content.Intent
 import android.os.Build
 import androidx.core.net.toUri
-import com.ichi2.anki.provider.CardContentProvider
 import com.ichi2.anki.storage.StorageDecision
 import com.ichi2.testutils.ExternalEntryPoints.EntryPoint
 import com.ichi2.testutils.grantPermissions
-import com.ichi2.testutils.skipTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -23,12 +21,11 @@ import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.Robolectric
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.shadows.ShadowMediaPlayer
+import kotlin.test.assertFailsWith
 import kotlin.test.fail
 
 /**
  * Handles the [CollectionHelper.storageDecision] returning [StorageDecision.Undecided].
- *
- * Entry points which do not yet handle the scenario are skipped: see [notYetHandledEntryPoints].
  */
 @RunWith(ParameterizedRobolectricTestRunner::class)
 class ExternalEntryPointsUndecidedStorageTest : RobolectricTest() {
@@ -50,17 +47,6 @@ class ExternalEntryPointsUndecidedStorageTest : RobolectricTest() {
     @After
     fun resetStorageDecision() {
         CollectionHelper.storageDecisionTestOverride = null
-    }
-
-    @Before
-    fun notYetHandledEntryPoints() {
-        notYetHandled<CardContentProvider>("query() opens the collection; the exception escapes over Binder, killing the process")
-    }
-
-    private inline fun <reified T : Any> notYetHandled(reason: String) {
-        if (entryPoint!!.className == T::class.qualifiedName) {
-            skipTest("${T::class.simpleName} does not yet handle undecided storage: $reason")
-        }
     }
 
     @Test
@@ -154,7 +140,10 @@ class ExternalEntryPointsUndecidedStorageTest : RobolectricTest() {
                 .buildContentProvider(providerClass)
                 .create(FlashCardsContract.AUTHORITY)
                 .get()
-        provider.query(FlashCardsContract.Note.CONTENT_URI, null, null, null, null)?.close()
+        // IllegalStateException is expected. A custom exception kills the process
+        assertFailsWith<IllegalStateException> {
+            provider.query(FlashCardsContract.Note.CONTENT_URI, null, null, null, null)?.close()
+        }
     }
 
     companion object {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ExternalEntryPointsUndecidedStorageTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ExternalEntryPointsUndecidedStorageTest.kt
@@ -10,14 +10,11 @@ import android.content.ContentProvider
 import android.content.Intent
 import android.os.Build
 import androidx.core.net.toUri
-import com.ichi2.anki.instantnoteeditor.InstantNoteEditorActivity
 import com.ichi2.anki.provider.CardContentProvider
 import com.ichi2.anki.storage.StorageDecision
 import com.ichi2.testutils.ExternalEntryPoints.EntryPoint
 import com.ichi2.testutils.grantPermissions
 import com.ichi2.testutils.skipTest
-import com.ichi2.widget.cardanalysis.CardAnalysisWidgetConfig
-import com.ichi2.widget.deckpicker.DeckPickerWidgetConfig
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -57,10 +54,6 @@ class ExternalEntryPointsUndecidedStorageTest : RobolectricTest() {
 
     @Before
     fun notYetHandledEntryPoints() {
-        notYetHandled<Reviewer>("setupFlags (onCreateOptionsMenu) reads flag names from the collection; the failure is unhandled")
-        notYetHandled<InstantNoteEditorActivity>("InstantEditorViewModel opens the collection when constructed; the failure is unhandled")
-        notYetHandled<DeckPickerWidgetConfig>("onCreate calls isCollectionEmpty(); the failure is unhandled")
-        notYetHandled<CardAnalysisWidgetConfig>("onCreate calls isCollectionEmpty(); shows an error dialog, not the setup flow")
         notYetHandled<CardContentProvider>("query() opens the collection; the exception escapes over Binder, killing the process")
     }
 
@@ -131,7 +124,15 @@ class ExternalEntryPointsUndecidedStorageTest : RobolectricTest() {
         }
         val controller = Robolectric.buildActivity(activityClass, entryPoint!!.externalIntent())
         saveControllerForCleanup(controller)
-        controller.setup()
+        // mirrors Android: an activity which finishes during onCreate (e.g. redirectToMainEntryPoint)
+        // does not receive the remaining lifecycle callbacks; controller.setup() would force them
+        controller.create()
+        if (controller.get().isFinishing) return
+        controller
+            .start()
+            .postCreate(null)
+            .resume()
+            .visible()
     }
 
     private fun sendBroadcast(className: String) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/startup/StartupGuardsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/startup/StartupGuardsTest.kt
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.startup
+
+import android.app.Activity
+import android.content.Intent
+import androidx.core.content.edit
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.IntentHandler
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.storage.StorageDecision
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.Shadows.shadowOf
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@RunWith(AndroidJUnit4::class)
+class StartupGuardsTest : RobolectricTest() {
+    @After
+    fun resetStorageDecision() {
+        CollectionHelper.storageDecisionTestOverride = null
+    }
+
+    private fun buildActivity(): Activity = Robolectric.buildActivity(Activity::class.java).create().get()
+
+    @Test
+    fun `passes when storage is decided and accessible`() {
+        val activity = buildActivity()
+
+        assertTrue(activity.ensureStorageIsReady())
+
+        assertFalse(activity.isFinishing, "activity should continue to start")
+        assertNull(shadowOf(activity).nextStartedActivity, "no redirect expected")
+    }
+
+    @Test
+    fun `redirects to the main entry point when storage is undecided`() {
+        CollectionHelper.storageDecisionTestOverride = StorageDecision.Undecided
+        val activity = buildActivity()
+
+        assertFalse(activity.ensureStorageIsReady())
+
+        assertTrue(activity.isFinishing, "activity should finish")
+        val redirect = shadowOf(activity).nextStartedActivity
+        assertNotNull(redirect, "the main entry point should be opened")
+        assertEquals(IntentHandler::class.qualifiedName, redirect.component?.className)
+        assertEquals(Intent.ACTION_MAIN, redirect.action)
+        val expectedFlags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        assertEquals(expectedFlags, redirect.flags and expectedFlags, "task should be cleared")
+    }
+
+    @Test
+    fun `finishes without redirect when a legacy folder is inaccessible`() {
+        // a legacy collection folder requires storage permissions, which tests do not hold
+        targetContext.sharedPrefs().edit {
+            putString(CollectionHelper.PREF_COLLECTION_PATH, "/storage/emulated/0/AnkiDroid")
+        }
+        val activity = buildActivity()
+
+        assertFalse(activity.ensureStorageIsReady())
+
+        assertTrue(activity.isFinishing, "activity should finish")
+        assertNull(shadowOf(activity).nextStartedActivity, "no redirect expected")
+    }
+}

--- a/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
+++ b/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
@@ -91,6 +91,9 @@ import com.ichi2.anki.api.Ease
  *                             | Supports query(). For code examples see class description of [Model].
  * --------------------------------------------------------------------------------------------------------------------
  * ```
+ *
+ * If AnkiDroid's storage is not yet configured (the user has not completed first-run setup),
+ * operations on this provider throw [IllegalStateException].
  */
 public object FlashCardsContract {
     public const val AUTHORITY: String = BuildConfig.AUTHORITY


### PR DESCRIPTION
> Assisted-by: Claude Fable 5
> implemented after a long discussion: comments, discussion and naming are mine

## Purpose / Description
This is theoretical and works in order to get `ExternalEntryPointsUndecidedStorageTest` working.

I want to move AnkiDroid away from implicit collection creation in `withCol` into a deferred 'startup' path in order to remove complexity, allow for easy migration of `CollectionHelper`/`CollectionManager` to `:anki-common`, and better support for choosing a non-public AnkiDroid folder:

* https://github.com/ankidroid/Anki-Android/issues/13574

## Fixes
* Fixes some of https://github.com/ankidroid/Anki-Android/issues/19552
* Yak shave for https://github.com/ankidroid/Anki-Android/issues/20737

## Approach
If the storage location is undecided:
* Redirect to `IntentHandler` if in the app
* ⚠️ Crash the content-provider API, as this cannot be handled from the user's perspective
  * **Optional follow-up**: we may want to add a follow-up issue to handle this more gracefully on 
  * **Optional follow-up**: do we want to add a localized exception message?

## How Has This Been Tested?
This code exists to make a unit test pass

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)