### PR TITLE
refactor: add more AnkiDroidApp profiling and refactor startup

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -184,10 +184,7 @@ open class AnkiDroidApp :
         CardBrowser.clearLastDeckId()
         val anki = AnkiContext.apply { setupAnkiBackend() }
         with(anki) { initializeAnkiDroidDirectory() }
-
-        // listen for day rollover: time + timezone changes
-        DayRolloverHandler.listenForRolloverEvents(this)
-        DayRolloverAlarm.scheduleNext(this)
+        with(anki) { setupDayRollover() }
 
         restoreRecurringAlarms(this)
 
@@ -360,6 +357,14 @@ open class AnkiDroidApp :
     private fun setupAnkiBackend() =
         setup("setupAnkiBackend") {
             LanguageUtil.setDefaultBackendLanguages()
+        }
+
+    /** Listen for day rollover: time + timezone changes and refresh on the day cutoff. */
+    context(_: AnkiContext)
+    private fun setupDayRollover() =
+        setup("setupDayRollover") {
+            DayRolloverHandler.listenForRolloverEvents(this)
+            DayRolloverAlarm.scheduleNext(this)
         }
 
     private fun setupLifecycleLogging() =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -190,9 +190,7 @@ open class AnkiDroidApp :
 
         setupLifecycleLogging()
         activityAgnosticDialogs = ActivityAgnosticDialogs.register(this)
-        TtsVoices.launchBuildLocalesJob()
-        // enable {{tts-voices:}} field filter
-        TtsVoicesFieldFilter.ensureApplied()
+        setupTextToSpeech()
     }
 
     /**
@@ -416,6 +414,14 @@ open class AnkiDroidApp :
                 },
             )
         }
+
+    private fun setupTextToSpeech() {
+        setup("setupTextToSpeech") {
+            TtsVoices.launchBuildLocalesJob()
+            // enable {{tts-voices:}} field filter
+            TtsVoicesFieldFilter.ensureApplied()
+        }
+    }
 
     /**
      * @return the app version, OS version and device model, provided when syncing.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -182,9 +182,8 @@ open class AnkiDroidApp :
 
         // Forget the last deck that was used in the CardBrowser
         CardBrowser.clearLastDeckId()
-        LanguageUtil.setDefaultBackendLanguages()
-
-        initializeAnkiDroidDirectory()
+        val anki = AnkiContext.apply { setupAnkiBackend() }
+        with(anki) { initializeAnkiDroidDirectory() }
 
         // listen for day rollover: time + timezone changes
         DayRolloverHandler.listenForRolloverEvents(this)
@@ -254,6 +253,7 @@ open class AnkiDroidApp :
      * In most cases the Anki Backend now creates the collection and [initializeAnkiDroidDirectory]
      *  is called on startup of the activity.
      */
+    context(_: AnkiContext)
     private fun initializeAnkiDroidDirectory() =
         setup("initializeAnkiDroidDirectory") {
             // #13207: `getCurrentAnkiDroidDirectory` failing is an unconditional be a fatal error
@@ -352,11 +352,15 @@ open class AnkiDroidApp :
      * @see opExecuted
      * @see ChangeManager
      */
-    private fun setupBackendChangeManager() {
+    private fun setupBackendChangeManager() =
         setup("setupBackendChangeManager") {
             ChangeManager.subscribe(this)
         }
-    }
+
+    private fun setupAnkiBackend() =
+        setup("setupAnkiBackend") {
+            LanguageUtil.setDefaultBackendLanguages()
+        }
 
     private fun setupLifecycleLogging() =
         setup("setupLifecycleLogging") {
@@ -465,6 +469,16 @@ open class AnkiDroidApp :
             Timber.d("No relevant changes to update the widget")
         }
     }
+
+    /**
+     * Initialization for the Anki Backend has completed:
+     * - [initAnkiBackend] - platform environment variables/logging
+     * - [makeBackendUsable] - load rsdroid.so
+     * - [setupBackendChangeManager] - change manager is subscribed
+     * - [setupAnkiBackend] - i18n is set up
+     */
+
+    object AnkiContext
 
     companion object {
         /**


### PR DESCRIPTION
In particular, this adds `AnkiContext` as a means to order dependencies. I plan to add `CrashReportingContext` in a follow-up PR

## Fixes
* Split from #20593 -  see this for more details

## Testing

```
Timber config: DEBUG
AnkiDroidApp: listing debug info
executed setupContextMenus in 885.5us
executed makeBackendUsable in 164.584us
AnkiDroidApp: Starting Services
executed setupNotifications in 8.013542ms
executed setupAppLifecycleObserver in 101.375us
executed setupBackendChangeManager in 7.502458ms
executed setupAnkiBackend in 1.263500ms
executed initializeAnkiDroidDirectory in 1.301166ms
executed setupDayRollover in 7.674542ms
executed setupLifecycleLogging in 539.584us
executed setupTextToSpeech in 1.201458ms
```

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)