### PR TITLE
fix: avoid TransactionTooLargeException with many-field note types

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.kt
@@ -18,9 +18,7 @@ package com.ichi2.anki
 import android.content.Context
 import android.graphics.drawable.Drawable
 import android.os.Build
-import android.os.Parcel
 import android.os.Parcelable
-import android.os.Parcelable.ClassLoaderCreator
 import android.util.AttributeSet
 import android.util.SparseArray
 import android.view.ActionMode
@@ -29,7 +27,6 @@ import android.view.View
 import android.widget.FrameLayout
 import androidx.annotation.DrawableRes
 import androidx.constraintlayout.widget.ConstraintSet
-import androidx.core.os.ParcelCompat
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import com.ichi2.anki.common.utils.android.getDensityAdjustedValue
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
@@ -37,6 +34,7 @@ import com.ichi2.anki.compat.setTooltipTextCompat
 import com.ichi2.anki.databinding.ViewCardMultimediaEditlineBinding
 import com.ichi2.ui.AnimationUtil.collapseView
 import com.ichi2.ui.AnimationUtil.expandView
+import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
 @KotlinCleanup("replace _name with `field`")
@@ -146,102 +144,38 @@ class FieldEditLine : FrameLayout {
 
     // keeps platform defined nullability
     @Suppress("RedundantNullableReturnType")
-    public override fun onSaveInstanceState(): Parcelable? {
-        val state = super.onSaveInstanceState()
-        val savedState = SavedState(state)
-        savedState.childrenStates = SparseArray()
-        savedState.editTextId = binding.editText.id
-        savedState.toggleStickyId = binding.toggleSticky.id
-        savedState.mediaButtonId = binding.mediaButton.id
-        savedState.expandButtonId = binding.expandButton.id
-        for (i in 0 until childCount) {
-            getChildAt(i).saveHierarchyState(savedState.childrenStates)
-        }
-        savedState.expansionState = expansionState
-        return savedState
-    }
+    public override fun onSaveInstanceState(): Parcelable? =
+        SavedState(
+            state = super.onSaveInstanceState(),
+            name = _name,
+            content = binding.editText.text?.toString(),
+            ord = binding.editText.ord,
+            expansionState = expansionState,
+        )
 
     public override fun onRestoreInstanceState(state: Parcelable) {
         if (state !is SavedState) {
             super.onRestoreInstanceState(state)
             return
         }
-        val editTextId = binding.editText.id
-        val toggleStickyId = binding.toggleSticky.id
-        val mediaButtonId = binding.mediaButton.id
-        val expandButtonId = binding.expandButton.id
-        binding.editText.id = state.editTextId
-        binding.toggleSticky.id = state.toggleStickyId
-        binding.mediaButton.id = state.mediaButtonId
-        binding.expandButton.id = state.expandButtonId
         super.onRestoreInstanceState(state.superState)
-        for (i in 0 until childCount) {
-            getChildAt(i).restoreHierarchyState(state.childrenStates)
-        }
-        binding.editText.id = editTextId
-        binding.toggleSticky.id = toggleStickyId
-        binding.mediaButton.id = mediaButtonId
-        binding.expandButton.id = expandButtonId
+        name = state.name
+        setContent(state.content, replaceNewline = false)
+        binding.editText.ord = state.ord
         if (expansionState != state.expansionState) {
             toggleExpansionState()
         }
-        expansionState = state.expansionState ?: ExpansionState.EXPANDED
+        expansionState = state.expansionState
     }
 
-    @KotlinCleanup("convert to parcelable")
-    internal class SavedState : BaseSavedState {
-        var childrenStates: SparseArray<Parcelable>? = null
-        var editTextId = 0
-        var toggleStickyId = 0
-        var mediaButtonId = 0
-        var expandButtonId = 0
-        var expansionState: ExpansionState? = null
-
-        constructor(superState: Parcelable?) : super(superState)
-
-        override fun writeToParcel(
-            out: Parcel,
-            flags: Int,
-        ) {
-            super.writeToParcel(out, flags)
-            out.writeSparseArray(childrenStates)
-            out.writeInt(editTextId)
-            out.writeInt(toggleStickyId)
-            out.writeInt(mediaButtonId)
-            out.writeInt(expandButtonId)
-            out.writeSerializable(expansionState)
-        }
-
-        private constructor(source: Parcel, loader: ClassLoader) : super(source) {
-            childrenStates = ParcelCompat.readSparseArray(source, loader, Parcelable::class.java)
-            editTextId = source.readInt()
-            toggleStickyId = source.readInt()
-            mediaButtonId = source.readInt()
-            expandButtonId = source.readInt()
-            expansionState =
-                ParcelCompat.readSerializable(
-                    source,
-                    ExpansionState::class.java.classLoader,
-                    ExpansionState::class.java,
-                )
-        }
-
-        companion object {
-            @JvmField // required field that makes Parcelables from a Parcel
-            @Suppress("unused")
-            val CREATOR: Parcelable.Creator<SavedState> =
-                object : ClassLoaderCreator<SavedState> {
-                    override fun createFromParcel(
-                        source: Parcel,
-                        loader: ClassLoader,
-                    ): SavedState = SavedState(source, loader)
-
-                    override fun createFromParcel(source: Parcel): SavedState = throw IllegalStateException()
-
-                    override fun newArray(size: Int): Array<SavedState?> = arrayOfNulls(size)
-                }
-        }
-    }
+    @Parcelize
+    internal class SavedState(
+        val state: Parcelable?,
+        val name: String?,
+        val content: String?,
+        val ord: Int,
+        val expansionState: ExpansionState,
+    ) : BaseSavedState(state)
 
     enum class ExpansionState {
         EXPANDED,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.kt
@@ -151,6 +151,8 @@ class FieldEditLine : FrameLayout {
             content = binding.editText.text?.toString(),
             ord = binding.editText.ord,
             expansionState = expansionState,
+            selectionStart = binding.editText.selectionStart,
+            selectionEnd = binding.editText.selectionEnd,
         )
 
     public override fun onRestoreInstanceState(state: Parcelable) {
@@ -161,6 +163,11 @@ class FieldEditLine : FrameLayout {
         super.onRestoreInstanceState(state.superState)
         name = state.name
         setContent(state.content, replaceNewline = false)
+        // put the cursor/selection back where it was, ignoring stale out of range values
+        val textLength = binding.editText.text?.length ?: 0
+        if (state.selectionStart in 0..textLength && state.selectionEnd in 0..textLength) {
+            binding.editText.setSelection(state.selectionStart, state.selectionEnd)
+        }
         binding.editText.ord = state.ord
         if (expansionState != state.expansionState) {
             toggleExpansionState()
@@ -175,6 +182,8 @@ class FieldEditLine : FrameLayout {
         val content: String?,
         val ord: Int,
         val expansionState: ExpansionState,
+        val selectionStart: Int,
+        val selectionEnd: Int,
     ) : BaseSavedState(state)
 
     enum class ExpansionState {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -21,6 +21,9 @@ import android.app.Activity
 import android.content.ClipData
 import android.content.Intent
 import android.os.Bundle
+import android.os.Parcel
+import android.os.Parcelable
+import android.util.SparseArray
 import android.widget.EditText
 import android.widget.Spinner
 import android.widget.TextView
@@ -52,6 +55,7 @@ import kotlinx.coroutines.runBlocking
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.lessThan
 import org.hamcrest.Matchers.not
 import org.junit.Ignore
 import org.junit.Test
@@ -89,6 +93,32 @@ class NoteEditorTest : RobolectricTest() {
             val actualResourceId = noteEditor.snackbarErrorText
             assertThat(actualResourceId, equalTo(CollectionManager.TR.addingTheFirstFieldIsEmpty()))
         }
+
+    @Test
+    fun savedFieldStateStaysWithinTransactionLimit() {
+        val fieldCount = 400
+        val fields = Array(fieldCount) { "Field$it" }
+        val noteTypeName = addStandardNoteType("Many Fields", fields, "{{Field0}}", "{{Field0}}")
+        val notetype = col.notetypes.byName(noteTypeName)!!
+        val editor = NoteEditorTestBuilder(notetype).build()
+
+        val viewState = SparseArray<Parcelable>()
+        editor.requireView().saveHierarchyState(viewState)
+        val parcel = Parcel.obtain()
+        val sizeInBytes =
+            try {
+                parcel.writeSparseArray(viewState)
+                parcel.dataSize()
+            } finally {
+                parcel.recycle()
+            }
+
+        assertThat(
+            "saved field state for $fieldCount fields must stay well under the Binder limit (was $sizeInBytes bytes)",
+            sizeInBytes,
+            lessThan(256 * 1024),
+        )
+    }
 
     @Test
     fun testErrorMessageNull() =

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -24,6 +24,7 @@ import android.os.Bundle
 import android.os.Parcel
 import android.os.Parcelable
 import android.util.SparseArray
+import android.view.View
 import android.widget.EditText
 import android.widget.Spinner
 import android.widget.TextView
@@ -118,6 +119,31 @@ class NoteEditorTest : RobolectricTest() {
             sizeInBytes,
             lessThan(256 * 1024),
         )
+    }
+
+    @Test
+    fun cursorSelectionIsRetainedAcrossViewStateRestore() {
+        val editor =
+            getNoteEditorAdding(NoteType.BASIC)
+                .withFirstField("hello world")
+                .build()
+        val editText = editor.getFieldForTest(0)
+        editText.setSelection(2, 5)
+
+        var lineView: View = editText
+        while (lineView !is FieldEditLine) {
+            lineView = lineView.parent as View
+        }
+        val viewState = SparseArray<Parcelable>()
+        lineView.saveHierarchyState(viewState)
+
+        // restore into a fresh line, as happens after a configuration change
+        val restored = FieldEditLine(editor.requireContext())
+        restored.id = lineView.id
+        restored.restoreHierarchyState(viewState)
+
+        assertThat(restored.binding.editText.selectionStart, equalTo(2))
+        assertThat(restored.binding.editText.selectionEnd, equalTo(5))
     }
 
     @Test


### PR DESCRIPTION
> [!NOTE]  
> Assisted by Opus 4.6 for tests (test)

<!--- Please fill the necessary details below -->
## Purpose / Description
A note type with a very large number of fields (e.g. ~400) crashes the note editor with `TransactionTooLargeException` when the editor is stopped  i.e. when the app is backgrounded or the previewer is opened so this PR fixes that

## Fixes
* Fixes  #21289

## Approach
`FieldEditLine` now persists only the essential, user-editable state `name`, `content`, `ord` and `expansionState` through a compact `@Parcelize SavedState`, instead of freezing the whole child view subtree and Java-serializing the enum.

## How Has This Been Tested?
Unit test and Pixel 10 wasn't able to reproduce the error

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->