### PR TITLE
Remove `runBlocking` calls in `AbstractFlashcardViewer` and `BrowserColumnSelectionFragment`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -161,6 +161,7 @@ import com.ichi2.utils.show
 import com.ichi2.utils.title
 import com.squareup.seismic.ShakeDetector
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 import java.io.File
 import java.io.UnsupportedEncodingException
@@ -1441,12 +1442,13 @@ abstract class AbstractFlashcardViewer :
 
     private fun updateCard(content: RenderedCard) {
         Timber.d("updateCard()")
+        // TODO: This doesn't need to be blocking
+        runBlocking {
+            cardMediaPlayer.loadCardAvTags(currentCard!!)
+        }
         cardContent = content.html
         fillFlashcard()
-        launchCatchingTask {
-            cardMediaPlayer.loadCardAvTags(currentCard!!)
-            playMedia(false)
-        }
+        playMedia(false) // Play media if appropriate
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -161,7 +161,6 @@ import com.ichi2.utils.show
 import com.ichi2.utils.title
 import com.squareup.seismic.ShakeDetector
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 import java.io.File
 import java.io.UnsupportedEncodingException
@@ -1442,13 +1441,12 @@ abstract class AbstractFlashcardViewer :
 
     private fun updateCard(content: RenderedCard) {
         Timber.d("updateCard()")
-        // TODO: This doesn't need to be blocking
-        runBlocking {
-            cardMediaPlayer.loadCardAvTags(currentCard!!)
-        }
         cardContent = content.html
         fillFlashcard()
-        playMedia(false) // Play media if appropriate
+        launchCatchingTask {
+            cardMediaPlayer.loadCardAvTags(currentCard!!)
+            playMedia(false)
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserColumnSelectionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserColumnSelectionFragment.kt
@@ -38,10 +38,10 @@ import com.ichi2.anki.browser.ColumnUsage.AVAILABLE
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.databinding.DialogBrowserColumnsSelectionBinding
 import com.ichi2.anki.dialogs.DiscardChangesDialog
+import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.model.CardsOrNotes
 import com.ichi2.anki.snackbar.showSnackbar
 import dev.androidbroadcast.vbpd.viewBinding
-import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 
 /**
@@ -110,16 +110,15 @@ class BrowserColumnSelectionFragment : DialogFragment(R.layout.dialog_browser_co
     ) {
         super.onViewCreated(view, savedInstanceState)
 
-        val (active, available) =
-            if (savedInstanceState == null) {
-                // TODO: runBlocking shouldn't be necessary here.
-                runBlocking { viewModel.previewColumnHeadings(cardsOrNotes) }
-            } else {
-                fun getSavedList(key: String) = BundleCompat.getParcelableArrayList(savedInstanceState, key, ColumnWithSample::class.java)!!
-
-                Pair(getSavedList(STATE_ACTIVE), getSavedList(STATE_AVAILABLE))
+        if (savedInstanceState == null) {
+            launchCatchingTask {
+                val (active, available) = viewModel.previewColumnHeadings(cardsOrNotes)
+                setupRecyclerView(active, available)
             }
-        setupRecyclerView(active, available)
+        } else {
+            fun getSavedList(key: String) = BundleCompat.getParcelableArrayList(savedInstanceState, key, ColumnWithSample::class.java)!!
+            setupRecyclerView(getSavedList(STATE_ACTIVE), getSavedList(STATE_AVAILABLE))
+        }
 
         binding.toolbar.setOnMenuItemClickListener { menuItem ->
             Timber.d("menu item click: %s", menuItem.title)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserColumnSelectionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserColumnSelectionFragment.kt
@@ -41,6 +41,7 @@ import com.ichi2.anki.dialogs.DiscardChangesDialog
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.model.CardsOrNotes
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.withProgress
 import dev.androidbroadcast.vbpd.viewBinding
 import timber.log.Timber
 
@@ -112,7 +113,10 @@ class BrowserColumnSelectionFragment : DialogFragment(R.layout.dialog_browser_co
 
         if (savedInstanceState == null) {
             launchCatchingTask {
-                val (active, available) = viewModel.previewColumnHeadings(cardsOrNotes)
+                val (active, available) =
+                    withProgress {
+                        viewModel.previewColumnHeadings(cardsOrNotes)
+                    }
                 setupRecyclerView(active, available)
             }
         } else {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Fixes two TODOs about `runBlocking` calls and refactors to the existing `launchCatchingTask` helper.

## Approach
Remove fully blocking calls with the `launchCatchingTask` helper

## How Has This Been Tested?

Ran `./gradlew :AnkiDroid:testPlayDebugUnitTest`

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->