### PR TITLE
refactor: replace unbound `CoroutineScope` with lifecycle-aware scope

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetConfigScreenAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetConfigScreenAdapter.kt
@@ -32,14 +32,14 @@ import kotlinx.coroutines.withContext
 /**
  * Adapter class for displaying and managing a list of selectable decks in a RecyclerView.
  *
- * @property decks the list of selectable decks to display
+ * @property coroutineScope lifecycle-bound scope used for deck name lookups
  * @property onDeleteDeck a function to call when a deck is removed
  */
 class WidgetConfigScreenAdapter(
+    private val coroutineScope: CoroutineScope,
     private val onDeleteDeck: (SelectableDeck.Deck, Int) -> Unit,
 ) : RecyclerView.Adapter<WidgetConfigScreenAdapter.DeckViewHolder>() {
     private val decks: MutableList<SelectableDeck.Deck> = mutableListOf()
-    private val coroutineScope = CoroutineScope(Dispatchers.Main)
 
     // Property to get the list of deck IDs
     val deckIds: List<Long> get() = decks.map { it.deckId }

--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
@@ -138,7 +138,7 @@ class DeckPickerWidgetConfig :
 
     private fun initializeUIComponents() {
         deckAdapter =
-            WidgetConfigScreenAdapter { deck, _ ->
+            WidgetConfigScreenAdapter(lifecycleScope) { deck, _ ->
                 deckAdapter.removeDeck(deck.deckId)
                 // Removal always frees at least one slot, so the FAB is going
                 // to be visible. Show it now (synchronously) so the snackbar


### PR DESCRIPTION
## Purpose / Description
Unbound `CoroutineScope(Dispatchers.Main)` was used, risking coroutines to outlive the components that launched them

## Approach
- **`WidgetConfigScreenAdapter`**: replace internally-created `CoroutineScope(Dispatchers.Main)` with constructor parameter instead
- **`DeckPickerWidgetConfig`**: passes `lifecycleScope` when constructing the adapter, so deck-name lookup coroutines are cancelled when the activity is destroyed.

## How Has This Been Tested?
Code-review only, no new execution paths are introduced.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the Google Accessibility Scanner


<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->