### PR TITLE
fix: apply color-scheme: dark in card night mode

### DIFF
--- a/AnkiDroid/src/main/assets/flashcard.css
+++ b/AnkiDroid/src/main/assets/flashcard.css
@@ -29,6 +29,11 @@ video {
 body.night_mode {
   color: white;
   background-color: black;
+  /* Make UA-painted system colors follow the dark theme: e.g. a <dialog>'s
+     default `Canvas` background, native form controls, scrollbars. Without
+     this they keep their light defaults even though the body is dark. Mirrors
+     desktop Anki, which sets `color-scheme: dark` on the night-mode root. */
+  color-scheme: dark;
 }
 
 body.ankidroid_dark_mode {


### PR DESCRIPTION
## Problem

Night mode for cards is implemented purely by swapping the body's text/background colors via the `night_mode` class in `flashcard.css`:

```css
body.night_mode {
  color: white;
  background-color: black;
}
```

`color-scheme` is never set. As a consequence, any element painted with **UA system colors** keeps its light defaults even on a dark card, because system colors (`Canvas`, `CanvasText`, …) resolve against the element's *used* color-scheme, which stays `light`.

The most visible case is `<dialog>` (incl. `popover` / `showModal()`): its UA default `background-color: Canvas` renders **white** on Android night mode. It also affects native form controls and scrollbars. Because `<dialog>` lives in the top layer, the `body.night_mode { background-color: black }` rule does not cover it.

## Why this is a divergence from desktop

Desktop Anki sets `color-scheme: dark` on the night-mode root (`ts/lib/sass/_root-vars.scss`):

```css
:root {
    color-scheme: light;
    &.night-mode { color-scheme: dark; }
}
```

So a card that themes correctly on desktop (e.g. a `<dialog>`-based image popover) renders wrong on AnkiDroid with no author action — the `<dialog>` is dark on desktop but white on Android.

## Fix

Set `color-scheme: dark` alongside the existing dark body colors, mirroring desktop. This makes UA system colors follow the dark theme.

```css
body.night_mode {
  color: white;
  background-color: black;
  color-scheme: dark;
}
```

One property + an explanatory comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)