### PR TITLE
fix: convert Title Case strings to sentence case in `02-strings.xml`

### DIFF
--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -66,11 +66,11 @@
     <string name="leech_notification">Card marked as leech</string>
     <string name="webview_crash_unknown">Unknown error</string>
     <string name="webview_crash_unknwon_detailed">This was caused by an internal error in the WebView</string>
-    <string name="webview_crash_oom">Out of Memory</string>
+    <string name="webview_crash_oom">Out of memory</string>
     <string name="webview_crash_oom_details">The WebView was terminated by the system. This typically happens when the application runs out of memory, often due to large fonts or media.</string>
     <string name="webview_crash_nonfatal">WebView renderer crashed. Cause: %s</string>
-    <string name="webview_crash_fatal">Fatal Error: WebView renderer crashed. Cause: %s</string>
-    <string name="webview_crash_loop_dialog_title">System WebView Rendering Failure</string>
+    <string name="webview_crash_fatal">Fatal error: WebView renderer crashed. Cause: %s</string>
+    <string name="webview_crash_loop_dialog_title">System WebView rendering failure</string>
     <string name="webview_crash_loop_dialog_content">System WebView failed to render card \'%1$s\'.\n %2$s</string>
     <string name="slide_to_cancel" comment="Message shown when pressing the record button">Slide to cancel</string>
 
@@ -222,7 +222,7 @@
     <string name="valid_js_api_version">Invalid AnkiDroid JS API version. Contact developer %s, or view wiki</string>
     <string name="update_js_api_version">AnkiDroid JS API update available. Contact developer %s, or view wiki</string>
     <string name="reviewer_invalid_api_version_visit_documentation">View</string>
-    <string name="anki_js_error_code">(Error Code: %d)</string>
+    <string name="anki_js_error_code">(Error code: %d)</string>
 
     <!-- About AnkiDroid screen -->
     <string name="about_ankidroid_successfully_copied_debug_info">Copied to clipboard</string>
@@ -233,7 +233,7 @@
 
     <!-- Deck Picker -->
     <string name="search_decks" maxLength="28">Search decks</string>
-    <string name="ankidroid_init_failed_webview_title">Fatal Error</string>
+    <string name="ankidroid_init_failed_webview_title">Fatal error</string>
     <string name="ankidroid_init_failed_webview">AnkiDroid relies on the System WebView which is unavailable. This can happen if the system is installing updates. Please try again in a few minutes.\n\n%s</string>
     <string name="ankidroid_init_failed_storage">AnkiDroid cannot access storage due to an Android error.\n\n%s</string>
 
@@ -294,11 +294,11 @@
     <string name="percentage">%s%%</string>
     <string name="download_deck">Download deck</string>
     <string name="open_in_browser" comment="Label of a button inviting to open ankiweb's shared deck page if automated download failed">Open in browser</string>
-    <string name="try_again">Try Again</string>
+    <string name="try_again">Try again</string>
     <string name="cancel_download">Cancel download</string>
     <string name="cancel_download_question_title">Cancel download?</string>
     <string name="downloading_file">Downloading %s</string>
-    <string name="import_deck">Import Deck</string>
+    <string name="import_deck">Import deck</string>
     <string name="something_wrong">Something went wrong, please try again</string>
     <string name="download_failed">Download failed</string>
     <string name="deck_download_progress_message">You can use other apps while the download is running</string>
@@ -317,7 +317,7 @@
     <!--  Note Editor Toggle Sticky  -->
     <string name="note_editor_toggle_sticky">Make field %s sticky</string>
 
-    <string name="scoped_storage_learn_more">Learn More</string>
+    <string name="scoped_storage_learn_more">Learn more</string>
 
     <string name="search_card_js_api_no_results">Search returned no results</string>
 
@@ -343,7 +343,7 @@
     <string name="intro_ankidroid_tagline_one">Study less</string>
     <string name="intro_ankidroid_tagline_two">Remember more</string>
     <string name="intro_short_ankidroid_explanation">Anki\'s card scheduler saves time by strengthening your weakest memories and preserving your strongest</string>
-    <string name="intro_get_started" comment="Action to start AnkiDroid for the first time without syncing from AnkiWeb">Get Started</string>
+    <string name="intro_get_started" comment="Action to start AnkiDroid for the first time without syncing from AnkiWeb">Get started</string>
     <string name="intro_sync_from_ankiweb">Sync from AnkiWeb</string>
 
     <!-- IntentHandler -->
@@ -423,12 +423,12 @@ opening the system text to speech settings fails">Failed to open text to speech 
     <string name="voice_not_supported">Voice not supported. Try another or install a voice engine.</string>
 
     <!--Keyboard shortcuts dialog-->
-    <string name="deck_picker_group" comment="Label for the group of shortcuts related to the deck picker">Deck Picker</string>
+    <string name="deck_picker_group" comment="Label for the group of shortcuts related to the deck picker">Deck picker</string>
     <string name="delete_deck_without_confirmation" comment="Description of the shortcut that deletes the deck without asking for confirmation">Delete deck without confirmation</string>
-    <string name="note_editor_group" comment="Label for the group of shortcuts related to the note editor">Note Editor</string>
+    <string name="note_editor_group" comment="Label for the group of shortcuts related to the note editor">Note editor</string>
     <string name="select_note_type" comment="Description of the shortcut that shows the note selection spinner">Select note type</string>
     <string name="tag_editor" comment="Description of the shortcut that opens the tags dialog">Tag editor</string>
-    <string name="card_template_editor_group" comment="Label for the group of shortcuts related to the card template editor">Card Template Editor</string>
+    <string name="card_template_editor_group" comment="Label for the group of shortcuts related to the card template editor">Card template editor</string>
     <string name="edit_front_template" comment="Description of the shortcut that shows the question side of the card template">Edit front template</string>
     <string name="edit_back_template" comment="Description of the shortcut that shows the answer side of the card template">Edit back template</string>
     <string name="edit_styling" comment="Description of the shortcut that shows the styling side of the card template">Edit styling</string>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -317,7 +317,7 @@
     <!--  Note Editor Toggle Sticky  -->
     <string name="note_editor_toggle_sticky">Make field %s sticky</string>
 
-    <string name="scoped_storage_learn_more">Learn more</string>
+    <string name="scoped_storage_learn_more">Learn More</string>
 
     <string name="search_card_js_api_no_results">Search returned no results</string>
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
@@ -262,6 +262,7 @@ class TranslationTest : RobolectricTest() {
                 "Import", // R.string.menu_import | TR.actionsImport()
                 "Language", // R.string.language | TR.preferencesLanguage()
                 "Later", // R.string.button_backup_later | TR.schedulingUpdateLaterButton()
+                "Learn More", // R.string.scoped_storage_learn_more | TR.schedulingUpdateMoreInfoButton()
                 "Learn ahead limit", // R.string.learn_cutoff | TR.preferencesLearnAheadLimit()
                 "Light", // R.string.day_theme_light | TR.preferencesThemeLight()
                 "Media", // R.string.media
@@ -352,7 +353,6 @@ class TranslationTest : RobolectricTest() {
                 "Answer buttons", // R.string.answer_buttons | TR.statisticsAnswerButtonsTitle()
                 "Follow system", // R.string.theme_follow_system | TR.preferencesThemeFollowSystem()
                 "Select all", // R.string.card_browser_select_all | TR.editingImageOcclusionSelectAll()
-                "Learn more", // R.string.scoped_storage_learn_more | TR.schedulingUpdateMoreInfoButton()
                 "Show answer", // R.string.show_answer
                 // TR.studyingShowAnswer()
                 // TR.deckConfigQuestionActionShowAnswer()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TranslationTest.kt
@@ -262,7 +262,6 @@ class TranslationTest : RobolectricTest() {
                 "Import", // R.string.menu_import | TR.actionsImport()
                 "Language", // R.string.language | TR.preferencesLanguage()
                 "Later", // R.string.button_backup_later | TR.schedulingUpdateLaterButton()
-                "Learn More", // R.string.scoped_storage_learn_more | TR.schedulingUpdateMoreInfoButton()
                 "Learn ahead limit", // R.string.learn_cutoff | TR.preferencesLearnAheadLimit()
                 "Light", // R.string.day_theme_light | TR.preferencesThemeLight()
                 "Media", // R.string.media
@@ -353,6 +352,7 @@ class TranslationTest : RobolectricTest() {
                 "Answer buttons", // R.string.answer_buttons | TR.statisticsAnswerButtonsTitle()
                 "Follow system", // R.string.theme_follow_system | TR.preferencesThemeFollowSystem()
                 "Select all", // R.string.card_browser_select_all | TR.editingImageOcclusionSelectAll()
+                "Learn more", // R.string.scoped_storage_learn_more | TR.schedulingUpdateMoreInfoButton()
                 "Show answer", // R.string.show_answer
                 // TR.studyingShowAnswer()
                 // TR.deckConfigQuestionActionShowAnswer()


### PR DESCRIPTION
## Purpose / Description
Few (12 to be precise) of the strings in `02-strings.xml` remained. Converted them to string case and fixed the failing test for it.

## Fixes
* Fixes #15760 

## Approach
- Changed 12 Title Case strings to sentence case.
- Fixed the failing test.

## How Has This Been Tested?

Ran build and test commands to test the changes. All passed.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

Note: there wasn't much of a huge change to add comments.

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->