### PR TITLE
test: fix backFromBrowserClosesTheActivity

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/CardBrowserDeepLinkTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/CardBrowserDeepLinkTest.kt
@@ -56,6 +56,7 @@ class CardBrowserDeepLinkTest : InstrumentedTest() {
      */
     @Test
     fun backFromBrowserClosesTheActivity() {
+        // TODO: make the 'back' experience consistent once we move to the M3 SearchBar
         addNoteUsingBasicNoteType("dog", "barks")
 
         val deepLink =
@@ -67,8 +68,14 @@ class CardBrowserDeepLinkTest : InstrumentedTest() {
 
         val browser = awaitResumed<CardBrowser>()
         val instrumentation = InstrumentationRegistry.getInstrumentation()
-        instrumentation.runOnMainSync { browser.onBackPressedDispatcher.onBackPressed() }
-        instrumentation.waitForIdleSync()
+
+        // The SearchBar & keyboard may need to be collapsed before 'back' finishes the activity
+        val deadline = SystemClock.uptimeMillis() + 3.seconds.inWholeMilliseconds
+        while (!browser.isFinishing && SystemClock.uptimeMillis() < deadline) {
+            instrumentation.runOnMainSync { browser.onBackPressedDispatcher.onBackPressed() }
+            instrumentation.waitForIdleSync()
+            SystemClock.sleep(50)
+        }
 
         assertThat("'back' closes the browser", browser.isFinishing, equalTo(true))
         assertThat(


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.8

## Fixes
* Fixes #21293

## Notes

I looked into having the activity not open the keyboard for deep links, but felt it's best until this is completed:

* https://github.com/ankidroid/Anki-Android/issues/18709


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)