### PR TITLE
feat(deck-picker): disable navigation drawer and indicator

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -509,7 +509,10 @@ open class DeckPicker :
 
         // create inherited navigation drawer layout here so that it can be used by parent class
         initNavigationDrawer()
-        if (Prefs.devBottomNavEnabled && !fragmented) disableDrawerSwipe()
+        if (Prefs.devBottomNavEnabled && !fragmented) {
+            disableDrawerSwipe()
+            disableDrawerIndicator()
+        }
         setupBottomNavigation()
         setupEdgeToEdge()
         title = resources.getString(R.string.app_name)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -405,6 +405,16 @@ abstract class NavigationDrawerActivity(
     protected open val currentCardId: CardId?
         get() = null
 
+    /**
+     * Hides the navigation drawer indicator (hamburger icon) and any back arrows
+     * from the toolbar. Used when bottom navigation is active.
+     */
+    protected fun disableDrawerIndicator() {
+        drawerToggle.isDrawerIndicatorEnabled = false
+        supportActionBar?.setDisplayHomeAsUpEnabled(false)
+        navButtonGoesBack = false
+    }
+
     protected fun showBackIcon() {
         drawerToggle.isDrawerIndicatorEnabled = false
         if (supportActionBar != null) {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Disables the navigation drawer swipe and hides the hamburger indicator when the bottom navigation developer option is enabled.

## Fixes
* For GSoC 2026: Redesign Deck Picker

## Approach
We create a function to disable the drawer that makes sure that android doesn't add in their own back button instead and use this to disable the drawer under the dev option.

## How Has This Been Tested?
Tested on emulator.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->