### PR TITLE
feat: add card flags to CardContentProvider and api

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -27,6 +27,7 @@ import anki.cards.FsrsMemoryState
 import anki.collection.OpChanges
 import anki.notetypes.StockNotetype
 import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.Flag
 import com.ichi2.anki.FlashCardsContract
 import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.common.storage.StorageDecision
@@ -2612,6 +2613,90 @@ class ContentProviderTest : InstrumentedTest() {
             assertEquals("UI should not be notified for empty bulk insert", 0, counter.count)
         } finally {
             ChangeManager.unsubscribe(counter)
+        }
+    }
+
+    @Test
+    fun testSetFlagCard() {
+        val noteId = createdNotes.first().lastPathSegment!!.toLong()
+        val noteUri = Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, noteId.toString())
+        val noteCardsUri = Uri.withAppendedPath(noteUri, "cards")
+        val card = col.getNote(noteId).cards(col).single()
+        val noteCardUri = Uri.withAppendedPath(noteCardsUri, card.ord.toString())
+
+        val negativeValue =
+            ContentValues().apply {
+                put(FlashCardsContract.Card.FLAGS, Flag.MIN_CODE - 1)
+            }
+        val exception1 = assertThrows<IllegalArgumentException> { contentResolver.update(noteCardUri, negativeValue, null, null) }
+        assertEquals(exception1.message, "Flags value must be in the range from ${Flag.MIN_CODE} to ${Flag.MAX_CODE}")
+
+        val tooLargeValue =
+            ContentValues().apply {
+                put(FlashCardsContract.Card.FLAGS, Flag.MAX_CODE + 1)
+            }
+        val exception2 = assertThrows<IllegalArgumentException> { contentResolver.update(noteCardUri, tooLargeValue, null, null) }
+        assertEquals(exception2.message, "Flags value must be in the range from ${Flag.MIN_CODE} to ${Flag.MAX_CODE}")
+
+        val correctValue =
+            ContentValues().apply {
+                put(FlashCardsContract.Card.FLAGS, Flag.MAX_CODE)
+            }
+        contentResolver.update(noteCardUri, correctValue, null, null)
+
+        val cursor =
+            checkNotNull(
+                contentResolver.query(
+                    noteCardUri,
+                    arrayOf(FlashCardsContract.Card.FLAGS),
+                    null,
+                    null,
+                    null,
+                ),
+            ) { "cursor from /notes/#/cards/#" }
+
+        cursor.use {
+            assertTrue(it.moveToFirst())
+            assertEquals(Flag.MAX_CODE, it.getInt(it.getColumnIndex(FlashCardsContract.Card.FLAGS)))
+        }
+    }
+
+    @Test
+    fun testSetUserFlag() {
+        val noteId = createdNotes.first().lastPathSegment!!.toLong()
+        val noteUri = Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, noteId.toString())
+        val noteCardsUri = Uri.withAppendedPath(noteUri, "cards")
+        val card = col.getNote(noteId).cards(col).single()
+        val noteCardUri = Uri.withAppendedPath(noteCardsUri, card.ord.toString())
+
+        // Set 8 (1000 in binary) manually
+        card.flags = 8
+        col.updateCard(card)
+
+        // Set 4 (100 in binary) using setUserFlag method
+        card.setUserFlag(4)
+        col.updateCard(card)
+
+        // If we override only first 3 bits, we won't affect fourth.
+        // Result will be 12 (1000 | 0100 = 1100 in binary).
+        val updatedCard = col.getNote(noteId).cards(col).single()
+        assertEquals(12, updatedCard.flags)
+
+        val cursor =
+            checkNotNull(
+                contentResolver.query(
+                    noteCardUri,
+                    arrayOf(FlashCardsContract.Card.FLAGS),
+                    null,
+                    null,
+                    null,
+                ),
+            ) { "cursor from /notes/#/cards/#" }
+
+        // But cursor should return 4 (only first 3 bits)
+        cursor.use {
+            assertTrue(it.moveToFirst())
+            assertEquals(4, it.getInt(it.getColumnIndex(FlashCardsContract.Card.FLAGS)))
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Flag.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Flag.kt
@@ -144,6 +144,9 @@ enum class Flag(
     fun toSearchNode(): SearchNode = searchNode { flag = toSearchValue() }
 
     companion object {
+        val MAX_CODE: Int = entries.maxOf { it.code }
+        val MIN_CODE: Int = entries.minOf { it.code }
+
         fun fromCode(code: Int) = Flag.entries.first { it.code == code }
 
         /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -35,6 +35,7 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.BuildConfig
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.FlashCardsContract
+import com.ichi2.anki.api.Flag
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
@@ -553,28 +554,38 @@ class CardContentProvider : ContentProvider() {
             NOTES_ID_CARDS -> throw UnsupportedOperationException("Not yet implemented")
             NOTES_ID_CARDS_ORD -> {
                 val currentCard = getCardFromUri(uri, col)
-                var isDeckUpdate = false
-                var did = Decks.NOT_FOUND_DECK_ID
                 // the key of the ContentValues contains the column name
                 // the value of the ContentValues contains the row value.
                 val valueSet = values!!.valueSet()
                 for ((key) in valueSet) {
-                    // Only updates on deck id is supported
-                    isDeckUpdate = key == FlashCardsContract.Card.DECK_ID
-                    did = values.getAsLong(key)
-                }
-                require(!col.decks.isFiltered(did)) { "Cards cannot be moved to a filtered deck" }
-                /* now update the card
-                 */
-                if (isDeckUpdate && did >= 0) {
-                    Timber.d("CardContentProvider: Moving card to other deck...")
-                    currentCard.did = did
-                    col.updateCard(currentCard)
+                    when (key) {
+                        FlashCardsContract.Card.DECK_ID -> {
+                            val did = values.getAsLong(key)
+                            require(!col.decks.isFiltered(did)) { "Cards cannot be moved to a filtered deck" }
 
-                    updated++
-                } else {
-                    // User tries an operation that is not (yet?) supported.
-                    throw IllegalArgumentException("Currently only updates of decks are supported")
+                            Timber.d("CardContentProvider: Moving card to other deck...")
+                            currentCard.did = did
+                            col.updateCard(currentCard)
+
+                            updated++
+                        }
+                        FlashCardsContract.Card.FLAGS -> {
+                            val flags = values.getAsInteger(key)
+
+                            if (flags == null || flags < Flag.MIN_CODE || flags > Flag.MAX_CODE) {
+                                throw IllegalArgumentException("Flags value must be in the range from ${Flag.MIN_CODE} to ${Flag.MAX_CODE}")
+                            }
+
+                            Timber.d("CardContentProvider: flags update...")
+                            currentCard.setUserFlag(flags)
+                            col.updateCard(currentCard)
+                            updated++
+                        }
+                        else -> {
+                            // User tries an operation that is not (yet?) supported.
+                            throw IllegalArgumentException("Currently only updates of decks and flags are supported")
+                        }
+                    }
                 }
             }
             NOTE_TYPES -> throw IllegalArgumentException("Cannot update models in bulk")
@@ -1238,6 +1249,7 @@ class CardContentProvider : ContentProvider() {
                 FlashCardsContract.Card.FSRS_DESIRED_RETENTION -> rb.add(currentCard.fsrsDesiredRetention)
                 FlashCardsContract.Card.FSRS_DECAY -> rb.add(currentCard.decay)
                 FlashCardsContract.Card.LAST_REVIEW_TIME_SECONDS -> rb.add(currentCard.lastReviewTimeSecs)
+                FlashCardsContract.Card.FLAGS -> rb.add(currentCard.flags and 7) // return only 3 first bits
                 else -> throw UnsupportedOperationException("Queue \"$column\" is unknown")
             }
         }

--- a/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
+++ b/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
@@ -894,6 +894,22 @@ public object FlashCardsContract {
         public const val LAST_REVIEW_TIME_SECONDS: String = "last_review_time_secs"
 
         /**
+         * The raw flag code in the range from 0 to 7
+         *
+         * * `0` = no flag
+         * * `1` = red
+         * * `2` = orange
+         * * `3` = green
+         * * `4` = blue
+         * * `5` = pink
+         * * `6` = turquoise
+         * * `7` = purple
+         *
+         * Other values will throw IllegalArgumentException on set.
+         */
+        public const val FLAGS: String = "flags"
+
+        /**
          * The content:// style URI for cards. Can be used to search for cards or access specific cards.
          * For examples on how to use the URI for queries see the overview in [FlashCardsContract].
          */
@@ -910,6 +926,7 @@ public object FlashCardsContract {
                 DECK_ID,
                 QUESTION,
                 ANSWER,
+                FLAGS,
             )
 
         /**

--- a/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
+++ b/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
@@ -504,6 +504,61 @@ public class AddContentApi(
     }
 
     /**
+     * Set the flag using flag code for a given note
+     * @param noteId the ID of the note to update
+     * @param rawFlag the flag code to set (should match a [Flag.code])
+     * @return true if flag was updated, otherwise false
+     * @throws SecurityException if READ_WRITE_PERMISSION not granted (e.g. due to install order bug)
+     * @throws IllegalArgumentException if flag code is not a valid [Flag.code]
+     */
+    public fun setFlagRaw(
+        noteId: Long,
+        rawFlag: Int,
+    ): Boolean {
+        val cardsUri =
+            Note.CONTENT_URI
+                .buildUpon()
+                .appendPath(noteId.toString())
+                .appendPath("cards")
+                .build()
+
+        val cardsQuery = resolver.query(cardsUri, null, null, null, null) ?: return false
+
+        val values =
+            ContentValues().apply {
+                put(Card.FLAGS, rawFlag)
+            }
+        var numRowsUpdated = 0
+
+        cardsQuery.use { cardsCursor ->
+            while (cardsCursor.moveToNext()) {
+                val cardUri =
+                    Note.CONTENT_URI
+                        .buildUpon()
+                        .appendPath(noteId.toString())
+                        .appendPath("cards")
+                        .appendPath(cardsCursor.getString(cardsCursor.getColumnIndex(Card.CARD_ORD)))
+                        .build()
+                numRowsUpdated += resolver.update(cardUri, values, null, null)
+            }
+        }
+
+        return numRowsUpdated > 0
+    }
+
+    /**
+     * Set the flag for a given note
+     * @param noteId the ID of the note to update
+     * @param flag the flag to set (should match a [Flag])
+     * @return true if flag was updated, otherwise false
+     * @throws SecurityException if READ_WRITE_PERMISSION not granted (e.g. due to install order bug)
+     */
+    public fun setFlag(
+        noteId: Long,
+        flag: Flag,
+    ): Boolean = setFlagRaw(noteId, flag.code)
+
+    /**
      * Get the name of the selected deck
      * @return deck name or null if there was a problem
      */

--- a/api/src/main/java/com/ichi2/anki/api/Flag.kt
+++ b/api/src/main/java/com/ichi2/anki/api/Flag.kt
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 ColgateTotal77 <serega2005n@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-or-later
+package com.ichi2.anki.api
+
+/*
+ * [code] should be kept in sync with the [com.ichi2.anki.Flag] enum.
+ *
+ * param code The code of the flag.
+ */
+public enum class Flag(
+    public val code: Int,
+) {
+    NONE(0),
+    RED(1),
+    ORANGE(2),
+    GREEN(3),
+    BLUE(4),
+    PINK(5),
+    TURQUOISE(6),
+    PURPLE(7),
+    ;
+
+    public companion object {
+        public val MAX_CODE: Int = entries.maxOf { it.code }
+        public val MIN_CODE: Int = entries.minOf { it.code }
+    }
+}

--- a/api/src/test/java/com/ichi2/anki/api/AddContentApiTest.kt
+++ b/api/src/test/java/com/ichi2/anki/api/AddContentApiTest.kt
@@ -1,16 +1,129 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 ColgateTotal77 <serega2005n@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-or-later
 package com.ichi2.anki.api
 
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.UriMatcher
 import android.content.pm.ProviderInfo
+import android.database.MatrixCursor
+import android.net.Uri
 import android.os.Bundle
 import com.ichi2.anki.FlashCardsContract
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+internal class FakeCardContentProvider : ContentProvider() {
+    companion object {
+        const val NOTES_ID_CARDS = 1003
+
+        val CARD_PROJECTION =
+            arrayOf(
+                FlashCardsContract.Card.NOTE_ID,
+                FlashCardsContract.Card.CARD_ORD,
+                FlashCardsContract.Card.FLAGS,
+            )
+
+        val uriMatcher =
+            UriMatcher(UriMatcher.NO_MATCH).apply {
+                addURI(FlashCardsContract.AUTHORITY, "notes/#/cards", NOTES_ID_CARDS)
+            }
+    }
+
+    private data class FakeCard(
+        val noteId: Long,
+        val ord: Int,
+        var flags: Int = Flag.NONE.code,
+    )
+
+    private val cards = mutableListOf<FakeCard>()
+
+    override fun onCreate(): Boolean = true
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?,
+    ) = when (uriMatcher.match(uri)) {
+        NOTES_ID_CARDS -> {
+            val noteId = uri.pathSegments[1].toLong()
+            MatrixCursor(CARD_PROJECTION).apply {
+                cards
+                    .filter { it.noteId == noteId }
+                    .forEach { addRow(listOf(it.noteId, it.ord, it.flags and 7)) }
+            }
+        }
+
+        else -> throw IllegalArgumentException("uri $uri is not supported")
+    }
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+    ): Int {
+        var updated = 0
+        val valueSet = values!!.valueSet()
+        val card = getCardFromUri(uri)
+        for ((key) in valueSet) {
+            when (key) {
+                FlashCardsContract.Card.FLAGS -> {
+                    val flags = values.getAsInteger(key)
+
+                    if (flags == null || flags < Flag.MIN_CODE || flags > Flag.MAX_CODE) {
+                        throw IllegalArgumentException("Flags value must be in the range from ${Flag.MIN_CODE} to ${Flag.MAX_CODE}")
+                    }
+
+                    card.flags = (flags and 7)
+                    updated++
+                }
+                else -> throw IllegalArgumentException("uri $uri is not supported")
+            }
+        }
+        return updated
+    }
+
+    override fun getType(uri: Uri): String? = null
+
+    override fun insert(
+        uri: Uri,
+        values: ContentValues?,
+    ): Uri? = null
+
+    override fun delete(
+        uri: Uri,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+    ): Int = 0
+
+    fun addNote(
+        noteId: Long,
+        cardCount: Int,
+    ) {
+        repeat(cardCount) { ord -> cards.add(FakeCard(noteId, ord)) }
+    }
+
+    private fun getCardFromUri(uri: Uri): FakeCard {
+        val noteId = uri.pathSegments[1].toLong()
+        val ord = uri.pathSegments[3].toInt()
+        return cards.firstOrNull { it.noteId == noteId && it.ord == ord }
+            ?: throw IllegalArgumentException("Card with ord $ord does not exist for note $noteId")
+    }
+
+    fun getNoteFlags(noteId: Long): List<Int> = cards.filter { it.noteId == noteId }.map { it.flags }
+}
 
 /**
  * This module's manifest registers no content provider, so by default Robolectric's
@@ -43,6 +156,40 @@ internal class AddContentApiTest {
         assertEquals(1, api.apiHostSpecVersion)
     }
 
+    @Test
+    fun testSetFlagRaw() {
+        val provider = installFakeCardProvider()
+
+        val updated = api.setFlagRaw(NOTE_ID, Flag.MAX_CODE)
+
+        assertThat("should return true if updated", updated, equalTo(true))
+        assertThat(
+            "should return updated flag codes",
+            provider.getNoteFlags(NOTE_ID),
+            equalTo(listOf(Flag.MAX_CODE, Flag.MAX_CODE)),
+        )
+
+        val tooLargeValue = assertFailsWith<IllegalArgumentException> { api.setFlagRaw(NOTE_ID, Flag.MAX_CODE + 1) }
+        assertThat(tooLargeValue.message, equalTo("Flags value must be in the range from ${Flag.MIN_CODE} to ${Flag.MAX_CODE}"))
+
+        val tooSmallValue = assertFailsWith<IllegalArgumentException> { api.setFlagRaw(NOTE_ID, Flag.MIN_CODE - 1) }
+        assertThat(tooSmallValue.message, equalTo("Flags value must be in the range from ${Flag.MIN_CODE} to ${Flag.MAX_CODE}"))
+    }
+
+    @Test
+    fun testSetFlag() {
+        val provider = installFakeCardProvider()
+
+        val updated = api.setFlag(NOTE_ID, Flag.RED)
+
+        assertThat("should return true if updated", updated, equalTo(true))
+        assertThat(
+            "should return updated flag codes",
+            provider.getNoteFlags(NOTE_ID),
+            equalTo(listOf(Flag.RED.code, Flag.RED.code)),
+        )
+    }
+
     private fun installAnkiDroid(metaData: Bundle?) {
         val provider =
             ProviderInfo().apply {
@@ -52,5 +199,17 @@ internal class AddContentApiTest {
                 this.metaData = metaData
             }
         shadowOf(RuntimeEnvironment.getApplication().packageManager).addOrUpdateProvider(provider)
+    }
+
+    private fun installFakeCardProvider(): FakeCardContentProvider =
+        Robolectric
+            .buildContentProvider(FakeCardContentProvider::class.java)
+            .create(FlashCardsContract.AUTHORITY)
+            .get()
+            .apply { addNote(NOTE_ID, CARD_COUNT) }
+
+    companion object {
+        private const val NOTE_ID = 1L
+        private const val CARD_COUNT = 2
     }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Expand CardContentProvider and api to work with card flags.

## Fixes
* Fixes #21298

## Approach
Added read/write for card flags in CardContentProvider and api.

## How Has This Been Tested?

Implemented test for negative, too large, and valid flag codes.

## Learning (optional, can help others)
I just looked at other api functions and content provider cases. Most of the code I just copied and a little tweaked for my case.
## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->