### PR TITLE
arch(dev-only): handle 'no storage decision' for all activities in `ActivityList`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -91,6 +91,7 @@ import com.ichi2.anki.previewer.TemplatePreviewerFragment
 import com.ichi2.anki.previewer.TemplatePreviewerPage
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.startup.ensureStorageIsReady
 import com.ichi2.anki.ui.ResizablePaneManager
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
@@ -184,6 +185,9 @@ open class CardTemplateEditor : AnkiActivity(R.layout.activity_card_template_edi
             return
         }
         super.onCreate(savedInstanceState)
+        if (!ensureStorageIsReady()) {
+            return
+        }
         // Load the args either from the intent or savedInstanceState bundle
         if (savedInstanceState == null) {
             // get note type id

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -34,10 +34,12 @@ import com.ichi2.anki.common.destinations.DeckOptionsDestination
 import com.ichi2.anki.dialogs.DatabaseErrorDialog
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType
 import com.ichi2.anki.exception.StorageAccessException
+import com.ichi2.anki.exception.StorageNotConfiguredException
 import com.ichi2.anki.libanki.exception.InvalidSearchException
 import com.ichi2.anki.pages.fromCurrentDeck
 import com.ichi2.anki.pages.toIntent
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.startup.redirectToMainEntryPoint
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.openUrl
 import com.ichi2.utils.create
@@ -189,6 +191,12 @@ suspend fun <T> FragmentActivity.runCatching(
             is BackendInterruptedException -> {
                 Timber.w(exc, errorMessage)
                 exc.localizedMessage?.let { showSnackbar(it) }
+            }
+            is StorageNotConfiguredException -> {
+                // expected before first-run setup completes: no crash report
+                // edge case when 'ensureStorageIsReady' was insufficient
+                Timber.w(exc, errorMessage)
+                if (!isFinishing) redirectToMainEntryPoint()
             }
             is BackendNetworkException, is BackendSyncException, is StorageAccessException, is BackendCardTypeException -> {
                 // these exceptions do not generate worthwhile crash reports

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -82,6 +82,7 @@ import com.ichi2.anki.InitialActivity.StartupFailure.DirectoryNotAccessible
 import com.ichi2.anki.InitialActivity.StartupFailure.DiskFull
 import com.ichi2.anki.InitialActivity.StartupFailure.FutureAnkidroidVersion
 import com.ichi2.anki.InitialActivity.StartupFailure.SDCardNotMounted
+import com.ichi2.anki.InitialActivity.StartupFailure.StorageUndecided
 import com.ichi2.anki.IntentHandler.Companion.intentToReviewDeckFromShortcuts
 import com.ichi2.anki.account.AccountActivity
 import com.ichi2.anki.analytics.UsageAnalytics
@@ -1025,6 +1026,11 @@ open class DeckPicker :
             is StartupFailure.InitializationError -> FatalErrorDialog.build(this, failure).show()
             is DiskFull -> displayNoStorageError()
             is DBError -> displayDatabaseFailure(CustomExceptionData.fromException(failure.exception))
+            is StorageUndecided -> {
+                Timber.i("Displaying storage setup required")
+                // unreachable: storageDecision() cannot yet return Undecided outside tests
+                TODO("#19552 - replace with the storage setup flow.")
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -37,6 +37,7 @@ import com.ichi2.anki.servicelayer.PreferenceUpgradeService
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService.setPreferencesUpToDate
 import com.ichi2.anki.servicelayer.ScopedStorageService.isLegacyStorage
 import com.ichi2.anki.storage.AnkiDroidFolder
+import com.ichi2.anki.storage.StorageDecision
 import com.ichi2.anki.ui.windows.permissions.InternetPermissionFragment
 import com.ichi2.anki.ui.windows.permissions.NotificationsPermissionFragment
 import com.ichi2.anki.ui.windows.permissions.PermissionsFragment
@@ -59,6 +60,13 @@ object InitialActivity {
     fun getStartupFailureType(initializeAnkiDroidDirectory: () -> Boolean): StartupFailure? {
         AnkiDroidApp.fatalError?.let {
             return StartupFailure.InitializationError(it)
+        }
+
+        // Opening the collection would throw a StorageNotConfiguredException, which is not worth
+        // a crash report
+        if (CollectionHelper.storageDecision() != StorageDecision.Decided) {
+            Timber.i("storage location is undecided")
+            return StartupFailure.StorageUndecided
         }
 
         val failure =
@@ -187,6 +195,13 @@ object InitialActivity {
         }
 
         data object DiskFull : StartupFailure()
+
+        /**
+         * The user has not yet decided where the collection is stored.
+         *
+         * @see CollectionHelper.storageDecision
+         */
+        data object StorageUndecided : StartupFailure()
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -28,6 +28,7 @@ import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.servicelayer.ScopedStorageService
 import com.ichi2.anki.settings.Prefs
+import com.ichi2.anki.storage.StorageDecision
 import com.ichi2.anki.ui.windows.reviewer.ReviewerFragment
 import com.ichi2.anki.utils.MimeTypeUtils
 import com.ichi2.anki.worker.SyncWorker
@@ -124,6 +125,8 @@ class IntentHandler : AbstractIntentHandler() {
      *  * AnkiDroid is using a legacy directory to store user data but has access to it since storage permission
      * has been granted (as long as AnkiDroid targeted API < 30, requested legacy storage, and has not been uninstalled since)
      *
+     * The user must also have [decided][CollectionHelper.storageDecision] where data is stored;
+     * otherwise they are routed to the [DeckPicker].
      */
     @NeedsTest("clicking a file in 'Files' to import")
     private fun performActionIfStorageAccessible(
@@ -131,6 +134,12 @@ class IntentHandler : AbstractIntentHandler() {
         action: String?,
         block: () -> Unit,
     ) {
+        if (CollectionHelper.storageDecision() != StorageDecision.Decided) {
+            // checked before permissions: the permissions required depend on the chosen folder
+            Timber.i("Storage is not configured, cancelling intent '%s'", action)
+            launchDeckPickerIfNoOtherTasks(reloadIntent)
+            return
+        }
         if (grantedStoragePermissions(this, showToast = true)) {
             Timber.i("User has storage permissions. Running intent: %s", action)
             block()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteTypeFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteTypeFieldEditor.kt
@@ -48,6 +48,7 @@ import com.ichi2.anki.libanki.NotetypeJson
 import com.ichi2.anki.libanki.exception.ConfirmModSchemaException
 import com.ichi2.anki.servicelayer.LanguageHintService.setLanguageHintForField
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.startup.ensureStorageIsReady
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
 import com.ichi2.anki.utils.ext.setCompoundDrawablesRelativeWithIntrinsicBoundsKt
@@ -97,6 +98,9 @@ class NoteTypeFieldEditor : AnkiActivity(R.layout.activity_note_type_field_edito
             return
         }
         super.onCreate(savedInstanceState)
+        if (!ensureStorageIsReady()) {
+            return
+        }
         setContentView(R.layout.activity_note_type_field_editor)
         enableToolbar()
         binding.notetypeName.text = intent.getStringExtra(EXTRA_NOTETYPE_NAME)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
@@ -29,6 +29,7 @@ import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction.Co
 import com.ichi2.anki.libanki.undoAvailable
 import com.ichi2.anki.libanki.undoLabel
 import com.ichi2.anki.observability.ChangeManager
+import com.ichi2.anki.startup.ensureStorageIsReady
 import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.ui.RtlCompliantActionProvider
 import kotlinx.coroutines.launch
@@ -47,6 +48,9 @@ class StudyOptionsActivity :
             return
         }
         super.onCreate(savedInstanceState)
+        if (!ensureStorageIsReady()) {
+            return
+        }
         enableToolbar().apply { title = "" }
         if (savedInstanceState == null) {
             loadStudyOptionsFragment()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaActivity.kt
@@ -32,6 +32,7 @@ import com.ichi2.anki.multimediacard.IMultimediaEditableNote
 import com.ichi2.anki.multimediacard.fields.IField
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
+import com.ichi2.anki.startup.ensureStorageIsReady
 import com.ichi2.themes.setTransparentStatusBar
 import com.ichi2.utils.FragmentFactoryUtils
 import dev.androidbroadcast.vbpd.viewBinding
@@ -75,6 +76,9 @@ class MultimediaActivity :
             return
         }
         super.onCreate(savedInstanceState)
+        if (!ensureStorageIsReady()) {
+            return
+        }
         setTransparentStatusBar()
         setSupportActionBar(binding.toolbar)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt
@@ -47,6 +47,7 @@ import com.ichi2.anki.dialogs.showLoadingDialog
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.notetype.ManageNoteTypesState.UserMessage
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.startup.ensureStorageIsReady
 import com.ichi2.anki.sync.userAcceptsSchemaChange
 import com.ichi2.anki.utils.Destination
 import com.ichi2.themes.setTransparentStatusBar
@@ -97,6 +98,9 @@ class ManageNotetypes : AnkiActivity(R.layout.activity_manage_note_types) {
             return
         }
         super.onCreate(savedInstanceState)
+        if (!ensureStorageIsReady()) {
+            return
+        }
 
         setTransparentStatusBar()
         enableToolbar()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/startup/StartupGuards.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/startup/StartupGuards.kt
@@ -11,17 +11,20 @@ import com.ichi2.anki.storage.StorageDecision
 import timber.log.Timber
 
 /**
- * Ensures storage is ready for use, finishes the activity is otherwise.
+ * Ensures storage is ready for use, finishes the activity and calls [redirectToMainEntryPoint]
+ * otherwise.
  *
- * - the user has decided where the collection is stored
- * - the app has permission to access
+ * - the user has decided where the collection is stored. ([ensureStorageIsConfigured])
+ * - the app has permission to access the collection. ([ensureStoragePermissions])
  *
  * This should be called AFTER a call to `super.`[onCreate][Activity.onCreate]
  *
  * @return `true`: activity may continue to start, `false`: [onCreate][Activity.onCreate]
  * should stop executing
  *
- * @throws SystemStorageException if `getExternalFilesDir` returns null
+ * @throws SystemStorageException if `getExternalFilesDir` returns `null`
+ *
+ * @see redirectToMainEntryPoint
  */
 fun Activity.ensureStorageIsReady(): Boolean {
     // The storage decision is checked first

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupUndecidedStorageTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupUndecidedStorageTest.kt
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki
+
+import com.ichi2.anki.storage.StorageDecision
+import com.ichi2.testutils.ActivityList
+import com.ichi2.testutils.ActivityList.ActivityLaunchParam
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.ParameterizedRobolectricTestRunner
+
+/**
+ * All activities start crash-free when [CollectionHelper.storageDecision] returns
+ * [StorageDecision.Undecided].
+ *
+ * Unlike [ExternalEntryPointsUndecidedStorageTest], this covers in-app navigation and pinned
+ * shortcuts.
+ *
+ * Collection-requiring activities are expected to finish via [ensureStorageIsReady][com.ichi2.anki.startup.ensureStorageIsReady].
+ *
+ * If this fails for a new activity, add the following after `super.onCreate`:
+ * ```
+ * if (!ensureStorageIsReady()) {
+ *     return
+ * }
+ * ```
+ */
+@RunWith(ParameterizedRobolectricTestRunner::class)
+class ActivityStartupUndecidedStorageTest : RobolectricTest() {
+    @ParameterizedRobolectricTestRunner.Parameter
+    @JvmField // required for Parameter
+    var launcher: ActivityLaunchParam? = null
+
+    // Only used for display, but needs to be defined
+    @ParameterizedRobolectricTestRunner.Parameter(1)
+    @JvmField // required for Parameter
+    @Suppress("unused")
+    var activityName: String? = null
+
+    @Before
+    fun setStorageUndecided() {
+        CollectionHelper.storageDecisionTestOverride = StorageDecision.Undecided
+    }
+
+    @After
+    fun resetStorageDecision() {
+        CollectionHelper.storageDecisionTestOverride = null
+    }
+
+    @Test
+    fun `startup is crash-free when storage is undecided`() {
+        val controller = launcher!!.build(targetContext)
+        // mirrors Android: an activity which finishes during onCreate (e.g. redirectToMainEntryPoint)
+        // does not receive the remaining lifecycle callbacks; controller.setup() would force them
+        controller.create()
+        if (!controller.get().isFinishing) {
+            controller
+                .start()
+                .postCreate(null)
+                .resume()
+                .visible()
+        }
+        advanceRobolectricLooper()
+    }
+
+    companion object {
+        @Suppress("unused")
+        @ParameterizedRobolectricTestRunner.Parameters(name = "{1}")
+        @JvmStatic // required for initParameters
+        fun initParameters(): Collection<Array<Any>> = ActivityList.allActivitiesAndIntents().map { arrayOf(it, it.simpleName) }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CoroutineHelpersRobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CoroutineHelpersRobolectricTest.kt
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki
+
+import androidx.fragment.app.FragmentActivity
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.exception.StorageNotConfiguredException
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.Shadows.shadowOf
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@RunWith(AndroidJUnit4::class)
+class CoroutineHelpersRobolectricTest : RobolectricTest() {
+    /**
+     * A [StorageNotConfiguredException] escaping a coroutine means an activity raced or
+     * outlived its [ensureStorageIsReady][com.ichi2.anki.startup.ensureStorageIsReady] check:
+     * the user should be sent to the main entry point, which handles storage setup.
+     */
+    @Test
+    fun `launchCatchingTask redirects to main entry point when storage is not configured`() {
+        val activity = Robolectric.buildActivity(FragmentActivity::class.java).create().get()
+
+        activity.launchCatchingTask { throw StorageNotConfiguredException() }
+        advanceRobolectricLooper()
+
+        assertTrue(activity.isFinishing, "activity should finish")
+        val redirect = shadowOf(activity).nextStartedActivity
+        assertNotNull(redirect, "the main entry point should be opened")
+        assertEquals(IntentHandler::class.qualifiedName, redirect.component?.className)
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/StorageDecisionGateTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/StorageDecisionGateTest.kt
@@ -7,6 +7,7 @@ import com.ichi2.anki.exception.StorageNotConfiguredException
 import com.ichi2.anki.storage.StorageDecision
 import org.junit.Test
 import org.junit.runner.RunWith
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 /**
@@ -21,6 +22,18 @@ class StorageDecisionGateTest : RobolectricTest() {
         CollectionHelper.storageDecisionTestOverride = StorageDecision.Undecided
         try {
             assertFailsWith<StorageNotConfiguredException> { CollectionManager.getColUnsafe() }
+        } finally {
+            CollectionHelper.storageDecisionTestOverride = null
+        }
+    }
+
+    /** No collection access should be attempted: a crash report would otherwise be generated */
+    @Test
+    fun `startup failure is StorageUndecided when storage is undecided`() {
+        CollectionHelper.storageDecisionTestOverride = StorageDecision.Undecided
+        try {
+            val failure = InitialActivity.getStartupFailureType { true }
+            assertEquals(InitialActivity.StartupFailure.StorageUndecided, failure)
         } finally {
             CollectionHelper.storageDecisionTestOverride = null
         }


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

## Purpose / Description
I want collection creation to become part of the onboarding sequence., moving it out of the implicit `Collection.withCol`

This opens the floor for a 'storage decision': if the user is using a `full` build - do they want to obtain `MANAGE_EXTERNAL_STORAGE`, or continue with app-private storage?

In this case, all activities need to handle the possibility that the decision wasn't made yet, or was revoked. Most of these cases have been handled, but these activities remained, typically being launched after process death, or through notifications/app shortcuts.

## Fixes
* Follow-on from https://github.com/ankidroid/Anki-Android/pull/21290
* Related to https://github.com/ankidroid/Anki-Android/issues/19552
* Related to https://github.com/ankidroid/Anki-Android/issues/20737
* Related to #13574

## Approach

* Redirect users to `IntentHandler` -> DeckPicker if no storage decision is made
  * A centralized point of handling in `IntentHandler`, in future to be moved to a selection screen. 
* Handle `launchCatchingTask`
* Scaffold for DeckPicker to handle this issue as an error
  * Normally it would be part of startup; DeckPicker should handle the case that this permission was revoked and allow a user to regain access  


## How Has This Been Tested?
Unit tested

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)