### PR TITLE
fix(whiteboard): keep the chosen hue visible when the brush is dark

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/ColorPickerDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/ColorPickerDialog.kt
@@ -17,6 +17,7 @@
 package com.ichi2.anki.ui.windows.reviewer.whiteboard
 
 import android.content.Context
+import android.graphics.Color
 import android.os.Build
 import android.view.Choreographer
 import android.widget.FrameLayout
@@ -61,7 +62,18 @@ fun Context.showColorPickerDialog(
             // This ensures the BrightnessSlideBar is fully initialized before applying
             // the initial color. Calling it too early causes the slider to use its
             // default position, resulting in an incorrect displayed color.
-            colorPickerView.post { colorPickerView.setInitialColor(initialColor) }
+            colorPickerView.post {
+                colorPickerView.setInitialColor(initialColor)
+                // The wheel only sets hue and saturation; brightness comes from the slider below it.
+                // A near-black seed parks that slider at zero, so any hue picked on the wheel would
+                // assemble back to black and the picker would seem to ignore the choice (issue #21329).
+                // Lift the slider once so the wheel is usable. Brighter seeds keep their own brightness.
+                if (initialColor.isNearBlack()) {
+                    colorPickerView.post {
+                        colorPickerView.brightnessSlider?.setSelectorByHalfSelectorPosition(1f)
+                    }
+                }
+            }
             // Bubble showing the selected color
             val bubbleFlag = BubbleFlag(this@showColorPickerDialog)
             colorPickerView.flagView = bubbleFlag
@@ -106,6 +118,19 @@ fun Context.showColorPickerDialog(
             choreographer.postFrameCallback(callback)
         }.setOnDismissListener { dismissed = true }
 }
+
+/**
+ * Whether the color's brightness is low enough to read as black. The brightness slider stores
+ * exactly this value, so a near-black color means the slider would be parked near zero.
+ */
+private fun Int.isNearBlack(): Boolean {
+    val hsv = FloatArray(3)
+    Color.colorToHSV(this, hsv)
+    return hsv[2] <= NEAR_BLACK_BRIGHTNESS
+}
+
+/** Brightness (HSV value) at or below which a color is treated as black. */
+private const val NEAR_BLACK_BRIGHTNESS = 0.05f
 
 /**
  * Custom flag view that displays the selected color in a bubble above the color picker selector.

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/ColorPickerDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/ColorPickerDialogTest.kt
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2026 Ashish Yadav <mailtoashish693@gmail.com>
+
+package com.ichi2.anki.ui.windows.reviewer.whiteboard
+
+import android.content.Context
+import android.graphics.Color
+import android.os.Looper
+import android.view.MotionEvent
+import androidx.appcompat.app.AlertDialog
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.themes.Themes
+import com.skydoves.colorpickerview.ColorPickerView
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.closeTo
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.greaterThan
+import org.hamcrest.Matchers.not
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.shadows.ShadowChoreographer
+import org.robolectric.shadows.ShadowDialog
+import java.time.Duration
+import kotlin.test.assertNotNull
+
+/** Tests for [showColorPickerDialog] */
+@RunWith(AndroidJUnit4::class)
+class ColorPickerDialogTest {
+    private lateinit var context: Context
+    private var pickedColor: Int? = null
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        Themes.setTheme(context)
+        // The dialog repositions its color bubble on every frame, so an unbounded
+        // looper drain would never terminate. Pause the choreographer so frames only
+        // run while the clock advances, and advance it in bounded steps (see idleMainLooper).
+        ShadowChoreographer.setPaused(true)
+        ShadowChoreographer.setFrameDelay(Duration.ofMillis(15))
+    }
+
+    @Test
+    fun `picking a hue on a black-seeded picker keeps the hue visible`() {
+        assertPickedHueIsVisible(seed = Color.BLACK)
+    }
+
+    @Test
+    fun `picking a hue on a near-black-seeded picker keeps the hue visible`() {
+        assertPickedHueIsVisible(seed = Color.rgb(3, 0, 0))
+    }
+
+    @Test
+    fun `confirming without touching anything returns the initial color`() {
+        val dialog = showPicker(initialColor = Color.BLACK)
+
+        dialog.confirm()
+
+        assertThat(pickedColor, equalTo(Color.BLACK))
+    }
+
+    @Test
+    fun `picking a hue on a bright seed keeps its brightness`() {
+        val seed = Color.rgb(128, 0, 0)
+        val dialog = showPicker(initialColor = seed)
+
+        dialog.wheel().tapRightEdge()
+        idleMainLooper()
+        dialog.confirm()
+
+        val color = assertNotNull(pickedColor, "a color should be returned on OK")
+        val pickedBrightness = FloatArray(3).also { Color.colorToHSV(color, it) }[2]
+        val seedBrightness = FloatArray(3).also { Color.colorToHSV(seed, it) }[2]
+        assertThat(
+            "brightness must be left untouched for a non-near-black seed",
+            pickedBrightness.toDouble(),
+            closeTo(seedBrightness.toDouble(), 0.02),
+        )
+    }
+
+    /** Seeds the picker with [seed], taps a bright hue, and asserts the result is not swallowed to black. */
+    private fun assertPickedHueIsVisible(seed: Int) {
+        val dialog = showPicker(initialColor = seed)
+
+        dialog.wheel().tapRightEdge() // pure red at full saturation
+        idleMainLooper()
+        dialog.confirm()
+
+        val color = assertNotNull(pickedColor, "a color should be returned on OK")
+        val hsv = FloatArray(3).also { Color.colorToHSV(color, it) }
+        assertThat("picked color is not black", color, not(equalTo(Color.BLACK)))
+        assertThat("picked hue keeps full brightness", hsv[2], equalTo(1f))
+    }
+
+    /** Shows the color picker dialog and waits for the picker to finish initializing. */
+    private fun showPicker(initialColor: Int): AlertDialog {
+        context.showColorPickerDialog(initialColor) { pickedColor = it }
+        val dialog =
+            assertNotNull(
+                ShadowDialog.getLatestDialog() as? AlertDialog,
+                "color picker dialog should be shown",
+            )
+        repeat(3) { idleMainLooper() }
+        return dialog
+    }
+
+    private fun AlertDialog.wheel(): ColorPickerView = assertNotNull(findViewById(com.skydoves.colorpickerview.R.id.colorPickerView))
+
+    private fun AlertDialog.confirm() {
+        getButton(AlertDialog.BUTTON_POSITIVE).performClick()
+        idleMainLooper()
+    }
+
+    private fun ColorPickerView.tapRightEdge() {
+        assertThat("the wheel should be laid out", width, greaterThan(0))
+        val x = width - 5f
+        val y = height / 2f
+        val down = MotionEvent.obtain(0, 0, MotionEvent.ACTION_DOWN, x, y, 0)
+        val up = MotionEvent.obtain(0, 10, MotionEvent.ACTION_UP, x, y, 0)
+        dispatchTouchEvent(down)
+        dispatchTouchEvent(up)
+        down.recycle()
+        up.recycle()
+    }
+
+    /**
+     * Bounded, because the dialog re-posts a frame callback forever: this runs the
+     * pending messages plus a few frames, then stops instead of draining endlessly.
+     */
+    private fun idleMainLooper() = shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(200))
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The whiteboard color picker ignores the color you choose when the current brush is dark: you tap a color on the wheel, press OK, and the brush stays black (or comes back near-black). This makes it impossible to add a custom brush color starting from the default black brush.

The cause is how the picker is built. The wheel only controls hue and saturation; brightness is a separate slider below it. When the picker opens on a dark color, that slider is parked near zero, and the final color is assembled from the slider's
brightness. So no matter where you tap on the wheel, the result assembles back to near-black and the picker looks broken.

## Fixes
* Fixes #21329

## Approach
On the first touch of the wheel, if the current color's brightness is near zero (the slider is parked there), snap the brightness slider to full before the tap is handled. This covers pure black and dark non-black seeds like `#030000`, without affecting normal picking.

## How Has This Been Tested?
Pixel 10 and added Robolectric unit tests in `ColorPickerDialogTest`

https://github.com/user-attachments/assets/cd874064-e280-49dd-b13b-9f16bc316763



## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->