### PR TITLE
fix(deck-picker): do not block the main thread on startup during sync

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -854,7 +854,13 @@ open class DeckPicker :
                         )
                     }
                 }
-                is StartupResponse.FatalError -> handleStartupFailure(response.failure)
+                is StartupResponse.FatalError -> {
+                    // the startup check is asynchronous, so the menu may already have been
+                    // built by the time a failure arrives; rebuild it so onCreateOptionsMenu
+                    // sees the error and blanks it
+                    invalidateOptionsMenu()
+                    handleStartupFailure(response.failure)
+                }
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -508,6 +508,10 @@ class DeckPickerViewModel :
         data object Success : StartupResponse()
     }
 
+    /** The startup check launched by [handleStartup]. Stored so tests can await it */
+    var startupJob: Job? = null
+        private set
+
     /**
      * The first call in showing dialogs for startup - error or success.
      * Attempts startup if storage permission has been acquired, else, it requests the permission
@@ -522,17 +526,26 @@ class DeckPickerViewModel :
         }
 
         Timber.d("handleStartup: Continuing after permission granted")
-        val failure = InitialActivity.getStartupFailureType(environment.preferences, environment::initializeAnkiDroidFolder)
-        if (failure != null) {
-            flowOfStartupResponse.value = StartupResponse.FatalError(failure)
-            return
-        }
+        startupJob =
+            viewModelScope.launch {
+                // opening the collection waits on the collection queue, which a sync stuck on an
+                // unresponsive server can hold for a long time. Waiting on the main thread here
+                // froze the DeckPicker when it was recreated
+                val failure =
+                    withContext(Dispatchers.IO) {
+                        InitialActivity.getStartupFailureType(environment.preferences, environment::initializeAnkiDroidFolder)
+                    }
+                if (failure != null) {
+                    flowOfStartupResponse.value = StartupResponse.FatalError(failure)
+                    return@launch
+                }
 
-        // successful startup
+                // successful startup
 
-        configureRenderingMode()
+                configureRenderingMode()
 
-        flowOfStartupResponse.value = StartupResponse.Success
+                flowOfStartupResponse.value = StartupResponse.Success
+            }
     }
 
     interface AnkiDroidEnvironment {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -86,6 +86,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
 
 typealias ContextMenuOption = DeckPickerContextMenuOption
 
@@ -810,6 +811,32 @@ class DeckPickerTest : RobolectricTest() {
             )
         }
 
+    @Test
+    fun `fatal error arriving after menu creation blanks the options menu`() =
+        deckPickerEx {
+            // the startup check runs on Dispatchers.IO; wait for it to finish and for its
+            // response to be handled, so it cannot race the injected failure below
+            val waitedFor = TimeSource.Monotonic.markNow()
+            while (waitedFor.elapsedNow() < 5.seconds &&
+                (viewModel.startupJob?.isCompleted != true || viewModel.flowOfStartupResponse.value != null)
+            ) {
+                Thread.sleep(10)
+                advanceRobolectricLooper()
+            }
+            assertThat("the real startup check completed", viewModel.startupJob?.isCompleted, equalTo(true))
+            assertThat("the startup response was handled", viewModel.flowOfStartupResponse.value, nullValue())
+            assertThat("menu was built normally on startup", lastCreateOptionsMenuResult, equalTo(true))
+
+            // a slow startup check delivers a fatal error once the menu already exists
+            viewModel.flowOfStartupResponse.value =
+                DeckPickerViewModel.StartupResponse.FatalError(InitialActivity.StartupFailure.DatabaseLocked)
+            advanceRobolectricLooper()
+            advanceRobolectricLooper()
+
+            assertThat("the failure was handled", databaseErrorDialog, equalTo(DatabaseErrorDialogType.DIALOG_DB_LOCKED))
+            assertThat("the menu is rebuilt and blanked", lastCreateOptionsMenuResult, equalTo(false))
+        }
+
     /** Regression test for [#20712](https://github.com/ankidroid/Anki-Android/issues/20712) */
     @Test
     fun `SQLiteDatabaseCorruptException in runCatching shows database error dialog`() =
@@ -873,6 +900,11 @@ class DeckPickerTest : RobolectricTest() {
         var databaseErrorDialog: DatabaseErrorDialogType? = null
         var displayedAnalyticsOptIn = false
         var optionsMenu: Menu? = null
+
+        /** result of the last [onCreateOptionsMenu] call: false means the menu was blanked */
+        var lastCreateOptionsMenuResult: Boolean? = null
+
+        override fun onCreateOptionsMenu(menu: Menu): Boolean = super.onCreateOptionsMenu(menu).also { lastCreateOptionsMenuResult = it }
 
         override fun showDatabaseErrorDialog(
             errorDialogType: DatabaseErrorDialogType,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerViewModelTest.kt
@@ -17,25 +17,37 @@
 package com.ichi2.anki.deckpicker
 
 import android.annotation.SuppressLint
+import android.content.SharedPreferences
 import androidx.annotation.CheckResult
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import anki.card_rendering.EmptyCardsReport
 import anki.card_rendering.emptyCardsReport
 import app.cash.turbine.test
+import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.PermissionSet
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.libanki.Consts
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.Note
 import com.ichi2.anki.libanki.emptyCids
+import com.ichi2.anki.storage.StorageDecision
 import com.ichi2.testutils.ensureOpsExecuted
+import kotlinx.coroutines.runBlocking
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.lessThan
 import org.junit.Test
 import org.junit.runner.RunWith
 import timber.log.Timber
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
 import kotlin.test.assertEquals
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.measureTime
 
 /** Test of [DeckPickerViewModel] */
 @RunWith(AndroidJUnit4::class)
@@ -239,4 +251,67 @@ class DeckPickerViewModelTest : RobolectricTest() {
             }
         }
     }
+
+    @Test
+    fun `handleStartup does not block while a hung sync holds the collection queue`() {
+        col
+        val queueHeld = CountDownLatch(1)
+        val releaseQueue = CountDownLatch(1)
+        // a sync against an unresponsive server runs `withCol { syncCollection(...) }`,
+        // holding the collection queue for the whole network call
+        val hungSync =
+            thread(name = "hung-sync") {
+                runBlocking {
+                    withCol {
+                        queueHeld.countDown()
+                        releaseQueue.await()
+                    }
+                }
+            }
+        try {
+            // in-memory tests don't set a collection path, so force the storage gate open;
+            // otherwise getStartupFailureType returns StorageUndecided before reaching the
+            // getColUnsafe() call that waits on the collection queue
+            CollectionHelper.storageDecisionTestOverride = StorageDecision.Decided
+
+            assertThat("sync is holding the collection queue", queueHeld.await(5.seconds), equalTo(true))
+
+            // if handleStartup blocks on the queue, free it after a delay so the test fails with a message instead of hanging
+            thread(name = "watchdog") {
+                if (!releaseQueue.await(WATCHDOG_TIMEOUT)) {
+                    releaseQueue.countDown()
+                }
+            }
+
+            val elapsed = measureTime { viewModel.handleStartup(grantedPermissionsEnvironment) }
+
+            assertThat(
+                "handleStartup waited $elapsed for the collection queue. On a device this ANRs when DeckPicker is recreated while a sync is stuck on an unresponsive server",
+                elapsed,
+                lessThan(WATCHDOG_TIMEOUT),
+            )
+        } finally {
+            CollectionHelper.storageDecisionTestOverride = null
+            releaseQueue.countDown()
+            hungSync.join()
+        }
+    }
+
+    private val grantedPermissionsEnvironment =
+        object : DeckPickerViewModel.AnkiDroidEnvironment {
+            override fun hasRequiredPermissions() = true
+
+            override val requiredPermissions: PermissionSet
+                get() = error("unused: permissions are granted")
+
+            override val preferences: SharedPreferences
+                get() = getPreferences()
+
+            override fun initializeAnkiDroidFolder() = true
+        }
 }
+
+/** how long the watchdog lets a blocked [DeckPickerViewModel.handleStartup] hold the test before freeing the queue */
+private val WATCHDOG_TIMEOUT = 2.seconds
+
+private fun CountDownLatch.await(timeout: Duration): Boolean = await(timeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.8 (some diagnosis and a few parts of code)

<!--- Please fill the necessary details below -->
## Purpose / Description
Fixes an ANR when the DeckPicker is recreated while a sync is stuck on an unresponsive server (for example AnkiWeb being down).

## Fixes
* Fixes #21305

## Approach
See commit 

## How Has This Been Tested?
Unit test

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->