### PR TITLE
refactor: use MenuProvider in StudyOptionsActivity, remove starting reviewer in undo

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
@@ -18,8 +18,10 @@ package com.ichi2.anki
 import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
+import android.view.MenuInflater
 import android.view.MenuItem
 import androidx.core.view.MenuItemCompat
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import androidx.lifecycle.lifecycleScope
@@ -62,6 +64,7 @@ class StudyOptionsActivity :
             loadStudyOptionsFragment()
         }
         setResult(RESULT_OK)
+        addMenuProvider(menuProvider)
 
         setFragmentResultListener(REQUEST_KEY) { _, bundle ->
             when (CustomStudyAction.fromBundle(bundle)) {
@@ -91,9 +94,39 @@ class StudyOptionsActivity :
                 )
                 addToBackStack(null)
             }
-            invalidateOptionsMenu()
+            invalidateMenu()
         }
     }
+
+    private val menuProvider: MenuProvider =
+        object : MenuProvider {
+            override fun onCreateMenu(
+                menu: Menu,
+                menuInflater: MenuInflater,
+            ) {
+                menuInflater.inflate(R.menu.activity_study_options, menu)
+                val undoMenuItem = menu.findItem(R.id.action_undo)
+                val undoActionProvider = MenuItemCompat.getActionProvider(undoMenuItem) as? RtlCompliantActionProvider
+                undoActionProvider?.clickHandler = { _, menuItem -> onMenuItemSelected(menuItem) }
+            }
+
+            override fun onPrepareMenu(menu: Menu) {
+                val undoMenuItem = menu.findItem(R.id.action_undo)
+                undoMenuItem.isVisible = undoState.hasAction && (currentFragment is StudyOptionsFragment)
+                undoMenuItem.title = undoState.label
+            }
+
+            override fun onMenuItemSelected(item: MenuItem): Boolean =
+                when (item.itemId) {
+                    R.id.action_undo -> {
+                        launchCatchingTask {
+                            undoAndShowSnackbar()
+                        }
+                        true
+                    }
+                    else -> false
+                }
+        }
 
     private fun loadStudyOptionsFragment() {
         val currentFragment = StudyOptionsFragment()
@@ -104,39 +137,6 @@ class StudyOptionsActivity :
 
     private val currentFragment: Fragment?
         get() = supportFragmentManager.findFragmentById(R.id.studyoptions_frame)
-
-    override fun onCreateOptionsMenu(menu: Menu): Boolean {
-        menuInflater.inflate(R.menu.activity_study_options, menu)
-        val undoMenuItem = menu.findItem(R.id.action_undo)
-        val undoActionProvider = MenuItemCompat.getActionProvider(undoMenuItem) as? RtlCompliantActionProvider
-        // Set the proper click target for the undo button's ActionProvider
-        undoActionProvider?.clickHandler = { _, menuItem -> onOptionsItemSelected(menuItem) }
-        undoMenuItem.isVisible = undoState.hasAction && (currentFragment is StudyOptionsFragment)
-        undoMenuItem.title = undoState.label
-        return true
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            android.R.id.home -> {
-                onBackPressedDispatcher.onBackPressed()
-                true
-            }
-            R.id.action_undo -> {
-                launchCatchingTask {
-                    undoAndShowSnackbar()
-                    // TODO why are we going to the Reviewer from here? Desktop doesn't do this
-                    Reviewer
-                        .getIntent(this@StudyOptionsActivity)
-                        .apply { flags = Intent.FLAG_ACTIVITY_FORWARD_RESULT }
-                        .also { startActivity(it) }
-                    finish()
-                }
-                true
-            }
-            else -> return super.onOptionsItemSelected(item)
-        }
-    }
 
     override fun onResume() {
         super.onResume()
@@ -162,7 +162,7 @@ class StudyOptionsActivity :
                 }
             if (undoState != newUndoState) {
                 undoState = newUndoState
-                invalidateOptionsMenu()
+                invalidateMenu()
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
@@ -124,12 +124,6 @@ class StudyOptionsActivity :
                         Timber.i("Undoing last action from study options screen")
                         launchCatchingTask {
                             undoAndShowSnackbar()
-                            // TODO why are we going to the Reviewer from here? Desktop doesn't do this
-                            Reviewer
-                                .getIntent(this@StudyOptionsActivity)
-                                .apply { flags = Intent.FLAG_ACTIVITY_FORWARD_RESULT }
-                                .also { startActivity(it) }
-                            finish()
                         }
                         true
                     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
@@ -18,8 +18,10 @@ package com.ichi2.anki
 import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
+import android.view.MenuInflater
 import android.view.MenuItem
 import androidx.core.view.MenuItemCompat
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import androidx.lifecycle.lifecycleScope
@@ -62,6 +64,7 @@ class StudyOptionsActivity :
             loadStudyOptionsFragment()
         }
         setResult(RESULT_OK)
+        addMenuProvider(menuProvider)
 
         setFragmentResultListener(REQUEST_KEY) { _, bundle ->
             when (CustomStudyAction.fromBundle(bundle)) {
@@ -91,9 +94,48 @@ class StudyOptionsActivity :
                 )
                 addToBackStack(null)
             }
-            invalidateOptionsMenu()
+            invalidateMenu()
         }
     }
+
+    private val menuProvider: MenuProvider =
+        object : MenuProvider {
+            override fun onCreateMenu(
+                menu: Menu,
+                menuInflater: MenuInflater,
+            ) {
+                menuInflater.inflate(R.menu.activity_study_options, menu)
+                val undoMenuItem = menu.findItem(R.id.action_undo)
+                val undoActionProvider = MenuItemCompat.getActionProvider(undoMenuItem) as? RtlCompliantActionProvider
+                undoActionProvider?.clickHandler = { _, menuItem -> onMenuItemSelected(menuItem) }
+            }
+
+            override fun onPrepareMenu(menu: Menu) {
+                val undoMenuItem = menu.findItem(R.id.action_undo)
+                // TODO: Ideally, the undo button should be owned by StudyOptionsFragment or be provided by a unified UndoMenuProvider
+                // Checking the current fragment from the activity to decide whether the button should be visible is hacky; see #21339
+                undoMenuItem.isVisible = undoState.hasAction && (currentFragment is StudyOptionsFragment)
+                undoMenuItem.title = undoState.label
+            }
+
+            override fun onMenuItemSelected(item: MenuItem): Boolean =
+                when (item.itemId) {
+                    R.id.action_undo -> {
+                        Timber.i("Undoing last action from study options screen")
+                        launchCatchingTask {
+                            undoAndShowSnackbar()
+                            // TODO why are we going to the Reviewer from here? Desktop doesn't do this
+                            Reviewer
+                                .getIntent(this@StudyOptionsActivity)
+                                .apply { flags = Intent.FLAG_ACTIVITY_FORWARD_RESULT }
+                                .also { startActivity(it) }
+                            finish()
+                        }
+                        true
+                    }
+                    else -> false
+                }
+        }
 
     private fun loadStudyOptionsFragment() {
         val currentFragment = StudyOptionsFragment()
@@ -104,39 +146,6 @@ class StudyOptionsActivity :
 
     private val currentFragment: Fragment?
         get() = supportFragmentManager.findFragmentById(R.id.studyoptions_frame)
-
-    override fun onCreateOptionsMenu(menu: Menu): Boolean {
-        menuInflater.inflate(R.menu.activity_study_options, menu)
-        val undoMenuItem = menu.findItem(R.id.action_undo)
-        val undoActionProvider = MenuItemCompat.getActionProvider(undoMenuItem) as? RtlCompliantActionProvider
-        // Set the proper click target for the undo button's ActionProvider
-        undoActionProvider?.clickHandler = { _, menuItem -> onOptionsItemSelected(menuItem) }
-        undoMenuItem.isVisible = undoState.hasAction && (currentFragment is StudyOptionsFragment)
-        undoMenuItem.title = undoState.label
-        return true
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            android.R.id.home -> {
-                onBackPressedDispatcher.onBackPressed()
-                true
-            }
-            R.id.action_undo -> {
-                launchCatchingTask {
-                    undoAndShowSnackbar()
-                    // TODO why are we going to the Reviewer from here? Desktop doesn't do this
-                    Reviewer
-                        .getIntent(this@StudyOptionsActivity)
-                        .apply { flags = Intent.FLAG_ACTIVITY_FORWARD_RESULT }
-                        .also { startActivity(it) }
-                    finish()
-                }
-                true
-            }
-            else -> return super.onOptionsItemSelected(item)
-        }
-    }
 
     override fun onResume() {
         super.onResume()
@@ -162,7 +171,7 @@ class StudyOptionsActivity :
                 }
             if (undoState != newUndoState) {
                 undoState = newUndoState
-                invalidateOptionsMenu()
+                invalidateMenu()
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
@@ -51,6 +51,10 @@ class StudyOptionsActivity :
     ChangeManager.Subscriber {
     private var undoState = UndoState()
 
+    init {
+        ChangeManager.subscribe(this)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {
             return
@@ -151,7 +155,6 @@ class StudyOptionsActivity :
         handler: Any?,
     ) {
         refreshUndoState()
-        (currentFragment as? StudyOptionsFragment)?.refreshInterface()
     }
 
     private fun refreshUndoState() {


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Sonnet 4.5

## Purpose / Description
- Split off from https://github.com/ankidroid/Anki-Android/pull/21140
- StudyOptionsActivity is currently using onOptionsItemSelected etc. This PR migrates it to the modern MenuProvider interface.
- Also, addresses a TODO comment left a while ago by lukstbit: I think it's safe to remove the call to open the reviewer:

```kotlin
                     // TODO why are we going to the Reviewer from here? Desktop doesn't do this
                    Reviewer
                        .getIntent(this@StudyOptionsActivity)
                        .apply { flags = Intent.FLAG_ACTIVITY_FORWARD_RESULT }
                        .also { startActivity(it) }
                    finish()
```

## Fixes
Originally created as a response to [one of David's comments](https://github.com/ankidroid/Anki-Android/pull/21140#discussion_r3324288970):

> Optional/for a TODO/ignore this
> Take a look at `CardBrowser` + `CardBrowserFragment`'s use of `MenuProvider
> Would this simplify the logic? Make one provider for each state: fragmented and non-fragmented, and the fragments control their menus
> https://github.com/ankidroid/Anki-Android/blob/25d4bc11d1675dc724371c410efb2189ae3cd684/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt#L361-L381

See below for discussion of David's concern above.

## Approach
- Simple refactor and removal of the reviewer-opening line

## How Has This Been Tested?
- No regressions on tablets, wide screens, including DeckPicker back button and undo button
- Back button works on StudyOptionsActivity
- Undo button works on StudyOptionsActivity
- Undo does not start reviewer anymore; if, for instance, the option to be undone is a deck selection, pressing undo navigates to the deck that was previously selected rather than opening the reviewer
- Physical Samsung S23, API 36

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->