### PR TITLE
fix(addons): improve addon validation [Dev-only]

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/AddonData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/AddonData.kt
@@ -70,23 +70,36 @@ data class DistInfo(
 )
 
 /**
+ * Result of validating a manifest ([AddonData]) as an AnkiDroid addon
+ */
+sealed interface AddonValidationResult {
+    /** The manifest maps to a usable [AddonModel] */
+    data class Valid(
+        val addonModel: AddonModel,
+    ) : AddonValidationResult
+
+    /** The manifest is not a valid AnkiDroid addon, for the reasons in [errors] */
+    data class Invalid(
+        val errors: List<String>,
+    ) : AddonValidationResult
+}
+
+/**
  * Check if npm package is valid or not by fields ankidroidJsApi, keywords (ankidroid-js-addon) and
  * addon_type (reviewer or note editor) in addonData
  *
- * For valid addon the error list will be empty,
- * for not valid addon the error list will contain the error related to the checks
- *
  * @param packageJsonPath package.json file path
- * @return Pair with addonModel and error list
+ * @return [AddonValidationResult.Valid] with the mapped model,
+ *   or [AddonValidationResult.Invalid] with the errors related to the failed checks
  */
 @Throws(IOException::class)
-fun getAddonModelFromJson(packageJsonPath: String): Pair<AddonModel?, List<String>> {
+fun getAddonModelFromJson(packageJsonPath: String): AddonValidationResult {
     val data = File(packageJsonPath).readBytes().decodeToString()
     return try {
         val json = Json { ignoreUnknownKeys = true }
         getAddonModelFromAddonData(json.decodeFromString(data))
     } catch (exc: SerializationException) {
-        return Pair(null, listOf("Unable to parse manifest: $exc"))
+        AddonValidationResult.Invalid(listOf("Unable to parse manifest: $exc"))
     }
 }
 
@@ -94,12 +107,10 @@ fun getAddonModelFromJson(packageJsonPath: String): Pair<AddonModel?, List<Strin
  * Get addonModel from addonData
  *
  * @param addonData
- * @return pair of valid addon model and errors list
+ * @return [AddonValidationResult.Valid] with the mapped model,
+ *   or [AddonValidationResult.Invalid] with the errors related to the failed checks
  */
-fun getAddonModelFromAddonData(addonData: AddonData): Pair<AddonModel?, List<String>> {
-    var errorStr: String
-    val errorList: MutableList<String> = ArrayList()
-
+fun getAddonModelFromAddonData(addonData: AddonData): AddonValidationResult {
     // either fields not present in package.json or failed to parse the fields
     if (addonData.name.isNullOrBlank() ||
         addonData.addonTitle.isNullOrBlank() ||
@@ -110,49 +121,46 @@ fun getAddonModelFromAddonData(addonData: AddonData): Pair<AddonModel?, List<Str
         addonData.homepage.isNullOrBlank() ||
         addonData.keywords.isNullOrEmpty()
     ) {
-        errorStr = "Invalid addon package: fields in package.json are empty or null"
-        errorList.add(errorStr)
         // the checks below dereference these fields, so they cannot run safely
-        return Pair(null, errorList)
+        return AddonValidationResult.Invalid(listOf("Invalid addon package: fields in package.json are empty or null"))
     }
+
+    val errorList: MutableList<String> = ArrayList()
 
     // check if name is safe and valid
     if (!validateName(addonData.name)) {
-        errorStr = "Invalid addon package: package name failed validation"
-        errorList.add(errorStr)
+        errorList.add("Invalid addon package: package name failed validation")
     }
 
     if (addonData.addonType != REVIEWER_ADDON && addonData.addonType != NOTE_EDITOR_ADDON) {
-        errorStr = "Invalid addon package: ${addonData.addonType} is not valid addon type, " +
-            "package.json must have 'addonType' fields of 'reviewer' or 'note-editor'"
-        errorList.add(errorStr)
+        errorList.add(
+            "Invalid addon package: ${addonData.addonType} is not valid addon type, " +
+                "package.json must have 'addonType' fields of 'reviewer' or 'note-editor'",
+        )
     }
 
     // if addon type is note editor then it must have icon
     if (addonData.addonType == NOTE_EDITOR_ADDON && addonData.icon.isNullOrBlank()) {
-        errorStr = "Invalid addon package: note editor addon must have 'icon' fields in package.json"
-        errorList.add(errorStr)
+        errorList.add("Invalid addon package: note editor addon must have 'icon' fields in package.json")
     }
 
     // check if ankidroid-js-addon present or not in mapped addonData
     val jsAddonKeywordsPresent = addonData.keywords.any { it == ANKIDROID_JS_ADDON_KEYWORDS }
     if (!jsAddonKeywordsPresent) {
-        errorStr = "Invalid addon package: package.json does not have 'ankidroid-js-addon' in ${addonData.keywords} keywords"
-        errorList.add(errorStr)
+        errorList.add("Invalid addon package: package.json does not have 'ankidroid-js-addon' in ${addonData.keywords} keywords")
     }
 
     // Check supplied api and current api
     if (addonData.ankidroidJsApi != CURRENT_JS_API_VERSION) {
-        errorStr = "Invalid addon package: supplied js api version ${addonData.ankidroidJsApi} must " +
-            "be equal to current js api version $CURRENT_JS_API_VERSION"
-        errorList.add(errorStr)
+        errorList.add(
+            "Invalid addon package: supplied js api version ${addonData.ankidroidJsApi} must " +
+                "be equal to current js api version $CURRENT_JS_API_VERSION",
+        )
     }
 
-    val immutableList: List<String> = ArrayList(errorList)
-
-    // there are errors in package.json so return null and errors list
+    // there are errors in package.json so return the errors list
     if (errorList.isNotEmpty()) {
-        return Pair(null, immutableList)
+        return AddonValidationResult.Invalid(errorList)
     }
 
     val icon = if (addonData.addonType == NOTE_EDITOR_ADDON) addonData.icon!! else ""
@@ -175,7 +183,7 @@ fun getAddonModelFromAddonData(addonData: AddonData): Pair<AddonModel?, List<Str
             dist = addonData.dist,
         )
 
-    return Pair(addonModel, immutableList)
+    return AddonValidationResult.Valid(addonModel)
 }
 
 /**
@@ -197,14 +205,13 @@ fun getAddonModelListFromJson(packageJsonUrl: URL): Pair<List<AddonModel>, List<
     val addonsData = json.decodeFromString<List<AddonData>>(urlData)
     val addonsModelList = mutableListOf<AddonModel>()
     for (addon in addonsData) {
-        val result = getAddonModelFromAddonData(addon)
-
-        if (result.first == null) {
-            Timber.i("Not a valid addon for AnkiDroid, the errors for the addon:\n %s", result.second)
-            errorList.addAll(result.second)
-            continue
+        when (val result = getAddonModelFromAddonData(addon)) {
+            is AddonValidationResult.Valid -> addonsModelList.add(result.addonModel)
+            is AddonValidationResult.Invalid -> {
+                Timber.i("Not a valid addon for AnkiDroid, the errors for the addon:\n %s", result.errors)
+                errorList.addAll(result.errors)
+            }
         }
-        addonsModelList.add(result.first!!)
     }
 
     return Pair(addonsModelList, errorList.toList())

--- a/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/AddonData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/AddonData.kt
@@ -75,20 +75,23 @@ sealed interface AddonValidationResult {
  * Check if npm package is valid or not by fields ankidroidJsApi, keywords (ankidroid-js-addon) and
  * addon_type (reviewer or note editor) in addonData
  *
- * @param packageJsonPath package.json file path
+ * Unreadable and unparseable files are reported as [AddonValidationResult.Invalid]: a caller
+ * listing an addons directory must not be aborted by one corrupt addon
+ *
+ * @param packageJson package.json file
  * @return [AddonValidationResult.Valid] with the mapped model,
  *   or [AddonValidationResult.Invalid] with the errors related to the failed checks
  */
-@Throws(IOException::class)
-fun getAddonModelFromJson(packageJsonPath: String): AddonValidationResult {
-    val data = File(packageJsonPath).readBytes().decodeToString()
-    return try {
+fun getAddonModelFromJson(packageJson: File): AddonValidationResult =
+    try {
+        val data = packageJson.readBytes().decodeToString()
         val json = Json { ignoreUnknownKeys = true }
         getAddonModelFromAddonData(json.decodeFromString(data))
     } catch (exc: SerializationException) {
         AddonValidationResult.Invalid(listOf("Unable to parse manifest: $exc"))
+    } catch (exc: IOException) {
+        AddonValidationResult.Invalid(listOf("Unable to read manifest: $exc"))
     }
-}
 
 /**
  * Get addonModel from addonData

--- a/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/AddonData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/AddonData.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (c) 2021 Mani <infinyte01@gmail.com>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2021 Mani <infinyte01@gmail.com>
 
 package com.ichi2.anki.jsaddons
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/AddonData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/AddonData.kt
@@ -40,6 +40,11 @@ import kotlin.jvm.Throws
  * @param name name of npm package, it unique for each package listed on npm
  * @param addonTitle  for showing in AnkiDroid
  * @param icon only required for note editor (single character recommended)
+ * @param description commonly absent from real package.json files; absence never invalidates the addon
+ * @param author commonly absent from real package.json files; absence never invalidates the addon
+ * @param license commonly absent from real package.json files; absence never invalidates the addon
+ * @param dist only exists in the npm registry API response, not in the package.json inside a tarball;
+ *   absence never invalidates the addon
  */
 
 @Serializable
@@ -99,6 +104,7 @@ fun getAddonModelFromAddonData(addonData: AddonData): Pair<AddonModel?, List<Str
     if (addonData.name.isNullOrBlank() ||
         addonData.addonTitle.isNullOrBlank() ||
         addonData.main.isNullOrBlank() ||
+        addonData.version.isNullOrBlank() ||
         addonData.ankidroidJsApi.isNullOrBlank() ||
         addonData.addonType.isNullOrBlank() ||
         addonData.homepage.isNullOrBlank() ||
@@ -106,10 +112,12 @@ fun getAddonModelFromAddonData(addonData: AddonData): Pair<AddonModel?, List<Str
     ) {
         errorStr = "Invalid addon package: fields in package.json are empty or null"
         errorList.add(errorStr)
+        // the checks below dereference these fields, so they cannot run safely
+        return Pair(null, errorList)
     }
 
     // check if name is safe and valid
-    if (!validateName(addonData.name!!)) {
+    if (!validateName(addonData.name)) {
         errorStr = "Invalid addon package: package name failed validation"
         errorList.add(errorStr)
     }
@@ -127,8 +135,8 @@ fun getAddonModelFromAddonData(addonData: AddonData): Pair<AddonModel?, List<Str
     }
 
     // check if ankidroid-js-addon present or not in mapped addonData
-    val jsAddonKeywordsPresent = addonData.keywords?.any { it == ANKIDROID_JS_ADDON_KEYWORDS }
-    if (!jsAddonKeywordsPresent!!) {
+    val jsAddonKeywordsPresent = addonData.keywords.any { it == ANKIDROID_JS_ADDON_KEYWORDS }
+    if (!jsAddonKeywordsPresent) {
         errorStr = "Invalid addon package: package.json does not have 'ankidroid-js-addon' in ${addonData.keywords} keywords"
         errorList.add(errorStr)
     }
@@ -153,18 +161,18 @@ fun getAddonModelFromAddonData(addonData: AddonData): Pair<AddonModel?, List<Str
     val addonModel =
         AddonModel(
             name = addonData.name,
-            addonTitle = addonData.addonTitle!!,
+            addonTitle = addonData.addonTitle,
             icon = icon,
-            version = addonData.version!!,
-            description = addonData.description!!,
-            main = addonData.main!!,
-            ankidroidJsApi = addonData.ankidroidJsApi!!,
-            addonType = addonData.addonType!!,
+            version = addonData.version,
+            description = addonData.description.orEmpty(),
+            main = addonData.main,
+            ankidroidJsApi = addonData.ankidroidJsApi,
+            addonType = addonData.addonType,
             keywords = addonData.keywords,
-            author = addonData.author!!,
-            license = addonData.license!!,
-            homepage = addonData.homepage!!,
-            dist = addonData.dist!!,
+            author = addonData.author ?: emptyMap(),
+            license = addonData.license.orEmpty(),
+            homepage = addonData.homepage,
+            dist = addonData.dist,
         )
 
     return Pair(addonModel, immutableList)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/AddonData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/AddonData.kt
@@ -56,6 +56,9 @@ data class DistInfo(
     val tarball: String,
 )
 
+/** Parsing contract for package.json: unknown fields must never fail parsing */
+private val json = Json { ignoreUnknownKeys = true }
+
 /**
  * Result of validating a manifest ([AddonData]) as an AnkiDroid addon
  */
@@ -85,7 +88,6 @@ sealed interface AddonValidationResult {
 fun getAddonModelFromJson(packageJson: File): AddonValidationResult =
     try {
         val data = packageJson.readBytes().decodeToString()
-        val json = Json { ignoreUnknownKeys = true }
         getAddonModelFromAddonData(json.decodeFromString(data))
     } catch (exc: SerializationException) {
         AddonValidationResult.Invalid(listOf("Unable to parse manifest: $exc"))
@@ -191,7 +193,6 @@ fun getAddonModelListFromJson(packageJsonUrl: URL): Pair<List<AddonModel>, List<
             HttpFetcher.fetchThroughHttp(packageJsonUrl.toString())
         }
     val errorList: MutableList<String> = ArrayList()
-    val json = Json { ignoreUnknownKeys = true }
     val addonsData = json.decodeFromString<List<AddonData>>(urlData)
     val addonsModelList = mutableListOf<AddonModel>()
     for (addon in addonsData) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/AddonModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/AddonModel.kt
@@ -3,9 +3,6 @@
 
 package com.ichi2.anki.jsaddons
 
-import android.content.SharedPreferences
-import androidx.core.content.edit
-
 data class AddonModel(
     val name: String,
     val addonTitle: String,
@@ -21,34 +18,4 @@ data class AddonModel(
     val homepage: String,
     /** Tarball location from the npm registry API; null for locally installed addons */
     val dist: DistInfo?,
-) {
-    /**
-     * Update preferences for addons with boolean remove, the preferences will be used to store the information about
-     * enabled and disabled addon. So, that other method will return content of script to reviewer or note editor
-     *
-     * @param preferences
-     * @param jsAddonKey  REVIEWER_ADDON_KEY
-     * @param remove    true for removing from prefs
-     *
-     * Android returns a reference to StringSet in SharedPreferences but does not mark it as modified if any changes made,
-     * so commit/apply won't persist it. It needs to make a copy and set the new copy in to persist any StringSet changes
-     * in SharedPreferences.
-     * https://stackoverflow.com/questions/19949182/android-sharedpreferences-string-set-some-items-are-removed-after-app-restart/19949833
-     */
-    fun updatePrefs(
-        preferences: SharedPreferences,
-        jsAddonKey: String,
-        remove: Boolean,
-    ) {
-        val reviewerEnabledAddonSet = preferences.getStringSet(jsAddonKey, HashSet())
-        val newStrSet: MutableSet<String> = reviewerEnabledAddonSet?.toHashSet()!!
-
-        if (remove) {
-            newStrSet.remove(name)
-        } else {
-            newStrSet.add(name)
-        }
-
-        preferences.edit { putStringSet(jsAddonKey, newStrSet) }
-    }
-}
+)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/AddonModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/AddonModel.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (c) 2021 Mani <infinyte01@gmail.com>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2021 Mani <infinyte01@gmail.com>
 
 package com.ichi2.anki.jsaddons
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/AddonModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/AddonModel.kt
@@ -32,7 +32,8 @@ data class AddonModel(
     val author: Map<String, String>,
     val license: String,
     val homepage: String,
-    val dist: DistInfo,
+    /** Tarball location from the npm registry API; null for locally installed addons */
+    val dist: DistInfo?,
 ) {
     /**
      * Update preferences for addons with boolean remove, the preferences will be used to store the information about

--- a/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/AddonsConst.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/AddonsConst.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (c) 2021 Mani <infinyte01@gmail.com>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2021 Mani <infinyte01@gmail.com>
 
 package com.ichi2.anki.jsaddons
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/NpmUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/NpmUtils.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (c) 2021 Mani <infinyte01@gmail.com>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 3 of the License, or (at your option) any later
- * version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2021 Mani <infinyte01@gmail.com>
 
 package com.ichi2.anki.jsaddons
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/TgzPackageExtract.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/TgzPackageExtract.kt
@@ -422,8 +422,12 @@ class TgzPackageExtract(
         }
     }
 
+    /**
+     * Recursively delete [addonsPackageDir], but only if it is inside an `addons` directory:
+     * a defence against deleting an arbitrary directory if a bad path is passed in
+     */
     private fun safeDeleteAddonsPackageDir(addonsPackageDir: AddonsPackageDir) {
-        if (addonsPackageDir.parent != "addons") {
+        if (addonsPackageDir.parentFile?.name != "addons") {
             return
         }
         addonsPackageDir.deleteRecursively()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/TgzPackageExtract.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/TgzPackageExtract.kt
@@ -36,7 +36,6 @@ package com.ichi2.anki.jsaddons
 import android.content.Context
 import android.text.format.Formatter
 import com.ichi2.anki.R
-import com.ichi2.anki.common.utils.android.showThemedToast
 import com.ichi2.anki.compat.CompatHelper.Companion.compat
 import com.ichi2.utils.FileUtil
 import org.apache.commons.compress.archivers.ArchiveException
@@ -135,9 +134,8 @@ class TgzPackageExtract(
         try {
             compat.createDirectories(addonsPackageDir)
         } catch (e: IOException) {
-            showThemedToast(context, context.getString(R.string.could_not_create_dir, addonsPackageDir.absolutePath), false)
             Timber.w(e)
-            return
+            throw IOException(context.getString(R.string.could_not_create_dir, addonsPackageDir.absolutePath))
         }
 
         // Make sure we have 2x the tar file size in free space (1x for tar file, 1x for unarchived tar file contents

--- a/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/TgzPackageExtract.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/TgzPackageExtract.kt
@@ -154,9 +154,12 @@ class TgzPackageExtract(
         try {
             // If space available then unTar it
             unTar(tarTempFile, addonsPackageDir)
-        } catch (e: IOException) {
-            Timber.w("Failed to unTar file")
+        } catch (e: Exception) {
+            // ArchiveException/IllegalStateException from unTar need the same cleanup as
+            // IOException: without it, a failed extraction leaves a partial addon behind
+            Timber.w(e, "Failed to unTar file")
             safeDeleteAddonsPackageDir(addonsPackageDir)
+            throw e
         } finally {
             tarTempFile.delete()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/TgzPackageExtract.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/TgzPackageExtract.kt
@@ -36,7 +36,6 @@ package com.ichi2.anki.jsaddons
 import android.content.Context
 import android.text.format.Formatter
 import com.ichi2.anki.R
-import com.ichi2.anki.common.utils.android.showThemedToast
 import com.ichi2.anki.compat.CompatHelper.Companion.compat
 import com.ichi2.utils.FileUtil
 import org.apache.commons.compress.archivers.ArchiveException
@@ -136,9 +135,8 @@ class TgzPackageExtract(
         try {
             compat.createDirectories(addonsPackageDir)
         } catch (e: IOException) {
-            showThemedToast(context, context.getString(R.string.could_not_create_dir, addonsPackageDir.absolutePath), false)
             Timber.w(e)
-            return
+            throw IOException(context.getString(R.string.could_not_create_dir, addonsPackageDir.absolutePath))
         }
 
         // Make sure we have 2x the tar file size in free space (1x for tar file, 1x for unarchived tar file contents

--- a/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/TgzPackageExtract.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/TgzPackageExtract.kt
@@ -155,9 +155,12 @@ class TgzPackageExtract(
         try {
             // If space available then unTar it
             unTar(tarTempFile, addonsPackageDir)
-        } catch (e: IOException) {
-            Timber.w("Failed to unTar file")
+        } catch (e: Exception) {
+            // ArchiveException/IllegalStateException from unTar need the same cleanup as
+            // IOException: without it, a failed extraction leaves a partial addon behind
+            Timber.w(e, "Failed to unTar file")
             safeDeleteAddonsPackageDir(addonsPackageDir)
+            throw e
         } finally {
             tarTempFile.delete()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/TgzPackageExtract.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/TgzPackageExtract.kt
@@ -436,8 +436,12 @@ class TgzPackageExtract(
         }
     }
 
+    /**
+     * Recursively delete [addonsPackageDir], but only if it is inside an `addons` directory:
+     * a defence against deleting an arbitrary directory if a bad path is passed in
+     */
     private fun safeDeleteAddonsPackageDir(addonsPackageDir: AddonsPackageDir) {
-        if (addonsPackageDir.parent != "addons") {
+        if (addonsPackageDir.parentFile?.name != "addons") {
             return
         }
         addonsPackageDir.deleteRecursively()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/AddonModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/AddonModelTest.kt
@@ -189,6 +189,13 @@ class AddonModelTest : RobolectricTest() {
         assertFalse("missing 'version' is reported as an error", errors.isEmpty())
     }
 
+    @Test // exercises the checks after the required-fields guard: their errors must be returned
+    fun invalidAddonTypeReturnsErrorTest() {
+        val result = getAddonModelFromAddonData(addonData(addonType = "invalid-type"))
+        val errors = assertIs<AddonValidationResult.Invalid>(result, "model is not built from an invalid manifest").errors
+        assertFalse("invalid 'addonType' is reported as an error", errors.isEmpty())
+    }
+
     @Test
     fun missingDistIsValidTest() {
         // 'dist' is metadata added by the npm registry API; the package.json inside a

--- a/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/AddonModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/AddonModelTest.kt
@@ -19,8 +19,10 @@ package com.ichi2.anki.jsaddons
 import android.content.SharedPreferences
 import android.os.Looper.getMainLooper
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.AnkiDroidJsAPIConstants.CURRENT_JS_API_VERSION
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.jsaddons.AddonsConst.ANKIDROID_JS_ADDON_KEYWORDS
 import com.ichi2.anki.jsaddons.AddonsConst.REVIEWER_ADDON
 import com.ichi2.utils.FileOperation
 import junit.framework.TestCase.assertEquals
@@ -125,11 +127,86 @@ class AddonModelTest : RobolectricTest() {
         // first addon name and tgz download url
         val addon1 = result.first[0]
         assertEquals(addon1.name, "ankidroid-js-addon-progress-bar")
-        assertThat(addon1.dist.tarball, endsWith(".tgz"))
+        assertThat(addon1.dist!!.tarball, endsWith(".tgz"))
 
         // second addon name and tgz download url
         val addon2 = result.first[1]
         assertEquals(addon2.name, "valid-ankidroid-js-addon-test")
-        assertThat(addon2.dist.tarball, endsWith(".tgz"))
+        assertThat(addon2.dist!!.tarball, endsWith(".tgz"))
+    }
+
+    /**
+     * A valid manifest, with individual fields overridable so each test can knock one out
+     */
+    private fun addonData(
+        name: String? = "valid-ankidroid-js-addon-test",
+        addonTitle: String? = "Valid AnkiDroid JS Addon",
+        icon: String? = "",
+        version: String? = "1.0.0",
+        description: String? = "A test addon",
+        main: String? = "index.js",
+        ankidroidJsApi: String? = CURRENT_JS_API_VERSION,
+        addonType: String? = REVIEWER_ADDON,
+        keywords: List<String>? = listOf(ANKIDROID_JS_ADDON_KEYWORDS),
+        author: Map<String, String>? = mapOf("name" to "AnkiDroid"),
+        license: String? = "MIT",
+        homepage: String? = "https://example.com",
+        dist: DistInfo? = DistInfo("https://example.com/addon.tgz"),
+    ): AddonData =
+        AddonData(
+            name,
+            addonTitle,
+            icon,
+            version,
+            description,
+            main,
+            ankidroidJsApi,
+            addonType,
+            keywords,
+            author,
+            license,
+            homepage,
+            dist,
+        )
+
+    @Test // the validator must report errors, never throw
+    fun missingNameReturnsErrorTest() {
+        val result = getAddonModelFromAddonData(addonData(name = null))
+        assertTrue("model is not built from an invalid manifest", result.first == null)
+        assertFalse("missing 'name' is reported as an error", result.second.isEmpty())
+    }
+
+    @Test // the validator must report errors, never throw
+    fun missingKeywordsReturnsErrorTest() {
+        val result = getAddonModelFromAddonData(addonData(keywords = null))
+        assertTrue("model is not built from an invalid manifest", result.first == null)
+        assertFalse("missing 'keywords' is reported as an error", result.second.isEmpty())
+    }
+
+    @Test // 'version' is force-unwrapped during model construction, so it must be validated
+    fun missingVersionReturnsErrorTest() {
+        val result = getAddonModelFromAddonData(addonData(version = null))
+        assertTrue("model is not built from an invalid manifest", result.first == null)
+        assertFalse("missing 'version' is reported as an error", result.second.isEmpty())
+    }
+
+    @Test
+    fun missingDistIsValidTest() {
+        // 'dist' is metadata added by the npm registry API; the package.json inside a
+        // tarball does not contain it, so a locally installed addon must still validate
+        val result = getAddonModelFromAddonData(addonData(dist = null))
+        assertTrue("no errors for a manifest without 'dist': ${result.second}", result.second.isEmpty())
+        assertTrue("model is built from a manifest without 'dist'", result.first != null)
+    }
+
+    @Test
+    fun missingOptionalMetadataIsValidTest() {
+        // description/author/license are commonly absent from real package.json files
+        val result = getAddonModelFromAddonData(addonData(description = null, author = null, license = null))
+        assertTrue("no errors for a manifest without optional metadata: ${result.second}", result.second.isEmpty())
+        val addon = result.first!!
+        assertEquals("", addon.description)
+        assertEquals(emptyMap<String, String>(), addon.author)
+        assertEquals("", addon.license)
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/AddonModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/AddonModelTest.kt
@@ -37,6 +37,7 @@ import org.robolectric.Shadows.shadowOf
 import java.io.File
 import java.io.IOException
 import kotlin.collections.HashSet
+import kotlin.test.assertIs
 
 @RunWith(AndroidJUnit4::class)
 class AddonModelTest : RobolectricTest() {
@@ -62,13 +63,11 @@ class AddonModelTest : RobolectricTest() {
     @Test
     @Throws(IOException::class)
     fun isValidAnkiDroidAddonTest() {
-        // test addon is valid or not, for valid addon the result string will be empty
-        val result: Pair<AddonModel?, List<String>> = getAddonModelFromJson(validNpmPackageJson)
-        assertTrue(result.second.isEmpty())
-        assertTrue("package.json contains required fields", result.first != null)
+        // test addon is valid or not, for a valid addon the result is Valid
+        val result = getAddonModelFromJson(validNpmPackageJson)
+        val addon = assertIs<AddonValidationResult.Valid>(result, "package.json contains required fields").addonModel
 
         // needs to test these fields
-        val addon = result.first!!
         assertEquals(addon.name, "valid-ankidroid-js-addon-test")
         assertEquals(addon.addonTitle, "Valid AnkiDroid JS Addon")
         assertEquals(addon.version, "1.0.0")
@@ -83,12 +82,12 @@ class AddonModelTest : RobolectricTest() {
     @Test
     @Throws(IOException::class)
     fun notValidAnkiDroidAddonTest() {
-        // test addon is valid or not, for not valid addon the result string will not be empty
-        val result: Pair<AddonModel?, List<String>> = getAddonModelFromJson(notValidNpmPackageJson)
-        // assert that addon model is null i.e. the package.json not mapped to addon model
-        assertTrue("package.json not contains required fields", result.first == null)
+        // test addon is valid or not, for a not valid addon the result is Invalid
+        val result = getAddonModelFromJson(notValidNpmPackageJson)
+        // assert that the package.json was not mapped to an addon model
+        val errors = assertIs<AddonValidationResult.Invalid>(result, "package.json not contains required fields").errors
         // assert that error list contains error when the package.json not mapped to AddonModel
-        assertFalse(result.second.isEmpty())
+        assertFalse(errors.isEmpty())
     }
 
     @Test
@@ -99,8 +98,8 @@ class AddonModelTest : RobolectricTest() {
         var reviewerEnabledAddonSet = prefs.getStringSet(REVIEWER_ADDON, HashSet())
         assertEquals(0, reviewerEnabledAddonSet?.size)
 
-        val result: Pair<AddonModel?, List<String>> = getAddonModelFromJson(validNpmPackageJson)
-        val addonModel = result.first!!
+        val result = getAddonModelFromJson(validNpmPackageJson)
+        val addonModel = assertIs<AddonValidationResult.Valid>(result).addonModel
 
         // update the prefs make it enabled
         addonModel.updatePrefs(prefs, REVIEWER_ADDON, false)
@@ -172,22 +171,22 @@ class AddonModelTest : RobolectricTest() {
     @Test // the validator must report errors, never throw
     fun missingNameReturnsErrorTest() {
         val result = getAddonModelFromAddonData(addonData(name = null))
-        assertTrue("model is not built from an invalid manifest", result.first == null)
-        assertFalse("missing 'name' is reported as an error", result.second.isEmpty())
+        val errors = assertIs<AddonValidationResult.Invalid>(result, "model is not built from an invalid manifest").errors
+        assertFalse("missing 'name' is reported as an error", errors.isEmpty())
     }
 
     @Test // the validator must report errors, never throw
     fun missingKeywordsReturnsErrorTest() {
         val result = getAddonModelFromAddonData(addonData(keywords = null))
-        assertTrue("model is not built from an invalid manifest", result.first == null)
-        assertFalse("missing 'keywords' is reported as an error", result.second.isEmpty())
+        val errors = assertIs<AddonValidationResult.Invalid>(result, "model is not built from an invalid manifest").errors
+        assertFalse("missing 'keywords' is reported as an error", errors.isEmpty())
     }
 
-    @Test // 'version' is force-unwrapped during model construction, so it must be validated
+    @Test // 'version' is required during model construction, so it must be validated
     fun missingVersionReturnsErrorTest() {
         val result = getAddonModelFromAddonData(addonData(version = null))
-        assertTrue("model is not built from an invalid manifest", result.first == null)
-        assertFalse("missing 'version' is reported as an error", result.second.isEmpty())
+        val errors = assertIs<AddonValidationResult.Invalid>(result, "model is not built from an invalid manifest").errors
+        assertFalse("missing 'version' is reported as an error", errors.isEmpty())
     }
 
     @Test
@@ -195,16 +194,14 @@ class AddonModelTest : RobolectricTest() {
         // 'dist' is metadata added by the npm registry API; the package.json inside a
         // tarball does not contain it, so a locally installed addon must still validate
         val result = getAddonModelFromAddonData(addonData(dist = null))
-        assertTrue("no errors for a manifest without 'dist': ${result.second}", result.second.isEmpty())
-        assertTrue("model is built from a manifest without 'dist'", result.first != null)
+        assertIs<AddonValidationResult.Valid>(result, "model is built from a manifest without 'dist'")
     }
 
     @Test
     fun missingOptionalMetadataIsValidTest() {
         // description/author/license are commonly absent from real package.json files
         val result = getAddonModelFromAddonData(addonData(description = null, author = null, license = null))
-        assertTrue("no errors for a manifest without optional metadata: ${result.second}", result.second.isEmpty())
-        val addon = result.first!!
+        val addon = assertIs<AddonValidationResult.Valid>(result, "model is built from a manifest without optional metadata").addonModel
         assertEquals("", addon.description)
         assertEquals(emptyMap<String, String>(), addon.author)
         assertEquals("", addon.license)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/AddonModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/AddonModelTest.kt
@@ -16,27 +16,21 @@
 
 package com.ichi2.anki.jsaddons
 
-import android.content.SharedPreferences
-import android.os.Looper.getMainLooper
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.AnkiDroidJsAPIConstants.CURRENT_JS_API_VERSION
 import com.ichi2.anki.RobolectricTest
-import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.jsaddons.AddonsConst.ANKIDROID_JS_ADDON_KEYWORDS
 import com.ichi2.anki.jsaddons.AddonsConst.REVIEWER_ADDON
 import com.ichi2.utils.FileOperation
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
-import junit.framework.TestCase.assertTrue
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.StringEndsWith.endsWith
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.Shadows.shadowOf
 import java.io.File
 import java.io.IOException
-import kotlin.collections.HashSet
 import kotlin.test.assertIs
 
 @RunWith(AndroidJUnit4::class)
@@ -44,12 +38,6 @@ class AddonModelTest : RobolectricTest() {
     private lateinit var validNpmPackageJson: String
     private lateinit var notValidNpmPackageJson: String
     private lateinit var addonsPackageListTestJson: String
-    private lateinit var prefs: SharedPreferences
-
-    @Before
-    fun before() {
-        prefs = targetContext.sharedPrefs()
-    }
 
     @Before
     override fun setUp() {
@@ -88,34 +76,6 @@ class AddonModelTest : RobolectricTest() {
         val errors = assertIs<AddonValidationResult.Invalid>(result, "package.json not contains required fields").errors
         // assert that error list contains error when the package.json not mapped to AddonModel
         assertFalse(errors.isEmpty())
-    }
-
-    @Test
-    fun updatePrefsTest() {
-        shadowOf(getMainLooper()).idle()
-
-        // test that prefs hashset for reviewer is empty
-        var reviewerEnabledAddonSet = prefs.getStringSet(REVIEWER_ADDON, HashSet())
-        assertEquals(0, reviewerEnabledAddonSet?.size)
-
-        val result = getAddonModelFromJson(validNpmPackageJson)
-        val addonModel = assertIs<AddonValidationResult.Valid>(result).addonModel
-
-        // update the prefs make it enabled
-        addonModel.updatePrefs(prefs, REVIEWER_ADDON, false)
-
-        // test that new prefs added and size is 1 and the prefs hashset contains enabled addons name
-        reviewerEnabledAddonSet = prefs.getStringSet(REVIEWER_ADDON, HashSet())
-        assertEquals(1, reviewerEnabledAddonSet?.size)
-        assertTrue(reviewerEnabledAddonSet!!.contains(addonModel.name))
-
-        // now remove the addons from prefs
-        addonModel.updatePrefs(prefs, REVIEWER_ADDON, true)
-
-        // prefs hashset size for reviewer should be zero and prefs will not have addon name
-        reviewerEnabledAddonSet = prefs.getStringSet(REVIEWER_ADDON, HashSet())
-        assertEquals(0, reviewerEnabledAddonSet?.size)
-        assertFalse(reviewerEnabledAddonSet!!.contains(addonModel.name))
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/AddonModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/AddonModelTest.kt
@@ -35,16 +35,16 @@ import kotlin.test.assertIs
 
 @RunWith(AndroidJUnit4::class)
 class AddonModelTest : RobolectricTest() {
-    private lateinit var validNpmPackageJson: String
-    private lateinit var notValidNpmPackageJson: String
+    private lateinit var validNpmPackageJson: File
+    private lateinit var notValidNpmPackageJson: File
     private lateinit var addonsPackageListTestJson: String
 
     @Before
     override fun setUp() {
         super.setUp()
 
-        validNpmPackageJson = FileOperation.getFileResource("valid-ankidroid-js-addon-test.json")
-        notValidNpmPackageJson = FileOperation.getFileResource("not-valid-ankidroid-js-addon-test.json")
+        validNpmPackageJson = File(FileOperation.getFileResource("valid-ankidroid-js-addon-test.json"))
+        notValidNpmPackageJson = File(FileOperation.getFileResource("not-valid-ankidroid-js-addon-test.json"))
         addonsPackageListTestJson = FileOperation.getFileResource("test-js-addon.json")
     }
 
@@ -76,6 +76,15 @@ class AddonModelTest : RobolectricTest() {
         val errors = assertIs<AddonValidationResult.Invalid>(result, "package.json not contains required fields").errors
         // assert that error list contains error when the package.json not mapped to AddonModel
         assertFalse(errors.isEmpty())
+    }
+
+    @Test
+    fun unreadableManifestReturnsErrorTest() {
+        // a missing/unreadable package.json must be reported as Invalid, not thrown:
+        // one corrupt addon directory must not abort listing the other addons
+        val result = getAddonModelFromJson(File("/does/not/exist/package.json"))
+        val errors = assertIs<AddonValidationResult.Invalid>(result, "model is not built from an unreadable manifest").errors
+        assertFalse("unreadable manifest is reported as an error", errors.isEmpty())
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
@@ -32,6 +32,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.File
 import java.io.IOException
+import kotlin.test.assertFailsWith
 
 @RunWith(AndroidJUnit4::class)
 class TgzPackageExtractTest : RobolectricTest() {
@@ -135,6 +136,21 @@ class TgzPackageExtractTest : RobolectricTest() {
         // test if package.json extracted successfully
         val packageJsonPath = File(packagePath, "package.json")
         assertThat(packageJsonPath, anExistingFile())
+    }
+
+    /**
+     * Test that failure to create the addon directory is reported to the caller
+     * instead of being silently swallowed
+     */
+    @Test
+    fun extractionFailureIsReportedTest() {
+        // a regular file where the addon directory should go: directory creation must fail
+        val blocker = File(addonDir, "blocker").also { it.writeText("") }
+        val addonsPackageDir = File(blocker, "some-addon")
+
+        assertFailsWith<IOException> {
+            addonPackage.extractTarGzipToAddonFolder(File(tarballPath), addonsPackageDir)
+        }
     }
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
@@ -21,6 +21,8 @@ import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.testutils.ShadowStatFs
 import com.ichi2.utils.FileOperation.Companion.getFileResource
+import io.mockk.every
+import io.mockk.spyk
 import junit.framework.TestCase.assertTrue
 import org.apache.commons.compress.archivers.ArchiveException
 import org.hamcrest.MatcherAssert.assertThat
@@ -150,6 +152,20 @@ class TgzPackageExtractTest : RobolectricTest() {
 
         assertFailsWith<IOException> {
             addonPackage.extractTarGzipToAddonFolder(File(tarballPath), addonsPackageDir)
+        }
+    }
+
+    /**
+     * Test that a failed extraction is reported to the caller
+     * instead of completing as if it had succeeded
+     */
+    @Test
+    fun unTarFailureIsReportedTest() {
+        val failingExtract = spyk(addonPackage)
+        every { failingExtract.unTar(any(), any()) } throws IOException("simulated failure")
+
+        assertFailsWith<IOException> {
+            failingExtract.extractTarGzipToAddonFolder(File(tarballPath), addonDir)
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
@@ -25,6 +25,7 @@ import io.mockk.every
 import io.mockk.spyk
 import junit.framework.TestCase.assertTrue
 import org.apache.commons.compress.archivers.ArchiveException
+import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.io.FileMatchers.anExistingDirectory
 import org.hamcrest.io.FileMatchers.anExistingFile
@@ -167,6 +168,24 @@ class TgzPackageExtractTest : RobolectricTest() {
         assertFailsWith<IOException> {
             failingExtract.extractTarGzipToAddonFolder(File(tarballPath), addonDir)
         }
+    }
+
+    @Test
+    fun failedExtractionCleansUpPartialAddonTest() {
+        // an addon package dir inside the addons dir, as production lays it out
+        val addonsPackageDir = File(addonDir, "some-addon")
+
+        val failingExtract = spyk(addonPackage)
+        every { failingExtract.unTar(any(), any()) } answers {
+            // simulate a partial extraction before the failure
+            File(addonsPackageDir, "partial.js").writeText("")
+            throw IOException("simulated failure")
+        }
+
+        assertFailsWith<IOException> {
+            failingExtract.extractTarGzipToAddonFolder(File(tarballPath), addonsPackageDir)
+        }
+        assertThat(addonsPackageDir, not(anExistingDirectory()))
     }
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
@@ -19,6 +19,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.File
 import java.io.IOException
+import kotlin.test.assertFailsWith
 
 @RunWith(AndroidJUnit4::class)
 class TgzPackageExtractTest : RobolectricTest() {
@@ -122,6 +123,21 @@ class TgzPackageExtractTest : RobolectricTest() {
         // test if package.json extracted successfully
         val packageJsonPath = File(packagePath, "package.json")
         assertThat(packageJsonPath, anExistingFile())
+    }
+
+    /**
+     * Test that failure to create the addon directory is reported to the caller
+     * instead of being silently swallowed
+     */
+    @Test
+    fun extractionFailureIsReportedTest() {
+        // a regular file where the addon directory should go: directory creation must fail
+        val blocker = File(addonDir, "blocker").also { it.writeText("") }
+        val addonsPackageDir = File(blocker, "some-addon")
+
+        assertFailsWith<IOException> {
+            addonPackage.extractTarGzipToAddonFolder(File(tarballPath), addonsPackageDir)
+        }
     }
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
@@ -12,6 +12,7 @@ import io.mockk.every
 import io.mockk.spyk
 import junit.framework.TestCase.assertTrue
 import org.apache.commons.compress.archivers.ArchiveException
+import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.io.FileMatchers.anExistingDirectory
 import org.hamcrest.io.FileMatchers.anExistingFile
@@ -154,6 +155,24 @@ class TgzPackageExtractTest : RobolectricTest() {
         assertFailsWith<IOException> {
             failingExtract.extractTarGzipToAddonFolder(File(tarballPath), addonDir)
         }
+    }
+
+    @Test
+    fun failedExtractionCleansUpPartialAddonTest() {
+        // an addon package dir inside the addons dir, as production lays it out
+        val addonsPackageDir = File(addonDir, "some-addon")
+
+        val failingExtract = spyk(addonPackage)
+        every { failingExtract.unTar(any(), any()) } answers {
+            // simulate a partial extraction before the failure
+            File(addonsPackageDir, "partial.js").writeText("")
+            throw IOException("simulated failure")
+        }
+
+        assertFailsWith<IOException> {
+            failingExtract.extractTarGzipToAddonFolder(File(tarballPath), addonsPackageDir)
+        }
+        assertThat(addonsPackageDir, not(anExistingDirectory()))
     }
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
@@ -8,6 +8,8 @@ import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.testutils.ShadowStatFs
 import com.ichi2.utils.FileOperation.Companion.getFileResource
+import io.mockk.every
+import io.mockk.spyk
 import junit.framework.TestCase.assertTrue
 import org.apache.commons.compress.archivers.ArchiveException
 import org.hamcrest.MatcherAssert.assertThat
@@ -137,6 +139,20 @@ class TgzPackageExtractTest : RobolectricTest() {
 
         assertFailsWith<IOException> {
             addonPackage.extractTarGzipToAddonFolder(File(tarballPath), addonsPackageDir)
+        }
+    }
+
+    /**
+     * Test that a failed extraction is reported to the caller
+     * instead of completing as if it had succeeded
+     */
+    @Test
+    fun unTarFailureIsReportedTest() {
+        val failingExtract = spyk(addonPackage)
+        every { failingExtract.unTar(any(), any()) } throws IOException("simulated failure")
+
+        assertFailsWith<IOException> {
+            failingExtract.extractTarGzipToAddonFolder(File(tarballPath), addonDir)
         }
     }
 


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

## Purpose / Description
* A number of addon validation mechanisms were inconsistent: throwing rather than returning.
* We are now in Kotlin, so a sealed class makes sense
* I want to move to a model where a state store defines each addon, so the individual keys for shared preferences are removed

## How Has This Been Tested?
Test-only

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)