### PR TITLE
feat: no longer implicitly set collection path when DB is used

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -533,6 +533,13 @@ open class AnkiDroidApp :
          */
         fun sharedPrefs() = sharedPreferencesTestingOverride ?: instance.sharedPrefs()
 
+        /**
+         * [sharedPrefs], or `null` if unavailable: [instance] is not initialized when running
+         * under a test-only [Application] (e.g. `EmptyApplication`) or in pure JVM tests
+         */
+        fun sharedPrefsOrNull(): SharedPreferences? =
+            sharedPreferencesTestingOverride ?: if (isInitialized) instance.sharedPrefs() else null
+
         /** HACK: Whether an exception report has been thrown - TODO: Rewrite an ACRA Listener to do this  */
         @VisibleForTesting
         var sentExceptionReportHack = false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -57,6 +57,7 @@ import com.ichi2.anki.services.AlarmManagerService
 import com.ichi2.anki.services.NotificationService
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.settings.PrefsRepository
+import com.ichi2.anki.startup.ensureCollectionPathSet
 import com.ichi2.anki.startup.getDefaultAnkiDroidDirectory
 import com.ichi2.anki.ui.dialogs.ActivityAgnosticDialogs
 import com.ichi2.utils.ExceptionUtil
@@ -258,6 +259,7 @@ open class AnkiDroidApp :
             //  is not considered to be a fatal error, unless the directory itself is not writable.
             val ankiDroidDir =
                 try {
+                    ensureCollectionPathSet(this)
                     CollectionHelper.getCurrentAnkiDroidDirectory(this)
                 } catch (e: SystemStorageException) {
                     fatalInitializationError = FatalInitializationError.StorageError(e)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -139,13 +139,28 @@ object CollectionHelper {
     var systemStorageFailure: SystemStorageException? = null
 
     /**
-     * Whether the user has chosen where the collection is stored.
+     * Whether the location of the collection has been decided: [StorageDecision.Decided] once
+     * [PREF_COLLECTION_PATH] is set (or a [ankiDroidDirectoryOverride] is active), which mirrors
+     * when [getCurrentAnkiDroidDirectory] can return a directory rather than throwing.
      *
-     * TODO: real implementation based on whether [PREF_COLLECTION_PATH] is set.
-     *  TODO: What is a user revokes full storage?
-     *  This currently returns [StorageDecision.Decided], so callers that gate on it are no-ops.
+     * The user is not asked yet: until the dedicated setup flow exists (#19552), the 'decision'
+     * is made on their behalf during startup by
+     * [ensureCollectionPathSet][com.ichi2.anki.startup.ensureCollectionPathSet], so this is
+     * [StorageDecision.Decided] by the time the collection is opened.
+     *
+     * @param preferences the preferences the collection path will be read from: pass the same
+     * (profile) context's preferences as the [getCurrentAnkiDroidDirectory] call being gated
+     *
+     * TODO: What if a user revokes full storage?
      */
-    fun storageDecision(): StorageDecision = storageDecisionTestOverride ?: StorageDecision.Decided
+    fun storageDecision(preferences: SharedPreferences): StorageDecision {
+        storageDecisionTestOverride?.let { return it }
+        if (ankiDroidDirectoryOverride != null) return StorageDecision.Decided
+        // a recorded systemStorageFailure also leaves the path unset: startup has already
+        // surfaced it via AnkiDroidApp.fatalError, and reads rethrow it rather than
+        // reporting 'not configured'
+        return if (preferences.contains(PREF_COLLECTION_PATH)) StorageDecision.Decided else StorageDecision.Undecided
+    }
 
     /**
      * @return the absolute path to the AnkiDroid directory.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -11,12 +11,11 @@ import com.ichi2.anki.CollectionHelper.getCurrentAnkiDroidDirectory
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.utils.android.isInstrumentationTest
 import com.ichi2.anki.exception.StorageAccessException
+import com.ichi2.anki.exception.StorageNotConfiguredException
 import com.ichi2.anki.exception.SystemStorageException
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.CollectionFiles
-import com.ichi2.anki.startup.getDefaultAnkiDroidDirectory
 import com.ichi2.anki.storage.StorageDecision
-import com.ichi2.preferences.getOrSetString
 import timber.log.Timber
 import java.io.File
 import java.io.IOException
@@ -81,7 +80,8 @@ object CollectionHelper {
 
     /**
      * Try to access the current AnkiDroid directory
-     * @return whether or not dir is accessible
+     * @return whether or not dir is accessible: `false` if inaccessible, not yet configured,
+     * or the system could not provide a storage location
      * @param context to get directory with
      */
     fun isCurrentAnkiDroidDirAccessible(context: Context): Boolean =
@@ -89,6 +89,12 @@ object CollectionHelper {
             initializeAnkiDroidDirectory(getCurrentAnkiDroidDirectory(context))
             true
         } catch (e: StorageAccessException) {
+            Timber.w(e)
+            false
+        } catch (e: StorageNotConfiguredException) {
+            Timber.w(e)
+            false
+        } catch (e: SystemStorageException) {
             Timber.w(e)
             false
         }
@@ -122,6 +128,17 @@ object CollectionHelper {
     var ankiDroidDirectoryOverride: File? = null
 
     /**
+     * Set when startup failed to choose a default collection path because Android could not
+     * provide a storage location ([SystemStorageException]: OS bug/SD card issue).
+     *
+     * Reads of an unset collection path rethrow this instead of [StorageNotConfiguredException],
+     * so the storage failure is not mistaken for the expected 'no collection path set' state.
+     */
+    // TODO: #19552 - consolidate with AnkiDroidApp.fatalError and StorageDecision (a dedicated
+    //  'storage unavailable' state) once the storage setup flow exists
+    var systemStorageFailure: SystemStorageException? = null
+
+    /**
      * Whether the user has chosen where the collection is stored.
      *
      * TODO: real implementation based on whether [PREF_COLLECTION_PATH] is set.
@@ -133,10 +150,13 @@ object CollectionHelper {
     /**
      * @return the absolute path to the AnkiDroid directory.
      *
-     * @throws SystemStorageException if `getExternalFilesDir` returns null
+     * @throws StorageNotConfiguredException if no collection path has been set
+     * ([PREF_COLLECTION_PATH] is unset): a default is chosen during startup by
+     * [ensureCollectionPathSet][com.ichi2.anki.startup.ensureCollectionPathSet]
+     * @throws SystemStorageException if startup failed to choose a default collection path
+     * ([systemStorageFailure])
      */
-    fun getCurrentAnkiDroidDirectory(context: Context): File =
-        getCurrentAnkiDroidDirectoryOptionalContext(context.sharedPrefs()) { context }
+    fun getCurrentAnkiDroidDirectory(context: Context): File = getCurrentAnkiDroidDirectory(context.sharedPrefs())
 
     fun getCollectionPaths(context: Context): CollectionFiles = CollectionFiles.FolderBasedCollection(getCurrentAnkiDroidDirectory(context))
 
@@ -144,38 +164,32 @@ object CollectionHelper {
     fun getMediaDirectory(context: Context) = getCollectionPaths(context).requireMediaFolder()
 
     /**
-     * An accessor which makes [Context] optional in the case that [PREF_COLLECTION_PATH] is set
-     *
      * @return the absolute path to the AnkiDroid directory.
+     *
+     * @throws StorageNotConfiguredException if no collection path has been set
+     * ([PREF_COLLECTION_PATH] is unset): a default is chosen during startup by
+     * [ensureCollectionPathSet][com.ichi2.anki.startup.ensureCollectionPathSet]
+     * @throws SystemStorageException if startup failed to choose a default collection path
+     * ([systemStorageFailure])
      */
-    // This uses a lambda as we typically depends on the `lateinit` appContext
-    // If we remove all Android references, we get a significant unit test speedup
-    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    internal fun getCurrentAnkiDroidDirectoryOptionalContext(
-        preferences: SharedPreferences,
-        context: () -> Context,
-    ): File =
-        if (isInstrumentationTest) {
+    fun getCurrentAnkiDroidDirectory(preferences: SharedPreferences): File {
+        val collectionDirectory = preferences.getString(PREF_COLLECTION_PATH, null)
+        return if (isInstrumentationTest) {
             // create an "androidTest" directory inside the current collection directory which contains the test data
             // "/AnkiDroid/androidTest" would be a new collection path
-            val currentCollectionDirectory =
-                preferences.getOrSetString(PREF_COLLECTION_PATH) {
-                    getDefaultAnkiDroidDirectory(context()).absolutePath
-                }
-            File(
-                currentCollectionDirectory,
-                "androidTest",
-            )
+            File(collectionDirectory ?: throw collectionPathUnset(), "androidTest")
         } else {
             ankiDroidDirectoryOverride
-                ?: File(
-                    preferences.getOrSetString(PREF_COLLECTION_PATH) {
-                        getDefaultAnkiDroidDirectory(
-                            context(),
-                        ).absolutePath
-                    },
-                )
+                ?: File(collectionDirectory ?: throw collectionPathUnset())
         }
+    }
+
+    /**
+     * The collection path is unset: either the expected pre-setup state
+     * ([StorageNotConfiguredException]) or startup failed to choose a default and the recorded
+     * [SystemStorageException] is rethrown.
+     */
+    private fun collectionPathUnset(): Exception = systemStorageFailure ?: StorageNotConfiguredException()
 
     /** Test-only override for [storageDecision]. @see ankiDroidDirectoryOverride */
     @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
@@ -18,10 +18,10 @@ import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.CollectionManager.withOpenColOrNull
 import com.ichi2.anki.CollectionManager.withQueue
 import com.ichi2.anki.backend.createDatabaseUsingRustBackend
-import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.utils.android.Threads
 import com.ichi2.anki.common.utils.android.isRobolectric
 import com.ichi2.anki.exception.StorageNotConfiguredException
+import com.ichi2.anki.exception.SystemStorageException
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.CollectionFiles
 import com.ichi2.anki.libanki.LibAnki
@@ -130,6 +130,8 @@ object CollectionManager {
      *
      * @throws StorageNotConfiguredException If [CollectionHelper.storageDecision] is undecided
      * (user has not selected a storage location).
+     * @throws SystemStorageException if startup failed to choose a default collection path
+     * ([CollectionHelper.systemStorageFailure])
      */
     suspend fun <T> withCol(
         @WorkerThread block: Collection.() -> T,
@@ -254,6 +256,8 @@ object CollectionManager {
      *
      * @throws StorageNotConfiguredException If [CollectionHelper.storageDecision] is undecided
      * (user has not selected a storage location).
+     * @throws SystemStorageException if startup failed to choose a default collection path
+     * ([CollectionHelper.systemStorageFailure])
      */
     suspend fun ensureOpen() {
         withQueue {
@@ -266,9 +270,15 @@ object CollectionManager {
      *
      * @throws StorageNotConfiguredException If [CollectionHelper.storageDecision] is not
      * [StorageDecision.Decided] (user has not selected a storage location).
+     * @throws SystemStorageException if startup failed to choose a default collection path
+     * ([CollectionHelper.systemStorageFailure])
      */
     private fun ensureOpenInner() {
-        if (CollectionHelper.storageDecision() != StorageDecision.Decided) throw StorageNotConfiguredException()
+        if (CollectionHelper.storageDecision() != StorageDecision.Decided) {
+            // rethrow a recorded startup storage failure: an OS bug/SD card issue must not be
+            // reported as the expected 'storage not configured' state
+            throw CollectionHelper.systemStorageFailure ?: StorageNotConfiguredException()
+        }
         ensureBackendInner()
         emulatedOpenFailure?.triggerFailure()
         if (collection == null || collection!!.dbClosed) {
@@ -290,8 +300,8 @@ object CollectionManager {
     }
 
     fun getCollectionDirectory() =
-        // Allow execution if appContext is not initialized
-        CollectionHelper.getCurrentAnkiDroidDirectoryOptionalContext(AnkiDroidApp.sharedPrefs()) { appContext }
+        // does not require appContext to be initialized
+        CollectionHelper.getCurrentAnkiDroidDirectory(AnkiDroidApp.sharedPrefs())
 
     /** Ensures the AnkiDroid directory is created, then returns the path to the
      * folder and the name of the collection file inside it. */
@@ -330,6 +340,8 @@ object CollectionManager {
      *
      * @throws StorageNotConfiguredException If [CollectionHelper.storageDecision] is undecided
      * (user has not selected a storage location).
+     * @throws SystemStorageException if startup failed to choose a default collection path
+     * ([CollectionHelper.systemStorageFailure])
      */
     fun getColUnsafe(): Collection =
         logUIHangs {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
@@ -20,6 +20,7 @@ import com.ichi2.anki.CollectionManager.withQueue
 import com.ichi2.anki.backend.createDatabaseUsingRustBackend
 import com.ichi2.anki.common.utils.android.Threads
 import com.ichi2.anki.common.utils.android.isRobolectric
+import com.ichi2.anki.common.utils.isRunningAsUnitTest
 import com.ichi2.anki.exception.StorageNotConfiguredException
 import com.ichi2.anki.exception.SystemStorageException
 import com.ichi2.anki.libanki.Collection
@@ -272,9 +273,21 @@ object CollectionManager {
      * [StorageDecision.Decided] (user has not selected a storage location).
      * @throws SystemStorageException if startup failed to choose a default collection path
      * ([CollectionHelper.systemStorageFailure])
+     * @throws IllegalStateException if executed before `AnkiDroidApp.onCreate`
      */
     private fun ensureOpenInner() {
-        if (CollectionHelper.storageDecision() != StorageDecision.Decided) {
+        // the decision is gated on the same preferences getCollectionDirectory() reads from
+        val decision =
+            CollectionHelper.storageDecisionTestOverride
+                ?: AnkiDroidApp.sharedPrefsOrNull()?.let { CollectionHelper.storageDecision(it) }
+                // test-only: in-memory test collections have no preferences and read no path
+                ?: if (isRunningAsUnitTest) {
+                    StorageDecision.Decided
+                } else {
+                    // the app instance is unset: treat this as a bug.
+                    throw IllegalStateException("Collection accessed before AnkiDroidApp was initialized")
+                }
+        if (decision != StorageDecision.Decided) {
             // rethrow a recorded startup storage failure: an OS bug/SD card issue must not be
             // reported as the expected 'storage not configured' state
             throw CollectionHelper.systemStorageFailure ?: StorageNotConfiguredException()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1002,6 +1002,9 @@ open class DeckPicker :
                 override val requiredPermissions: PermissionSet
                     get() = permissions
 
+                override val preferences: SharedPreferences
+                    get() = context.sharedPrefs()
+
                 override fun initializeAnkiDroidFolder(): Boolean = CollectionHelper.isCurrentAnkiDroidDirAccessible(context)
             }
 
@@ -1035,9 +1038,16 @@ open class DeckPicker :
             is DiskFull -> displayNoStorageError()
             is DBError -> displayDatabaseFailure(CustomExceptionData.fromException(failure.exception))
             is StorageUndecided -> {
-                Timber.i("Displaying storage setup required")
-                // unreachable: storageDecision() cannot yet return Undecided outside tests
-                TODO("#19552 - replace with the storage setup flow.")
+                // unreachable: Undecided requires PREF_COLLECTION_PATH to be unset, which only
+                // happens if ensureCollectionPathSet failed at startup; getStartupFailureType
+                // then returns InitializationError (fatalError) before checking the decision
+                // TODO: #19552 - replace with the storage setup flow
+                Timber.w("storage setup flow (#19552) not implemented; showing load-failure options")
+                CrashReportService.sendExceptionReport(
+                    IllegalStateException("StorageUndecided reached without a startup failure"),
+                    "DeckPicker::handleStartupFailure",
+                )
+                showDatabaseErrorDialog(DatabaseErrorDialogType.DIALOG_LOAD_FAILED)
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -30,6 +30,7 @@ import androidx.core.content.edit
 import com.ichi2.anki.backend.DatabaseCorruption
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.permissions.hasAllPermissions
+import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.utils.android.SdCard
 import com.ichi2.anki.compat.CompatHelper.Companion.sdkVersion
 import com.ichi2.anki.exception.StorageAccessException
@@ -53,18 +54,21 @@ import timber.log.Timber
 object InitialActivity {
     @CheckResult
     fun getStartupFailureType(context: Context): StartupFailure? =
-        getStartupFailureType { CollectionHelper.isCurrentAnkiDroidDirAccessible(context) }
+        getStartupFailureType(context.sharedPrefs()) { CollectionHelper.isCurrentAnkiDroidDirAccessible(context) }
 
     /** Returns null on success  */
     @CheckResult
-    fun getStartupFailureType(initializeAnkiDroidDirectory: () -> Boolean): StartupFailure? {
+    fun getStartupFailureType(
+        preferences: SharedPreferences,
+        initializeAnkiDroidDirectory: () -> Boolean,
+    ): StartupFailure? {
         AnkiDroidApp.fatalError?.let {
             return StartupFailure.InitializationError(it)
         }
 
         // Opening the collection would throw a StorageNotConfiguredException, which is not worth
         // a crash report
-        if (CollectionHelper.storageDecision() != StorageDecision.Decided) {
+        if (CollectionHelper.storageDecision(preferences) != StorageDecision.Decided) {
             Timber.i("storage location is undecided")
             return StartupFailure.StorageUndecided
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -18,6 +18,7 @@ import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.permissions.hasLegacyStorageAccessPermission
 import com.ichi2.anki.common.permissions.isExternalStorageManagerCompat
+import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.utils.android.showThemedToast
 import com.ichi2.anki.common.utils.trimToLength
 import com.ichi2.anki.dialogs.DialogHandler.Companion.storeMessage
@@ -134,7 +135,7 @@ class IntentHandler : AbstractIntentHandler() {
         action: String?,
         block: () -> Unit,
     ) {
-        if (CollectionHelper.storageDecision() != StorageDecision.Decided) {
+        if (CollectionHelper.storageDecision(sharedPrefs()) != StorageDecision.Decided) {
             // checked before permissions: the permissions required depend on the chosen folder
             Timber.i("Storage is not configured, cancelling intent '%s'", action)
             launchDeckPickerIfNoOtherTasks(reloadIntent)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -522,7 +522,7 @@ class DeckPickerViewModel :
         }
 
         Timber.d("handleStartup: Continuing after permission granted")
-        val failure = InitialActivity.getStartupFailureType(environment::initializeAnkiDroidFolder)
+        val failure = InitialActivity.getStartupFailureType(environment.preferences, environment::initializeAnkiDroidFolder)
         if (failure != null) {
             flowOfStartupResponse.value = StartupResponse.FatalError(failure)
             return
@@ -539,6 +539,9 @@ class DeckPickerViewModel :
         fun hasRequiredPermissions(): Boolean
 
         val requiredPermissions: PermissionSet
+
+        /** The preferences of the (profile) context the collection path is read from */
+        val preferences: SharedPreferences
 
         fun initializeAnkiDroidFolder(): Boolean
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/startup/SetupStorage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/startup/SetupStorage.kt
@@ -8,11 +8,38 @@ import androidx.annotation.CheckResult
 import androidx.core.content.edit
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.exception.StorageNotConfiguredException
 import com.ichi2.anki.exception.SystemStorageException
 import com.ichi2.anki.selectAnkiDroidFolder
 import com.ichi2.anki.storage.AnkiDroidFolder
 import timber.log.Timber
 import java.io.File
+
+/**
+ * Ensures [CollectionHelper.PREF_COLLECTION_PATH] is set, choosing and persisting
+ * [getDefaultAnkiDroidDirectory] if it is unset.
+ *
+ * This decides the storage location on the user's behalf: until a storage setup flow exists
+ * (#19552), the user is not asked.
+ *
+ * @throws SystemStorageException if `getExternalFilesDir` returns null. The failure is recorded
+ * in [CollectionHelper.systemStorageFailure] so reads report it rather than
+ * [StorageNotConfiguredException]
+ */
+fun ensureCollectionPathSet(context: Context) {
+    val preferences = context.sharedPrefs()
+    if (preferences.contains(CollectionHelper.PREF_COLLECTION_PATH)) return
+    val defaultPath =
+        try {
+            getDefaultAnkiDroidDirectory(context).absolutePath
+        } catch (e: SystemStorageException) {
+            CollectionHelper.systemStorageFailure = e
+            throw e
+        }
+    Timber.i("collection path set to default")
+    Timber.d("default collection path: %s", defaultPath)
+    preferences.edit { putString(CollectionHelper.PREF_COLLECTION_PATH, defaultPath) }
+}
 
 /**
  * Get the absolute path to a directory that is suitable to be the default starting location

--- a/AnkiDroid/src/main/java/com/ichi2/anki/startup/StartupGuards.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/startup/StartupGuards.kt
@@ -6,6 +6,7 @@ import android.app.Activity
 import android.content.Intent
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.IntentHandler
+import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.exception.SystemStorageException
 import com.ichi2.anki.storage.StorageDecision
 import timber.log.Timber
@@ -45,7 +46,7 @@ fun Activity.ensureStorageIsReady(): Boolean {
  * @see redirectToMainEntryPoint
  */
 private fun Activity.ensureStorageIsConfigured(): Boolean {
-    if (CollectionHelper.storageDecision() == StorageDecision.Decided) {
+    if (CollectionHelper.storageDecision(sharedPrefs()) == StorageDecision.Decided) {
         return true
     }
     Timber.w("finishing activity. Storage is not configured")

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -254,6 +254,18 @@ class DeckPickerTest : RobolectricTest() {
         )
     }
 
+    /** Until the storage setup flow exists (#19552), the user gets recovery options, not a crash */
+    @Test
+    fun `storage undecided shows load-failure options rather than crashing`() {
+        // don't call .onCreate
+        val deckPicker = Robolectric.buildActivity(DeckPickerEx::class.java, Intent()).get()
+        deckPicker.handleStartupFailure(InitialActivity.StartupFailure.StorageUndecided)
+        assertThat(
+            deckPicker.databaseErrorDialog,
+            equalTo(DatabaseErrorDialogType.DIALOG_LOAD_FAILED),
+        )
+    }
+
     @Test
     fun databaseLockedWithPermissionIntegrationTest() {
         AnkiDroidApp.sentExceptionReportHack = false

--- a/AnkiDroid/src/test/java/com/ichi2/anki/StorageDecisionGateTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/StorageDecisionGateTest.kt
@@ -2,43 +2,69 @@
 
 package com.ichi2.anki
 
+import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.exception.StorageNotConfiguredException
 import com.ichi2.anki.exception.SystemStorageException
 import com.ichi2.anki.storage.StorageDecision
+import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertSame
 
 /**
- * Proves the storage-decision gate in [CollectionManager.ensureOpenInner] is wired up. In production
- * [CollectionHelper.storageDecision] always returns [com.ichi2.anki.storage.StorageDecision.Decided], so this never fires;
- * here we force [com.ichi2.anki.storage.StorageDecision.Undecided] via the test override.
+ * Proves the storage-decision gate in [CollectionManager.ensureOpenInner] is wired up.
+ * [CollectionHelper.storageDecision] is [StorageDecision.Decided] once a collection path has
+ * been set ([CollectionHelper.PREF_COLLECTION_PATH]); tests force
+ * [StorageDecision.Undecided] via the test override.
  */
 @RunWith(AndroidJUnit4::class)
 class StorageDecisionGateTest : RobolectricTest() {
+    private val prefs
+        get() = targetContext.sharedPrefs()
+
+    @After
+    fun resetOverrides() {
+        CollectionHelper.ankiDroidDirectoryOverride = null
+        CollectionHelper.storageDecisionTestOverride = null
+        CollectionHelper.systemStorageFailure = null
+    }
+
+    @Test
+    fun `storage decision is decided when the collection path is set`() {
+        prefs.edit { putString(CollectionHelper.PREF_COLLECTION_PATH, "/a/collection/path") }
+        assertEquals(StorageDecision.Decided, CollectionHelper.storageDecision(prefs))
+    }
+
+    @Test
+    fun `storage decision is undecided when the collection path is unset`() {
+        prefs.edit { remove(CollectionHelper.PREF_COLLECTION_PATH) }
+        assertEquals(StorageDecision.Undecided, CollectionHelper.storageDecision(prefs))
+    }
+
+    @Test
+    fun `storage decision is decided when a directory override is active`() {
+        prefs.edit { remove(CollectionHelper.PREF_COLLECTION_PATH) }
+        CollectionHelper.ankiDroidDirectoryOverride = File("/an/override")
+        assertEquals(StorageDecision.Decided, CollectionHelper.storageDecision(prefs))
+    }
+
     @Test
     fun `opening the collection throws when storage is undecided`() {
         CollectionHelper.storageDecisionTestOverride = StorageDecision.Undecided
-        try {
-            assertFailsWith<StorageNotConfiguredException> { CollectionManager.getColUnsafe() }
-        } finally {
-            CollectionHelper.storageDecisionTestOverride = null
-        }
+        assertFailsWith<StorageNotConfiguredException> { CollectionManager.getColUnsafe() }
     }
 
     /** No collection access should be attempted: a crash report would otherwise be generated */
     @Test
     fun `startup failure is StorageUndecided when storage is undecided`() {
         CollectionHelper.storageDecisionTestOverride = StorageDecision.Undecided
-        try {
-            val failure = InitialActivity.getStartupFailureType { true }
-            assertEquals(InitialActivity.StartupFailure.StorageUndecided, failure)
-        } finally {
-            CollectionHelper.storageDecisionTestOverride = null
-        }
+        val failure = InitialActivity.getStartupFailureType(prefs) { true }
+        assertEquals(InitialActivity.StartupFailure.StorageUndecided, failure)
     }
 
     /**
@@ -50,12 +76,8 @@ class StorageDecisionGateTest : RobolectricTest() {
         val failure = SystemStorageException.build("simulated getExternalFilesDir failure")
         CollectionHelper.storageDecisionTestOverride = StorageDecision.Undecided
         CollectionHelper.systemStorageFailure = failure
-        try {
-            val thrown = assertFailsWith<SystemStorageException> { CollectionManager.getColUnsafe() }
-            assertSame(failure, thrown)
-        } finally {
-            CollectionHelper.storageDecisionTestOverride = null
-            CollectionHelper.systemStorageFailure = null
-        }
+
+        val thrown = assertFailsWith<SystemStorageException> { CollectionManager.getColUnsafe() }
+        assertSame(failure, thrown)
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/StorageDecisionGateTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/StorageDecisionGateTest.kt
@@ -4,11 +4,13 @@ package com.ichi2.anki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.exception.StorageNotConfiguredException
+import com.ichi2.anki.exception.SystemStorageException
 import com.ichi2.anki.storage.StorageDecision
 import org.junit.Test
 import org.junit.runner.RunWith
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
 
 /**
  * Proves the storage-decision gate in [CollectionManager.ensureOpenInner] is wired up. In production
@@ -36,6 +38,24 @@ class StorageDecisionGateTest : RobolectricTest() {
             assertEquals(InitialActivity.StartupFailure.StorageUndecided, failure)
         } finally {
             CollectionHelper.storageDecisionTestOverride = null
+        }
+    }
+
+    /**
+     * A storage failure at startup ([SystemStorageException]: OS bug/SD card issue) must not
+     * masquerade as the expected 'storage not configured' state when opening the collection.
+     */
+    @Test
+    fun `opening the collection reports a recorded startup storage failure`() {
+        val failure = SystemStorageException.build("simulated getExternalFilesDir failure")
+        CollectionHelper.storageDecisionTestOverride = StorageDecision.Undecided
+        CollectionHelper.systemStorageFailure = failure
+        try {
+            val thrown = assertFailsWith<SystemStorageException> { CollectionManager.getColUnsafe() }
+            assertSame(failure, thrown)
+        } finally {
+            CollectionHelper.storageDecisionTestOverride = null
+            CollectionHelper.systemStorageFailure = null
         }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/startup/SetupStorageTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/startup/SetupStorageTest.kt
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.startup
+
+import androidx.core.content.edit
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.exception.StorageNotConfiguredException
+import com.ichi2.anki.exception.SystemStorageException
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+@RunWith(AndroidJUnit4::class)
+class SetupStorageTest : RobolectricTest() {
+    private val prefs
+        get() = targetContext.sharedPrefs()
+
+    private val collectionPath: String?
+        get() = prefs.getString(CollectionHelper.PREF_COLLECTION_PATH, null)
+
+    @After
+    fun resetCollectionHelperState() {
+        CollectionHelper.ankiDroidDirectoryOverride = null
+        CollectionHelper.systemStorageFailure = null
+    }
+
+    /**
+     * Reading the collection path must not silently choose and persist a default:
+     * that decision belongs to startup ([ensureCollectionPathSet]).
+     */
+    @Test
+    fun `reading the collection path throws when unset`() {
+        prefs.edit { remove(CollectionHelper.PREF_COLLECTION_PATH) }
+
+        assertFailsWith<StorageNotConfiguredException> {
+            CollectionHelper.getCurrentAnkiDroidDirectory(targetContext)
+        }
+    }
+
+    /**
+     * A storage failure at startup must not masquerade as the expected 'no collection path set'
+     * state: the [SystemStorageException] edge case (OS bug/SD card issue) is reported as itself.
+     */
+    @Test
+    fun `reading the collection path reports a recorded startup storage failure`() {
+        prefs.edit { remove(CollectionHelper.PREF_COLLECTION_PATH) }
+        val failure = SystemStorageException.build("simulated getExternalFilesDir failure")
+        CollectionHelper.systemStorageFailure = failure
+
+        val thrown =
+            assertFailsWith<SystemStorageException> {
+                CollectionHelper.getCurrentAnkiDroidDirectory(targetContext)
+            }
+        assertSame(failure, thrown)
+    }
+
+    @Test
+    fun `reading the collection path returns the stored value`() {
+        prefs.edit { putString(CollectionHelper.PREF_COLLECTION_PATH, "/a/collection/path") }
+
+        assertEquals(File("/a/collection/path"), CollectionHelper.getCurrentAnkiDroidDirectory(targetContext))
+    }
+
+    @Test
+    fun `the directory override takes precedence over the stored value`() {
+        prefs.edit { putString(CollectionHelper.PREF_COLLECTION_PATH, "/a/collection/path") }
+        CollectionHelper.ankiDroidDirectoryOverride = File("/an/override")
+
+        assertEquals(File("/an/override"), CollectionHelper.getCurrentAnkiDroidDirectory(targetContext))
+    }
+
+    @Test
+    fun `ensureCollectionPathSet persists a default when unset`() {
+        prefs.edit { remove(CollectionHelper.PREF_COLLECTION_PATH) }
+
+        ensureCollectionPathSet(targetContext)
+
+        assertTrue(!collectionPath.isNullOrEmpty(), "a default collection path should be set")
+    }
+
+    @Test
+    fun `ensureCollectionPathSet does not overwrite an existing value`() {
+        prefs.edit { putString(CollectionHelper.PREF_COLLECTION_PATH, "/a/custom/path") }
+
+        ensureCollectionPathSet(targetContext)
+
+        assertEquals("/a/custom/path", collectionPath)
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/testutils/TestApplicationSingletons.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/testutils/TestApplicationSingletons.kt
@@ -6,14 +6,16 @@ import android.app.Application
 import com.ichi2.anki.common.android.Animations
 import com.ichi2.anki.navigation.initializeNavigator
 import com.ichi2.anki.settings.PrefsRepository
+import com.ichi2.anki.startup.ensureCollectionPathSet
 import com.ichi2.testutils.EmptyApplication
 
 /**
  * Registers the global singletons that [com.ichi2.anki.AnkiDroidApp.onCreate] wires up, for tests
  * which use [EmptyApplication] (and therefore skip `AnkiDroidApp.onCreate`).
  */
-context(_: Application)
+context(application: Application)
 fun registerTestApplicationSingletons() {
     initializeNavigator()
     Animations.setPreferencesProvider { context -> PrefsRepository(context) }
+    ensureCollectionPathSet(application)
 }


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

## Purpose / Description
* Removes the 'create collection' responsibility of `getCurrentAnkiDroidDirectory` via moving storage initialization into `startup/SetupStorage.kt`
* ⚠️ Accessing the collection no longer initializes it

## Fixes
* Part of #19552
* Part of #13574
* Part of #20737

## Approach
* Implement `storageDecision()` based on whether the collection path is set
* Add error handling to DeckPicker if `storageDecision` isn't set
* Initialization is moved to `AnkiDroidApp`
* ⚠️ `getCurrentAnkiDroidDirectory` no longer sets the collection path; throwing `StorageNotConfiguredException`
* `ensureOpenInner` also throws

----

I maintained `SystemStorageException` for the OS-level errors if `context.getExternalFilesDir` returns null

## How Has This Been Tested?
Unit tested

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)