### PR TITLE
read Svg preview off the main Thread

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaImageFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaImageFragment.kt
@@ -64,8 +64,11 @@ import com.ichi2.utils.openInputStreamSafe
 import com.ichi2.utils.positiveButton
 import com.ichi2.utils.show
 import dev.androidbroadcast.vbpd.viewBinding
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.io.File
 import java.io.FileNotFoundException
@@ -551,14 +554,23 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
      * @param imageUri The URI of the SVG image.
      */
     private fun WebView.loadSvgImage(imageUri: Uri) {
-        val svgData = loadSvgFromUri(imageUri)
-        if (svgData != null) {
-            Timber.i("Selected image is an SVG.")
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                val svgData = withContext(Dispatchers.IO) { loadSvgFromUri(imageUri) }
+                if (svgData != null) {
+                    Timber.i("Selected image is an SVG.")
 
-            loadDataWithBaseURL(null, svgData, SVG_IMAGE, "UTF-8", null)
-        } else {
-            Timber.w("Failed to load SVG from URI")
-            showErrorInWebView()
+                    loadDataWithBaseURL(null, svgData, SVG_IMAGE, "UTF-8", null)
+                } else {
+                    Timber.w("Failed to load SVG from URI")
+                    showErrorInWebView()
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.w(e, "Error loading SVG preview")
+                showErrorInWebView()
+            }
         }
     }
 


### PR DESCRIPTION
## Purpose / Description

When previewing a selected SVG in the multimedia image editor, the
SVG file is read on the main thread (loadSvgFromUri -> openInputStream
-> convertToString) before it's passed to the WebView. For a large SVG
or a slow document provider, this read can briefly block the UI.

This moves the read to Dispatchers.IO and keeps the WebView update on
the main thread. Behaviour is unchanged.

Fixes #21276

## How Has This Been Tested?

Manually previewed SVG and non-SVG images in the multimedia image
editor; the preview renders as before. `:AnkiDroid:compilePlayDebugKotlin`
builds cleanly.

I didn't add an automated test: this is a threading change with no
observable behaviour difference, and there isn't existing infrastructure
to assert main-thread usage here. Happy to add one if you'd prefer a
specific approach.
