### PR TITLE
refactor: move CollectionHelper to `:anki-common`

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/dialogs/CollectionPathMismatchRecoveryTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/dialogs/CollectionPathMismatchRecoveryTest.kt
@@ -12,11 +12,11 @@ import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
 import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.startup.getDefaultAnkiDroidDirectory
 import com.ichi2.anki.tests.InstrumentedTest
 import com.ichi2.anki.testutil.disableIntroductionSlide

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/dialogs/DatabaseCorruptDialogTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/dialogs/DatabaseCorruptDialogTest.kt
@@ -24,11 +24,11 @@ import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.anki.CollectionHelper.getCurrentAnkiDroidDirectory
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
 import com.ichi2.anki.backend.DatabaseCorruption
+import com.ichi2.anki.common.storage.CollectionHelper.getCurrentAnkiDroidDirectory
 import com.ichi2.anki.tests.InstrumentedTest
 import com.ichi2.anki.tests.Shared
 import com.ichi2.anki.testutil.discardPreliminaryViews

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -26,9 +26,10 @@ import android.net.Uri
 import anki.cards.FsrsMemoryState
 import anki.collection.OpChanges
 import anki.notetypes.StockNotetype
-import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.FlashCardsContract
+import com.ichi2.anki.common.storage.CollectionHelper
+import com.ichi2.anki.common.storage.StorageDecision
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.common.utils.emptyStringArray
@@ -49,7 +50,6 @@ import com.ichi2.anki.libanki.getStockNotetype
 import com.ichi2.anki.libanki.sched.Scheduler
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.provider.pureAnswer
-import com.ichi2.anki.storage.StorageDecision
 import com.ichi2.anki.testutil.DatabaseUtils.cursorFillWindow
 import com.ichi2.anki.testutil.GrantStoragePermission.storagePermission
 import com.ichi2.anki.testutil.addNote

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -36,6 +36,7 @@ import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.crashreporting.CrashReportService.sendExceptionReport
 import com.ichi2.anki.common.permissions.hasLegacyStorageAccessPermission
 import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.common.utils.android.SdCard
 import com.ichi2.anki.common.utils.android.showThemedToast
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionIntegrityStorageCheck.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionIntegrityStorageCheck.kt
@@ -15,6 +15,7 @@ package com.ichi2.anki
 
 import android.content.Context
 import android.text.format.Formatter
+import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.utils.FileUtil
 import timber.log.Timber
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
@@ -18,6 +18,8 @@ import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.CollectionManager.withOpenColOrNull
 import com.ichi2.anki.CollectionManager.withQueue
 import com.ichi2.anki.backend.createDatabaseUsingRustBackend
+import com.ichi2.anki.common.storage.CollectionHelper
+import com.ichi2.anki.common.storage.StorageDecision
 import com.ichi2.anki.common.utils.android.Threads
 import com.ichi2.anki.common.utils.android.isRobolectric
 import com.ichi2.anki.common.utils.isRunningAsUnitTest
@@ -28,7 +30,6 @@ import com.ichi2.anki.libanki.CollectionFiles
 import com.ichi2.anki.libanki.LibAnki
 import com.ichi2.anki.libanki.Storage.collection
 import com.ichi2.anki.libanki.importCollectionPackage
-import com.ichi2.anki.storage.StorageDecision
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -102,6 +102,7 @@ import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.destinations.PreferencesDestination
 import com.ichi2.anki.common.destinations.navigate
 import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.utils.android.isRobolectric
 import com.ichi2.anki.common.utils.android.showThemedToast

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Import.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Import.kt
@@ -11,6 +11,7 @@ import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.destinations.CsvImporterDestination
 import com.ichi2.anki.common.destinations.addNextIntent
 import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.dialogs.AsyncDialogFragment
 import com.ichi2.anki.dialogs.ImportDialog
 import com.ichi2.anki.dialogs.ImportFileSelectionFragment

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -31,14 +31,15 @@ import com.ichi2.anki.backend.DatabaseCorruption
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.permissions.hasAllPermissions
 import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.common.storage.AnkiDroidFolder
+import com.ichi2.anki.common.storage.CollectionHelper
+import com.ichi2.anki.common.storage.StorageDecision
 import com.ichi2.anki.common.utils.android.SdCard
 import com.ichi2.anki.compat.CompatHelper.Companion.sdkVersion
 import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService.setPreferencesUpToDate
 import com.ichi2.anki.servicelayer.ScopedStorageService.isLegacyStorage
-import com.ichi2.anki.storage.AnkiDroidFolder
-import com.ichi2.anki.storage.StorageDecision
 import com.ichi2.anki.ui.windows.permissions.InternetPermissionFragment
 import com.ichi2.anki.ui.windows.permissions.NotificationsPermissionFragment
 import com.ichi2.anki.ui.windows.permissions.PermissionsFragment
@@ -231,7 +232,7 @@ enum class PermissionSet(
 
 /**
  * Returns the [PermissionSet] required to access the folder where AnkiDroid data is saved.
- * [com.ichi2.anki.storage.AnkiDroidFolder.PUBLIC] is preferred, as it reduces risk of data loss.
+ * [AnkiDroidFolder.PUBLIC] is preferred, as it reduces risk of data loss.
  * When impossible, we use the app-private directory.
  * See https://github.com/ankidroid/Anki-Android/issues/5304 for more context.
  */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -19,6 +19,8 @@ import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.permissions.hasLegacyStorageAccessPermission
 import com.ichi2.anki.common.permissions.isExternalStorageManagerCompat
 import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.common.storage.CollectionHelper
+import com.ichi2.anki.common.storage.StorageDecision
 import com.ichi2.anki.common.utils.android.showThemedToast
 import com.ichi2.anki.common.utils.trimToLength
 import com.ichi2.anki.dialogs.DialogHandler.Companion.storeMessage
@@ -29,7 +31,6 @@ import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.servicelayer.ScopedStorageService
 import com.ichi2.anki.settings.Prefs
-import com.ichi2.anki.storage.StorageDecision
 import com.ichi2.anki.ui.windows.reviewer.ReviewerFragment
 import com.ichi2.anki.utils.MimeTypeUtils
 import com.ichi2.anki.worker.SyncWorker

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ViewerResourceHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ViewerResourceHandler.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import com.ichi2.anki.common.annotations.NeedsTest
+import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.utils.AssetHelper.guessMimeType
 import timber.log.Timber
 import java.io.ByteArrayInputStream

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
@@ -23,13 +23,13 @@ import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.AbstractFlashcardViewer.Companion.getMediaBaseUrl
 import com.ichi2.anki.AndroidTtsError
 import com.ichi2.anki.AndroidTtsPlayer
-import com.ichi2.anki.CollectionHelper.getMediaDirectory
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.cardviewer.MediaErrorBehavior.CONTINUE_MEDIA
 import com.ichi2.anki.cardviewer.MediaErrorBehavior.RETRY_MEDIA
 import com.ichi2.anki.cardviewer.MediaErrorBehavior.STOP_MEDIA
 import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.annotations.NeedsTest
+import com.ichi2.anki.common.storage.CollectionHelper.getMediaDirectory
 import com.ichi2.anki.libanki.AvTag
 import com.ichi2.anki.libanki.Card
 import com.ichi2.anki.libanki.SoundOrVideoTag

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/BackgroundImage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/BackgroundImage.kt
@@ -21,9 +21,9 @@ import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.provider.MediaStore
 import androidx.annotation.CheckResult
-import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
+import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.preferences.AppearanceSettingsFragment
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -17,7 +17,6 @@ import androidx.core.os.BundleCompat
 import androidx.lifecycle.lifecycleScope
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.BackupManager
-import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.ConflictResolution
@@ -30,6 +29,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.ankiActivity
 import com.ichi2.anki.backend.DatabaseCorruption
 import com.ichi2.anki.backend.getDatabaseVersion
+import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType.DIALOG_CONFIRM_DATABASE_CHECK
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType.DIALOG_CONFIRM_RESTORE_BACKUP

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerBackupNoSpaceLeftDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerBackupNoSpaceLeftDialog.kt
@@ -19,10 +19,10 @@ package com.ichi2.anki.dialogs
 import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
 import com.ichi2.anki.BackupManager
-import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
+import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.utils.create
 import com.ichi2.utils.message
 import com.ichi2.utils.positiveButton

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileManager.kt
@@ -11,9 +11,9 @@ import android.webkit.WebView
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
-import com.ichi2.anki.CollectionHelper.PREF_COLLECTION_PATH
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.common.storage.CollectionHelper.PREF_COLLECTION_PATH
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.time.getTimestamp
 import com.ichi2.anki.startup.getDefaultAnkiDroidDirectory

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
@@ -22,11 +22,11 @@ import androidx.appcompat.app.AlertDialog
 import androidx.preference.EditTextPreference
 import androidx.preference.Preference
 import androidx.preference.SwitchPreferenceCompat
-import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.MetaDB
 import com.ichi2.anki.R
+import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.compat.CompatHelper
 import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.launchCatchingTask

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DeveloperOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DeveloperOptionsFragment.kt
@@ -10,12 +10,12 @@ import androidx.preference.Preference
 import androidx.preference.SwitchPreferenceCompat
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.BuildConfig
-import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.common.utils.android.showThemedToast
 import com.ichi2.anki.dialogs.TtsVoicesDialogFragment
 import com.ichi2.anki.launchCatchingTask

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
@@ -20,8 +20,8 @@ package com.ichi2.anki.servicelayer
 import android.content.Context
 import android.os.Build
 import android.os.Environment
-import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.ui.windows.managespace.isInsideDirectoriesRemovedWithTheApp
 import com.ichi2.utils.Permissions
 import timber.log.Timber

--- a/AnkiDroid/src/main/java/com/ichi2/anki/startup/SetupStorage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/startup/SetupStorage.kt
@@ -6,12 +6,12 @@ import android.content.Context
 import android.os.Environment
 import androidx.annotation.CheckResult
 import androidx.core.content.edit
-import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.common.storage.AnkiDroidFolder
+import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.exception.StorageNotConfiguredException
 import com.ichi2.anki.exception.SystemStorageException
 import com.ichi2.anki.selectAnkiDroidFolder
-import com.ichi2.anki.storage.AnkiDroidFolder
 import timber.log.Timber
 import java.io.File
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/startup/SetupStorage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/startup/SetupStorage.kt
@@ -156,7 +156,7 @@ private fun legacyAnkiDroidDirectory(directoryName: String = "AnkiDroid"): File 
  *
  * @throws SystemStorageException if `getExternalFilesDir` returns null
  */
-private fun getAppSpecificExternalAnkiDroidDirectory(context: Context): String? {
+private fun getAppSpecificExternalAnkiDroidDirectory(context: Context): String {
     val externalFilesDir = context.getExternalFilesDir(null)
 
     // This value *may* be null but we strictly require it. This has caused NullPointerException

--- a/AnkiDroid/src/main/java/com/ichi2/anki/startup/StartupGuards.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/startup/StartupGuards.kt
@@ -4,11 +4,11 @@ package com.ichi2.anki.startup
 
 import android.app.Activity
 import android.content.Intent
-import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.IntentHandler
 import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.common.storage.CollectionHelper
+import com.ichi2.anki.common.storage.StorageDecision
 import com.ichi2.anki.exception.SystemStorageException
-import com.ichi2.anki.storage.StorageDecision
 import timber.log.Timber
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/AndroidPermanentlyRevokedPermissionsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/AndroidPermanentlyRevokedPermissionsDialog.kt
@@ -21,8 +21,8 @@ import android.content.Context
 import android.content.DialogInterface
 import androidx.appcompat.app.AlertDialog
 import com.ichi2.anki.AnkiActivity
-import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.R
+import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.UninstallListItem.Companion.createNoStorageList
 import com.ichi2.utils.cancelable

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Context.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Context.kt
@@ -22,7 +22,7 @@ import android.graphics.BitmapFactory
 import android.util.AttributeSet
 import androidx.annotation.AttrRes
 import androidx.annotation.StyleRes
-import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.common.storage.CollectionHelper
 import java.io.File
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupUndecidedStorageTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupUndecidedStorageTest.kt
@@ -2,7 +2,8 @@
 
 package com.ichi2.anki
 
-import com.ichi2.anki.storage.StorageDecision
+import com.ichi2.anki.common.storage.CollectionHelper
+import com.ichi2.anki.common.storage.StorageDecision
 import com.ichi2.testutils.ActivityList
 import com.ichi2.testutils.ActivityList.ActivityLaunchParam
 import org.junit.After

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerNoExternalFilesDirTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerNoExternalFilesDirTest.kt
@@ -21,6 +21,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.common.utils.android.SdCard
 import com.ichi2.anki.dialogs.utils.ankiListView
 import com.ichi2.anki.dialogs.utils.message

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerOnDiskTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerOnDiskTest.kt
@@ -22,6 +22,7 @@ import com.ichi2.anki.DeckPickerTest.CollectionType
 import com.ichi2.anki.DeckPickerTest.DeckPickerEx
 import com.ichi2.anki.backend.getDatabaseVersion
 import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType
 import com.ichi2.anki.exception.UnknownDatabaseVersionException

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ExternalEntryPointsUndecidedStorageTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ExternalEntryPointsUndecidedStorageTest.kt
@@ -10,7 +10,8 @@ import android.content.ContentProvider
 import android.content.Intent
 import android.os.Build
 import androidx.core.net.toUri
-import com.ichi2.anki.storage.StorageDecision
+import com.ichi2.anki.common.storage.CollectionHelper
+import com.ichi2.anki.common.storage.StorageDecision
 import com.ichi2.testutils.ExternalEntryPoints.EntryPoint
 import com.ichi2.testutils.grantPermissions
 import org.junit.After

--- a/AnkiDroid/src/test/java/com/ichi2/anki/StorageDecisionGateTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/StorageDecisionGateTest.kt
@@ -5,9 +5,10 @@ package com.ichi2.anki
 import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.common.storage.CollectionHelper
+import com.ichi2.anki.common.storage.StorageDecision
 import com.ichi2.anki.exception.StorageNotConfiguredException
 import com.ichi2.anki.exception.SystemStorageException
-import com.ichi2.anki.storage.StorageDecision
 import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
@@ -17,8 +17,8 @@
 package com.ichi2.anki.jsaddons
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.testutils.ShadowStatFs
 import com.ichi2.utils.FileOperation.Companion.getFileResource
 import junit.framework.TestCase.assertTrue

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/ProfileManagerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/ProfileManagerTest.kt
@@ -25,8 +25,8 @@ import android.webkit.WebView
 import androidx.core.content.edit
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.anki.CollectionHelper.PREF_COLLECTION_PATH
 import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.common.storage.CollectionHelper.PREF_COLLECTION_PATH
 import com.ichi2.anki.multiprofile.ProfileManager.Companion.KEY_LAST_ACTIVE_PROFILE_ID
 import com.ichi2.anki.multiprofile.ProfileManager.Companion.PROFILE_REGISTRY_FILENAME
 import io.mockk.every

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesScreenshotTest.kt
@@ -4,9 +4,9 @@ package com.ichi2.anki.preferences
 
 import androidx.preference.Preference
 import androidx.test.core.app.ActivityScenario
-import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.R
 import com.ichi2.anki.ScreenshotTest
+import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.settings.Prefs
 import org.junit.Test
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/startup/SetupStorageTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/startup/SetupStorageTest.kt
@@ -4,9 +4,9 @@ package com.ichi2.anki.startup
 
 import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.exception.StorageNotConfiguredException
 import com.ichi2.anki.exception.SystemStorageException
 import org.junit.After

--- a/AnkiDroid/src/test/java/com/ichi2/anki/startup/StartupGuardsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/startup/StartupGuardsTest.kt
@@ -6,11 +6,11 @@ import android.app.Activity
 import android.content.Intent
 import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.IntentHandler
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.common.preferences.sharedPrefs
-import com.ichi2.anki.storage.StorageDecision
+import com.ichi2.anki.common.storage.CollectionHelper
+import com.ichi2.anki.common.storage.StorageDecision
 import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/BackupManagerTestUtilities.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/BackupManagerTestUtilities.kt
@@ -17,7 +17,7 @@ package com.ichi2.testutils
 
 import android.content.Context
 import com.ichi2.anki.BackupManager.Companion.enoughDiscSpace
-import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.common.storage.CollectionHelper
 import org.junit.Assert.assertTrue
 import java.lang.IllegalStateException
 

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/DbUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/DbUtils.kt
@@ -16,8 +16,8 @@
 package com.ichi2.testutils
 
 import android.content.Context
-import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.backend.createDatabaseUsingAndroidFramework
+import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.libanki.DB
 
 object DbUtils {

--- a/anki-common/src/main/kotlin/com/ichi2/anki/CollectionHelper.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/CollectionHelper.kt
@@ -6,8 +6,6 @@ package com.ichi2.anki
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.annotation.VisibleForTesting
-import com.ichi2.anki.CollectionHelper.PREF_COLLECTION_PATH
-import com.ichi2.anki.CollectionHelper.getCurrentAnkiDroidDirectory
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.utils.android.isInstrumentationTest
 import com.ichi2.anki.exception.StorageAccessException
@@ -25,7 +23,7 @@ object CollectionHelper {
      * The preference key for the path to the current AnkiDroid directory
      *
      * This directory contains all AnkiDroid data and media for a given collection
-     * Except the Android preferences, cached files and [MetaDB]
+     * Except the Android preferences, cached files and `MetaDB`
      *
      * This can be changed by the Preferences screen
      * to allow a user to access a second collection via the same AnkiDroid app instance.
@@ -101,7 +99,7 @@ object CollectionHelper {
 
     /**
      * @return Returns an array of [File]s reflecting the directories that AnkiDroid can access without storage permissions
-     * @see android.content.Context.getExternalFilesDirs
+     * @see Context.getExternalFilesDirs
      */
     fun getAppSpecificExternalDirectories(context: Context): List<File> = context.getExternalFilesDirs(null)?.filterNotNull() ?: listOf()
 
@@ -144,9 +142,8 @@ object CollectionHelper {
      * when [getCurrentAnkiDroidDirectory] can return a directory rather than throwing.
      *
      * The user is not asked yet: until the dedicated setup flow exists (#19552), the 'decision'
-     * is made on their behalf during startup by
-     * [ensureCollectionPathSet][com.ichi2.anki.startup.ensureCollectionPathSet], so this is
-     * [StorageDecision.Decided] by the time the collection is opened.
+     * is made on their behalf during startup by `ensureCollectionPathSet` (app module), so this
+     * is [StorageDecision.Decided] by the time the collection is opened.
      *
      * @param preferences the preferences the collection path will be read from: pass the same
      * (profile) context's preferences as the [getCurrentAnkiDroidDirectory] call being gated
@@ -167,7 +164,7 @@ object CollectionHelper {
      *
      * @throws StorageNotConfiguredException if no collection path has been set
      * ([PREF_COLLECTION_PATH] is unset): a default is chosen during startup by
-     * [ensureCollectionPathSet][com.ichi2.anki.startup.ensureCollectionPathSet]
+     * `ensureCollectionPathSet` (app module)
      * @throws SystemStorageException if startup failed to choose a default collection path
      * ([systemStorageFailure])
      */
@@ -183,7 +180,7 @@ object CollectionHelper {
      *
      * @throws StorageNotConfiguredException if no collection path has been set
      * ([PREF_COLLECTION_PATH] is unset): a default is chosen during startup by
-     * [ensureCollectionPathSet][com.ichi2.anki.startup.ensureCollectionPathSet]
+     * `ensureCollectionPathSet` (app module)
      * @throws SystemStorageException if startup failed to choose a default collection path
      * ([systemStorageFailure])
      */

--- a/anki-common/src/main/kotlin/com/ichi2/anki/common/storage/AnkiDroidFolder.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/common/storage/AnkiDroidFolder.kt
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package com.ichi2.anki.storage
+package com.ichi2.anki.common.storage
 
 /**
  * Where AnkiDroid stores its collection.

--- a/anki-common/src/main/kotlin/com/ichi2/anki/common/storage/CollectionHelper.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/common/storage/CollectionHelper.kt
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>
 
-package com.ichi2.anki
+package com.ichi2.anki.common.storage
 
 import android.content.Context
 import android.content.SharedPreferences
@@ -13,7 +13,6 @@ import com.ichi2.anki.exception.StorageNotConfiguredException
 import com.ichi2.anki.exception.SystemStorageException
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.CollectionFiles
-import com.ichi2.anki.storage.StorageDecision
 import timber.log.Timber
 import java.io.File
 import java.io.IOException

--- a/anki-common/src/main/kotlin/com/ichi2/anki/common/storage/StorageDecision.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/common/storage/StorageDecision.kt
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package com.ichi2.anki.storage
+package com.ichi2.anki.common.storage
 
 /**
  * Whether the user has chosen where AnkiDroid stores its collection.
  *
- * On a fresh install the location must be chosen explicitly (see [com.ichi2.anki.AnkiDroidFolder]); there is no
+ * On a fresh install the location must be chosen explicitly (see [AnkiDroidFolder]); there is no
  * silent default, and the collection must not be opened until a choice has been made.
  */
 sealed interface StorageDecision {

--- a/anki-common/src/main/kotlin/com/ichi2/anki/exception/StorageNotConfiguredException.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/exception/StorageNotConfiguredException.kt
@@ -2,9 +2,11 @@
 
 package com.ichi2.anki.exception
 
+import com.ichi2.anki.common.storage.StorageDecision
+
 /**
  * Thrown when the collection is accessed before the user has chosen where it should be stored
- * (the [storage decision][com.ichi2.anki.storage.StorageDecision] is `Undecided`).
+ * (the [storage decision][StorageDecision] is `Undecided`).
  *
  * Use `StorageAccessException` if a known path is unusable.
  */


### PR DESCRIPTION
* Stacked on https://github.com/ankidroid/Anki-Android/pull/21343


## Purpose / Description
Simple migration commit

## Fixes
* Part of https://github.com/ankidroid/Anki-Android/issues/20737

## How Has This Been Tested?
Trusting lint & unit tests

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)