### PR TITLE
fix: drop empty label from network errors

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -114,7 +114,10 @@ fun CoroutineScope.launchCatching(
                     is BackendException, is InvalidSearchException -> exception.localizedMessage
                     else -> null
                 } ?: exception.toString()
-            errorMessageHandler.invoke(message)
+            // backend network errors may carry a dangling empty "Error details:" label; remove it.
+            // guarded to backend exceptions so the translations aren't queried when none are loaded
+            val displayMessage = if (exception is BackendException) stripEmptyErrorDetails(message) else message
+            errorMessageHandler.invoke(displayMessage)
         }
     }
 
@@ -201,7 +204,7 @@ suspend fun <T> FragmentActivity.runCatching(
             is BackendNetworkException, is BackendSyncException, is StorageAccessException, is BackendCardTypeException -> {
                 // these exceptions do not generate worthwhile crash reports
                 Timber.i("Showing error dialog but not sending a crash report.")
-                showError(exc.localizedMessage!!, exc.toCrashReportData(this, reportException = false))
+                showError(stripEmptyErrorDetails(exc.localizedMessage!!), exc.toCrashReportData(this, reportException = false))
             }
             is BackendException -> {
                 Timber.e(exc, errorMessage)
@@ -265,6 +268,33 @@ fun Fragment.launchCatchingTask(
     lifecycle.coroutineScope.launch {
         requireActivity().runCatching(errorMessage, skipCrashReport = skipCrashReport) { block() }
     }
+
+/**
+ * Drops a trailing, empty "Error details:" label from a backend error [message].
+ *
+ * The backend tacks `network-details` (`Error details: { $details }`) onto network errors even when
+ * there's nothing to fill it in, leaving the label dangling. We read the label from [networkDetails]
+ * so this works in any language, and bail if a translation doesn't put the value last (there we
+ * can't tell an empty value from real text).
+ */
+@VisibleForTesting
+fun stripEmptyErrorDetails(
+    message: String,
+    networkDetails: (details: String) -> String = TR::networkDetails,
+): String {
+    // only safe when the value sits at the end of the label. if a translation wraps it (e.g.
+    // Lojban) we can't tell empty from real content, so leave it be
+    val emptyLabel = networkDetails("")
+    if (!networkDetails("_").startsWith(emptyLabel.trimEnd())) return message
+
+    val label = emptyLabel.trim()
+    if (label.isEmpty()) return message
+
+    val trimmed = message.trimEnd()
+    if (!trimmed.endsWith(label)) return message
+
+    return trimmed.removeSuffix(label).trimEnd()
+}
 
 /**
  * Displays an error dialog with title 'Error' and provided [message].

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CoroutineHelpersTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CoroutineHelpersTest.kt
@@ -19,6 +19,45 @@ class CoroutineHelpersTest {
             assertThat(captured, equalTo("Invalid search: an and"))
         }
 
+    @Test
+    fun `strips a dangling empty error details label`() {
+        // the backend formats network errors as `<summary>\n\n<details>`; with no details to
+        // report the "Error details:" label is left dangling with nothing after it
+        val message = "A network error occurred.\n\nError details: "
+        val cleaned = stripEmptyErrorDetails(message) { details -> "Error details: $details" }
+        assertThat(cleaned, equalTo("A network error occurred."))
+    }
+
+    @Test
+    fun `keeps the label when there are real error details`() {
+        val message = "A network error occurred.\n\nError details: connection refused"
+        val cleaned = stripEmptyErrorDetails(message) { details -> "Error details: $details" }
+        assertThat(cleaned, equalTo(message))
+    }
+
+    @Test
+    fun `strips the dangling label in other languages`() {
+        // German `network-details` translation, to confirm the check isn't hardcoded to English
+        val message = "Ein Netzwerkfehler ist aufgetreten.\n\nFehlerbeschreibung: "
+        val cleaned = stripEmptyErrorDetails(message) { details -> "Fehlerbeschreibung: $details" }
+        assertThat(cleaned, equalTo("Ein Netzwerkfehler ist aufgetreten."))
+    }
+
+    @Test
+    fun `leaves the message unchanged when details are not substituted at the end of the label`() {
+        // Lojban wraps the details value, so an empty value can't be told apart from real content
+        val lojban = { details: String -> ".i tcila pa nabmi fa la'o zoi. $details .zoi" }
+        val message = "summary\n\n${lojban("")}"
+        assertThat(stripEmptyErrorDetails(message, lojban), equalTo(message))
+    }
+
+    @Test
+    fun `leaves messages without an error details label unchanged`() {
+        val message = "Your account has been disabled."
+        val cleaned = stripEmptyErrorDetails(message) { details -> "Error details: $details" }
+        assertThat(cleaned, equalTo(message))
+    }
+
     private suspend fun CoroutineScope.captureErrorMessage(block: suspend CoroutineScope.() -> Unit): String? {
         var captured: String? = null
         launchCatching(


### PR DESCRIPTION
> [!NOTE]
> Assisted-By: Claude Opus 4.8 - analysing the upstream cause and testing the fix

<!--- Please fill the necessary details below -->
## Purpose / Description
When a sync fails with a network error (e.g. AnkiWeb is down or unreachable), the error dialog shows a dangling "Error details:" label with nothing after it. There are simply no details to show, so the bare label looks unfinished. This pr cleans that

Also i have opened an issue upstream: 
- https://github.com/ankitects/anki/issues/5117

## Fixes
* Fixes #21306

## Approach
- Added `stripEmptyErrorDetails()` in `CoroutineHelpers.kt` to drop that trailing label before the message is shown

## How Has This Been Tested?
unit testing

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->