### PR TITLE
fix: select the newly created deck by default

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2142,12 +2142,22 @@ open class DeckPicker :
                 deckDialogType = CreateDeckDialog.DeckDialogType.DECK,
                 parentId = null,
             )
-        createDeckDialog.onNewDeckCreated = {
-            updateDeckList()
-            invalidateOptionsMenu()
-        }
+        createDeckDialog.onNewDeckCreated = ::onDeckCreated
         createDeckDialog.showDialog()
     }
+
+    /**
+     * Handles a deck created from the deck picker: selects it so the toolbar and, on tablets, the
+     * [StudyOptionsFragment] panel follow the new deck instead of the previously current deck, which
+     * is often the hidden Default deck.
+     */
+    private fun onDeckCreated(deckId: DeckId) =
+        launchCatchingTask {
+            viewModel.selectDeck(deckId).join()
+            updateDeckList()
+            tryShowStudyOptionsPanel()
+            invalidateOptionsMenu()
+        }
 
     /**
      * Deletes the provided deck, child decks, and all cards inside.
@@ -2200,13 +2210,11 @@ open class DeckPicker :
                 deckDialogType = CreateDeckDialog.DeckDialogType.SUB_DECK,
                 parentId = did,
             )
-        createDeckDialog.onNewDeckCreated = {
+        createDeckDialog.onNewDeckCreated = { deckId ->
             // a deck was created
             dismissAllDialogFragments()
             deckListAdapter.notifyDataSetChanged()
-            updateDeckList()
-            tryShowStudyOptionsPanel()
-            invalidateOptionsMenu()
+            onDeckCreated(deckId)
         }
         createDeckDialog.showDialog()
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -30,6 +30,8 @@ import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType
 import com.ichi2.anki.dialogs.DeckPickerContextMenu.DeckPickerContextMenuOption
 import com.ichi2.anki.dialogs.DeckPickerContextMenuResult
 import com.ichi2.anki.dialogs.setDeckPickerContextMenuResult
+import com.ichi2.anki.dialogs.utils.input
+import com.ichi2.anki.dialogs.utils.performPositiveClick
 import com.ichi2.anki.dialogs.utils.title
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.navigation.AnkiDroidNavigator
@@ -822,6 +824,23 @@ class DeckPickerTest : RobolectricTest() {
                     assertThat(extra.permissions, equalTo(listOf(INTERNET)))
                 }
             }
+        }
+
+    @Test
+    fun `creating a deck selects it`() =
+        deckPicker {
+            showCreateDeckDialog()
+            val dialog = ShadowDialog.getLatestDialog() as AlertDialog
+            dialog.input = "My Deck"
+            dialog.performPositiveClick()
+            ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+            val newDeckId = col.decks.byName("My Deck")!!.id
+            assertThat(
+                "the newly created deck should become the current deck",
+                col.decks.current().id,
+                equalTo(newDeckId),
+            )
         }
 
     enum class CollectionType(


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Root cause: creating a deck never selected it. `CreateDeckDialog.createNewDeck()` calls `decks.id(name)`, which creates the deck but leaves `decks.current()` pointing at whatever it was before (on a fresh install, the hidden Default deck). On a tablet the StudyOptions side-pane reads decks.current(), and the toolbar acts on the current deck so both kept showing Default.

## Fixes
* Fixes #21355

## Approach
See commit

## How Has This Been Tested?
Pixel Tab emulator and unit test

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->