### PR TITLE
chore: standardize RESULT_ for review reminders

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -430,7 +430,7 @@ class StudyOptionsFragment :
         /**
          * Bundle key for the deck ID whose study options are being displayed, used when the review reminders screen is being opened.
          */
-        private const val KEY_REVIEW_REMINDERS_DECK_ID = "review_reminders_deck_id"
+        private const val RESULT_REVIEW_REMINDERS_DECK_ID = "result_review_reminders_deck_id"
 
         @VisibleForTesting
         fun formatDescription(
@@ -460,7 +460,7 @@ class StudyOptionsFragment :
         fun FragmentActivity.registerStudyOptionsAddEditReminderHandler(action: (did: DeckId) -> Unit) {
             setFragmentResultListener(REQUEST_STUDY_OPTIONS_REVIEW_REMINDERS) { _, bundle ->
                 Timber.i("Received fragment result from study options fragment for adding / editing review reminders")
-                val did = bundle.getLong(KEY_REVIEW_REMINDERS_DECK_ID)
+                val did = bundle.getLong(RESULT_REVIEW_REMINDERS_DECK_ID)
                 action(did)
             }
         }
@@ -472,7 +472,7 @@ class StudyOptionsFragment :
         private fun FragmentManager.setStudyOptionsAddEditReminderResult(did: DeckId) {
             setFragmentResult(
                 REQUEST_STUDY_OPTIONS_REVIEW_REMINDERS,
-                Bundle().apply { putLong(KEY_REVIEW_REMINDERS_DECK_ID, did) },
+                Bundle().apply { putLong(RESULT_REVIEW_REMINDERS_DECK_ID, did) },
             )
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
@@ -311,8 +311,8 @@ class AddEditReminderDialog : DialogFragment() {
         setFragmentResult(
             REQUEST_ADD_EDIT_REMINDER,
             Bundle().apply {
-                putParcelable(KEY_REMINDER_MODE, dialogMode)
-                putParcelable(KEY_REMINDER_RESULT, reminderToBeReturned)
+                putParcelable(RESULT_MODE, dialogMode)
+                putParcelable(RESULT_REMINDER, reminderToBeReturned)
             },
         )
 
@@ -339,8 +339,8 @@ class AddEditReminderDialog : DialogFragment() {
                 REQUEST_ADD_EDIT_REMINDER,
                 Bundle().apply {
                     // dialogMode should always be DialogMode.Edit in this case since the delete button only exists in Edit mode
-                    putParcelable(KEY_REMINDER_MODE, dialogMode)
-                    putParcelable(KEY_REMINDER_RESULT, null)
+                    putParcelable(RESULT_MODE, dialogMode)
+                    putParcelable(RESULT_REMINDER, null)
                 },
             )
             dismiss()
@@ -388,12 +388,12 @@ class AddEditReminderDialog : DialogFragment() {
         /**
          * Fragment result bundle key for the [DialogMode] of a recently closed [AddEditReminderDialog].
          */
-        private const val KEY_REMINDER_MODE = "key_reminder_mode"
+        private const val RESULT_MODE = "result_mode"
 
         /**
          * Fragment result bundle key for the [ReviewReminder] result of a recently closed [AddEditReminderDialog].
          */
-        private const val KEY_REMINDER_RESULT = "key_reminder_result"
+        private const val RESULT_REMINDER = "result_reminder"
 
         /**
          * Unique fragment tag for the Material TimePicker shown for setting the time of a review reminder.
@@ -413,9 +413,9 @@ class AddEditReminderDialog : DialogFragment() {
                 Timber.i("Received fragment result from add/edit dialog")
                 val modeOfFinishedDialog =
                     bundle.getParcelableCompat<DialogMode>(
-                        KEY_REMINDER_MODE,
+                        RESULT_MODE,
                     ) ?: return@setFragmentResultListener
-                val newOrModifiedReminder = bundle.getParcelableCompat<ReviewReminder>(KEY_REMINDER_RESULT)
+                val newOrModifiedReminder = bundle.getParcelableCompat<ReviewReminder>(RESULT_REMINDER)
                 action(newOrModifiedReminder, modeOfFinishedDialog)
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/NotificationsPermissionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/NotificationsPermissionFragment.kt
@@ -56,7 +56,7 @@ class NotificationsPermissionFragment : PermissionsFragment(R.layout.fragment_no
         // onResume is called after returning from both the OS settings and the OS permission request dialog
         if (Permissions.canPostNotifications(requireContext())) {
             // Post a fragment result to indicate that the bottom sheet can be dismissed
-            setFragmentResult(PermissionsBottomSheet.DISMISS_RESULT_REQUEST_KEY, Bundle())
+            setFragmentResult(PermissionsBottomSheet.RESULT_DISMISS, Bundle())
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsBottomSheet.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsBottomSheet.kt
@@ -63,7 +63,7 @@ class PermissionsBottomSheet : BottomSheetDialogFragment() {
         }
 
         binding.closeButton.setOnClickListener { dismiss() }
-        childFragmentManager.setFragmentResultListener(DISMISS_RESULT_REQUEST_KEY, this) { _, _ ->
+        childFragmentManager.setFragmentResultListener(RESULT_DISMISS, this) { _, _ ->
             dismiss()
         }
 
@@ -97,7 +97,7 @@ class PermissionsBottomSheet : BottomSheetDialogFragment() {
          * Fragment result request key for dismissing this BottomSheet.
          * Public so that child fragments can set it.
          */
-        const val DISMISS_RESULT_REQUEST_KEY = "permissions_bottom_sheet_dismiss"
+        const val RESULT_DISMISS = "result_dismiss"
 
         /**
          * Starts this BottomSheet with the provided [PermissionSet].


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

<!---
Uncomment this section if AI tools were used. New contributors may not use AI tools. See:
https://github.com/ankidroid/Anki-Android/blob/main/AI_POLICY.md
> [!NOTE]
> Assisted-by: ___
--->

## Purpose / Description
Just a simple renaming refactor of some of the variables I originally created. I originally tried applying this fix to all instances of fragment result bundle keys, but that got big and messy really fast so I'll just do this minimal compliance fix for now.

## Fixes
* Part of https://github.com/ankidroid/Anki-Android/issues/19896
* Addresses feedback from David at https://github.com/ankidroid/Anki-Android/pull/21140

## Approach
Just a simple rename.

## How Has This Been Tested?
Builds, unit tests pass.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->