### PR TITLE
chore: remove non-standard _EXTRA instances

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -350,7 +350,7 @@ abstract class AbstractFlashcardViewer :
                The card could have been rescheduled, the deck could have changed, or a change of
                note type could have lead to the card being deleted */
             val reloadRequired =
-                result.data?.getBooleanExtra(NoteEditorFragment.RELOAD_REQUIRED_EXTRA_KEY, false) == true
+                result.data?.getBooleanExtra(NoteEditorFragment.EXTRA_RELOAD_REQUIRED, false) == true
             if (reloadRequired) {
                 performReload()
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -843,7 +843,7 @@ open class AnkiActivity(
 
     companion object {
         /** Extra key to set the finish animation of an activity  */
-        const val FINISH_ANIMATION_EXTRA = "finishAnimation"
+        const val EXTRA_FINISH_ANIMATION = "finishAnimation"
 
         private const val SIMPLE_NOTIFICATION_ID = 0
         private const val KEY_EXPORT_FILE_NAME = "key_export_file_name"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1783,7 +1783,7 @@ open class DeckPicker :
             if (VersionUtils.isReleaseVersion) {
                 Timber.i("Displaying new features")
                 val infoIntent = Intent(this, Info::class.java)
-                infoIntent.putExtra(Info.TYPE_EXTRA, Info.TYPE_NEW_VERSION)
+                infoIntent.putExtra(Info.EXTRA_TYPE, Info.TYPE_NEW_VERSION)
                 showNewVersionInfoLauncher.launch(infoIntent)
             } else {
                 Timber.i("Dev Build - not showing 'new features'")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
@@ -50,7 +50,7 @@ class Info :
         }
         super.onCreate(savedInstanceState)
         val res = resources
-        val type = intent.getIntExtra(TYPE_EXTRA, TYPE_NEW_VERSION)
+        val type = intent.getIntExtra(EXTRA_TYPE, TYPE_NEW_VERSION)
         // If the page crashes, we do not want to display it again (#7135 maybe)
         if (type == TYPE_NEW_VERSION) {
             val prefs = this.baseContext.sharedPrefs()
@@ -184,7 +184,7 @@ class Info :
     }
 
     companion object {
-        const val TYPE_EXTRA = "infoType"
+        const val EXTRA_TYPE = "infoType"
         const val TYPE_NEW_VERSION = 2
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -113,7 +113,7 @@ class IntentHandler : AbstractIntentHandler() {
         Timber.i("Copying debug info to clipboard")
         // null string is handled by copyToClipboard in try-catch
         this.copyToClipboard(
-            text = (intent.getStringExtra(CLIPBOARD_INTENT_EXTRA_DATA)!!),
+            text = (intent.getStringExtra(EXTRA_CLIPBOARD_DATA)!!),
             failureMessageId = R.string.about_ankidroid_error_copy_debug_info,
         )
     }
@@ -168,7 +168,7 @@ class IntentHandler : AbstractIntentHandler() {
         reloadIntent: Intent,
         reviewerIntent: Intent,
     ) {
-        val deckId = intent.getLongExtra(REVIEW_DECK_INTENT_EXTRA_DECK_ID, 0)
+        val deckId = intent.getLongExtra(EXTRA_DECK_ID, 0)
         Timber.i("Handling intent to review deck '%d'", deckId)
 
         val reviewIntent =
@@ -347,9 +347,9 @@ class IntentHandler : AbstractIntentHandler() {
     }
 
     companion object {
-        const val REVIEW_DECK_INTENT_EXTRA_DECK_ID = "EXTRA_DECK_ID"
+        const val EXTRA_DECK_ID = "EXTRA_DECK_ID"
         private const val CLIPBOARD_INTENT = "com.ichi2.anki.COPY_DEBUG_INFO"
-        private const val CLIPBOARD_INTENT_EXTRA_DATA = "clip_data"
+        private const val EXTRA_CLIPBOARD_DATA = "clip_data"
 
         private val textMimeTypes = MimeTypeUtils.CSV_TSV_MIME_TYPES
 
@@ -408,7 +408,7 @@ class IntentHandler : AbstractIntentHandler() {
                 }
             } else if ("com.ichi2.anki.DO_SYNC" == action) {
                 LaunchType.SYNC
-            } else if (intent.hasExtra(REVIEW_DECK_INTENT_EXTRA_DECK_ID)) {
+            } else if (intent.hasExtra(EXTRA_DECK_ID)) {
                 LaunchType.REVIEW
             } else if (action == CLIPBOARD_INTENT) {
                 LaunchType.COPY_DEBUG_INFO
@@ -432,7 +432,7 @@ class IntentHandler : AbstractIntentHandler() {
             it.action = CLIPBOARD_INTENT
             // max length for an intent is 500KB.
             // 25000 * 2 (bytes per char) = 50,000 bytes <<< 500KB
-            it.putExtra(CLIPBOARD_INTENT_EXTRA_DATA, textToCopy.trimToLength(25000))
+            it.putExtra(EXTRA_CLIPBOARD_DATA, textToCopy.trimToLength(25000))
         }
 
         fun requiresCollectionAccess(launchType: LaunchType): Boolean =
@@ -507,7 +507,7 @@ class IntentHandler : AbstractIntentHandler() {
         fun getReviewDeckIntent(
             context: Context,
             deckId: DeckId,
-        ): Intent = Intent(context, IntentHandler::class.java).putExtra(REVIEW_DECK_INTENT_EXTRA_DECK_ID, deckId)
+        ): Intent = Intent(context, IntentHandler::class.java).putExtra(EXTRA_DECK_ID, deckId)
 
         /**
          * Returns an intent to review a specific deck.
@@ -520,7 +520,7 @@ class IntentHandler : AbstractIntentHandler() {
             deckId: DeckId,
         ) = Intent(context, IntentHandler::class.java).apply {
             setAction(Intent.ACTION_VIEW)
-            putExtra(REVIEW_DECK_INTENT_EXTRA_DECK_ID, deckId)
+            putExtra(EXTRA_DECK_ID, deckId)
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -504,11 +504,11 @@ class NoteEditorFragment :
             addNote = savedInstanceState.getBoolean("addNote")
             deckId = savedInstanceState.getLong("did")
             selectedTags = savedInstanceState.getStringArrayList("tags")
-            reloadRequired = savedInstanceState.getBoolean(RELOAD_REQUIRED_EXTRA_KEY)
+            reloadRequired = savedInstanceState.getBoolean(EXTRA_RELOAD_REQUIRED)
             multimediaController.onRestoreInstanceState(savedInstanceState)
             toggleStickyText =
                 savedInstanceState.getSerializableCompat<HashMap<Int, String?>>("toggleSticky")!!
-            changed = savedInstanceState.getBoolean(NOTE_CHANGED_EXTRA_KEY)
+            changed = savedInstanceState.getBoolean(EXTRA_NOTE_CHANGED)
         } else {
             caller = fromValue(requireArguments().getInt(EXTRA_CALLER, NoteEditorCaller.NO_CALLER.value))
             if (caller == NoteEditorCaller.NO_CALLER) {
@@ -594,8 +594,8 @@ class NoteEditorFragment :
         savedInstanceState.putInt(CALLER_KEY, caller.value)
         savedInstanceState.putBoolean("addNote", addNote)
         savedInstanceState.putLong("did", deckId)
-        savedInstanceState.putBoolean(NOTE_CHANGED_EXTRA_KEY, changed)
-        savedInstanceState.putBoolean(RELOAD_REQUIRED_EXTRA_KEY, reloadRequired)
+        savedInstanceState.putBoolean(EXTRA_NOTE_CHANGED, changed)
+        savedInstanceState.putBoolean(EXTRA_RELOAD_REQUIRED, reloadRequired)
         savedInstanceState.putIntegerArrayList("customViewIds", customViewIds)
         multimediaController.onSaveInstanceState(savedInstanceState)
         savedInstanceState.putSerializable("toggleSticky", toggleStickyText)
@@ -1640,10 +1640,10 @@ class NoteEditorFragment :
                 RESULT_CANCELED
             }
         if (reloadRequired) {
-            intent.putExtra(RELOAD_REQUIRED_EXTRA_KEY, true)
+            intent.putExtra(EXTRA_RELOAD_REQUIRED, true)
         }
         if (changed) {
-            intent.putExtra(NOTE_CHANGED_EXTRA_KEY, true)
+            intent.putExtra(EXTRA_NOTE_CHANGED, true)
         }
         closeNoteEditor(result, intent)
     }
@@ -1673,7 +1673,7 @@ class NoteEditorFragment :
             val animation =
                 BundleCompat.getParcelable(
                     requireArguments(),
-                    AnkiActivity.FINISH_ANIMATION_EXTRA,
+                    AnkiActivity.EXTRA_FINISH_ANIMATION,
                     TransitionDirection::class.java,
                 )
             if (animation != null) {
@@ -2669,8 +2669,8 @@ class NoteEditorFragment :
         const val EXTRA_EDIT_FROM_CARD_ID = "editCid"
         const val ACTION_CREATE_FLASHCARD = "org.openintents.action.CREATE_FLASHCARD"
         const val ACTION_CREATE_FLASHCARD_SEND = "android.intent.action.SEND"
-        const val NOTE_CHANGED_EXTRA_KEY = "noteChanged"
-        const val RELOAD_REQUIRED_EXTRA_KEY = "reloadRequired"
+        const val EXTRA_NOTE_CHANGED = "noteChanged"
+        const val EXTRA_RELOAD_REQUIRED = "reloadRequired"
         const val EXTRA_IMG_OCCLUSION = "image_uri"
         const val IN_CARD_BROWSER_ACTIVITY = "inCardBrowserActivity"
         const val EXTRA_CARD_IDS = "EXTRA_CARD_IDS"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -803,7 +803,7 @@ open class Reviewer :
         Timber.i("opening card info")
         val intent = CardInfoDestination(currentCard!!.id, EntryPoint.CURRENT_CARD_STUDY).toIntent(this)
         val animation = getAnimationTransitionFromGesture(fromGesture)
-        intent.putExtra(FINISH_ANIMATION_EXTRA, animation.invert() as Parcelable)
+        intent.putExtra(EXTRA_FINISH_ANIMATION, animation.invert() as Parcelable)
         startActivityWithAnimation(intent, animation)
     }
 
@@ -816,7 +816,7 @@ open class Reviewer :
         Timber.i("opening previous card info")
         val intent = CardInfoDestination(previousCardId!!, EntryPoint.PREVIOUS_CARD_STUDY).toIntent(this)
         val animation = getAnimationTransitionFromGesture(fromGesture)
-        intent.putExtra(FINISH_ANIMATION_EXTRA, animation.invert() as Parcelable)
+        intent.putExtra(EXTRA_FINISH_ANIMATION, animation.invert() as Parcelable)
         startActivityWithAnimation(intent, animation)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
@@ -71,7 +71,7 @@ open class SingleFragmentActivity :
         if (savedInstanceState != null) {
             return
         }
-        val assignedFragment = intent.getStringExtra(FRAGMENT_NAME_EXTRA)
+        val assignedFragment = intent.getStringExtra(EXTRA_FRAGMENT_NAME)
         // One of the activities inheriting this activity is ManageSpaceActivity which is started
         // only by the system. When we encounter this activity we need to assign it here the fragment
         // it expects, which is ManageSpaceFragment
@@ -80,14 +80,14 @@ open class SingleFragmentActivity :
                 // the IDE updates this when moving ManageSpaceFragment
                 "com.ichi2.anki.ui.windows.managespace.ManageSpaceFragment"
             } else {
-                requireNotNull(assignedFragment) { "'$FRAGMENT_NAME_EXTRA' extra should be provided" }
+                requireNotNull(assignedFragment) { "'$EXTRA_FRAGMENT_NAME' extra should be provided" }
             }
 
         Timber.d("Creating fragment %s", fragmentClassName)
 
         val fragment =
             FragmentFactoryUtils.instantiate<Fragment>(this, fragmentClassName).apply {
-                arguments = intent.getBundleExtra(FRAGMENT_ARGS_EXTRA)
+                arguments = intent.getBundleExtra(EXTRA_FRAGMENT_ARGS)
             }
         supportFragmentManager.commit {
             replace(R.id.fragment_container, fragment, FRAGMENT_TAG)
@@ -120,8 +120,8 @@ open class SingleFragmentActivity :
         get() = (fragment as? ShortcutGroupProvider)?.shortcuts
 
     companion object {
-        const val FRAGMENT_NAME_EXTRA = "fragmentName"
-        const val FRAGMENT_ARGS_EXTRA = "fragmentArgs"
+        const val EXTRA_FRAGMENT_NAME = "extra_fragment_name"
+        const val EXTRA_FRAGMENT_ARGS = "extra_fragment_args"
         const val FRAGMENT_TAG = "SingleFragmentActivityTag"
 
         fun getIntent(
@@ -131,8 +131,8 @@ open class SingleFragmentActivity :
             intentAction: String? = null,
         ): Intent =
             Intent(context, SingleFragmentActivity::class.java).apply {
-                putExtra(FRAGMENT_NAME_EXTRA, fragmentClass.jvmName)
-                putExtra(FRAGMENT_ARGS_EXTRA, arguments)
+                putExtra(EXTRA_FRAGMENT_NAME, fragmentClass.jvmName)
+                putExtra(EXTRA_FRAGMENT_ARGS, arguments)
                 action = intentAction
             }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaActivity.kt
@@ -66,7 +66,7 @@ class MultimediaActivity :
     private val binding by viewBinding(ActivityMultimediaBinding::bind)
 
     private val Intent.multimediaArgsExtra: MultimediaActivityExtra?
-        get() = extras?.getSerializableCompat(MULTIMEDIA_ARGS_EXTRA)
+        get() = extras?.getSerializableCompat(EXTRA_FRAGMENT_ARGS)
 
     private val Intent.mediaOptionsExtra: Serializable?
         get() = getSerializableExtraCompat(EXTRA_MEDIA_OPTIONS)
@@ -88,15 +88,15 @@ class MultimediaActivity :
         }
 
         val fragmentClassName =
-            requireNotNull(intent.getStringExtra(MULTIMEDIA_FRAGMENT_NAME_EXTRA)) {
-                "'$MULTIMEDIA_FRAGMENT_NAME_EXTRA' extra should be provided"
+            requireNotNull(intent.getStringExtra(EXTRA_FRAGMENT_NAME)) {
+                "'$EXTRA_FRAGMENT_NAME' extra should be provided"
             }
 
         val fragment =
             FragmentFactoryUtils.instantiate<Fragment>(this, fragmentClassName).apply {
                 arguments =
                     Bundle().apply {
-                        putSerializable(MULTIMEDIA_ARGS_EXTRA, intent.multimediaArgsExtra)
+                        putSerializable(EXTRA_FRAGMENT_ARGS, intent.multimediaArgsExtra)
                         putSerializable(EXTRA_MEDIA_OPTIONS, intent.mediaOptionsExtra)
                     }
             }
@@ -123,8 +123,8 @@ class MultimediaActivity :
     }
 
     companion object {
-        const val MULTIMEDIA_ARGS_EXTRA = "fragmentArgs"
-        const val MULTIMEDIA_FRAGMENT_NAME_EXTRA = "fragmentName"
+        const val EXTRA_FRAGMENT_ARGS = "extra_fragment_args"
+        const val EXTRA_FRAGMENT_NAME = "extra_fragment_name"
 
         /** used in case a fragment supports more than media operations **/
         const val EXTRA_MEDIA_OPTIONS = "extra_media_options"
@@ -136,8 +136,8 @@ class MultimediaActivity :
             mediaOptions: Serializable? = null,
         ): Intent =
             Intent(context, MultimediaActivity::class.java).apply {
-                putExtra(MULTIMEDIA_ARGS_EXTRA, arguments)
-                putExtra(MULTIMEDIA_FRAGMENT_NAME_EXTRA, fragmentClass.jvmName)
+                putExtra(EXTRA_FRAGMENT_ARGS, arguments)
+                putExtra(EXTRA_FRAGMENT_NAME, fragmentClass.jvmName)
                 putExtra(EXTRA_MEDIA_OPTIONS, mediaOptions)
             }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaFragment.kt
@@ -88,7 +88,7 @@ abstract class MultimediaFragment(
             @Suppress("USELESS_CAST")
             val multimediaActivityExtra =
                 arguments?.getSerializableCompat<MultimediaActivityExtra>(
-                    MultimediaActivity.MULTIMEDIA_ARGS_EXTRA,
+                    MultimediaActivity.EXTRA_FRAGMENT_ARGS,
                 )
 
             if (multimediaActivityExtra != null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
@@ -113,7 +113,7 @@ sealed interface NoteEditorLauncher : Destination {
         override fun toBundle(): Bundle =
             Bundle().apply {
                 putInt(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.REVIEWER_ADD.value)
-                animation?.let { putParcelable(AnkiActivity.FINISH_ANIMATION_EXTRA, it as Parcelable) }
+                animation?.let { putParcelable(AnkiActivity.EXTRA_FINISH_ANIMATION, it as Parcelable) }
             }
     }
 
@@ -150,7 +150,7 @@ sealed interface NoteEditorLauncher : Destination {
                 putLong(NoteEditorFragment.EXTRA_CARD_ID, cardIds.first())
                 // To handle multi select and note edit
                 putLongArray(NoteEditorFragment.EXTRA_CARD_IDS, cardIds.toLongArray())
-                putParcelable(AnkiActivity.FINISH_ANIMATION_EXTRA, animation as Parcelable)
+                putParcelable(AnkiActivity.EXTRA_FINISH_ANIMATION, animation as Parcelable)
                 putBoolean(NoteEditorFragment.IN_CARD_BROWSER_ACTIVITY, inCardBrowserActivity)
             }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
@@ -110,7 +110,7 @@ class AboutFragment : Fragment(R.layout.fragment_about) {
         binding.openChangelog.setOnClickListener {
             val openChangelogIntent =
                 Intent(requireContext(), Info::class.java).apply {
-                    putExtra(Info.TYPE_EXTRA, Info.TYPE_NEW_VERSION)
+                    putExtra(Info.EXTRA_TYPE, Info.TYPE_NEW_VERSION)
                 }
             startActivity(openChangelogIntent)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -207,10 +207,10 @@ class PreferencesFragment :
     /**
      * Starts the first settings fragment, which by default is [HeaderFragment].
      * The initial fragment may be overridden by putting the java class name
-     * of the fragment on an intent extra with the key [INITIAL_FRAGMENT_EXTRA]
+     * of the fragment on an intent extra with the key [EXTRA_INITIAL_FRAGMENT]
      */
     private fun loadInitialSubscreen() {
-        val fragmentClassName = arguments?.getString(INITIAL_FRAGMENT_EXTRA)
+        val fragmentClassName = arguments?.getString(EXTRA_INITIAL_FRAGMENT)
         val initialFragment =
             if (fragmentClassName == null) {
                 if (!settingsIsSplit) HeaderFragment() else GeneralSettingsFragment()
@@ -249,10 +249,10 @@ class PreferencesActivity :
             context: Context,
             initialFragment: KClass<out Fragment>? = null,
         ): Intent {
-            val arguments = Bundle().apply { putString(INITIAL_FRAGMENT_EXTRA, initialFragment?.jvmName) }
+            val arguments = Bundle().apply { putString(EXTRA_INITIAL_FRAGMENT, initialFragment?.jvmName) }
             return Intent(context, PreferencesActivity::class.java).apply {
-                putExtra(FRAGMENT_NAME_EXTRA, PreferencesFragment::class.jvmName)
-                putExtra(FRAGMENT_ARGS_EXTRA, arguments)
+                putExtra(EXTRA_FRAGMENT_NAME, PreferencesFragment::class.jvmName)
+                putExtra(EXTRA_FRAGMENT_ARGS, arguments)
             }
         }
     }
@@ -262,7 +262,7 @@ class PreferencesActivity :
 @LegacyNotifications("Magic number which is no longer needed")
 const val PENDING_NOTIFICATIONS_ONLY = 1000000
 
-const val INITIAL_FRAGMENT_EXTRA = "initial_fragment"
+const val EXTRA_INITIAL_FRAGMENT = "initial_fragment"
 
 /**
  * @return the [SettingsFragment] which uses the given [screen] resource.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerActivity.kt
@@ -41,8 +41,8 @@ class CardViewerActivity : SingleFragmentActivity() {
             arguments: Bundle? = null,
         ): Intent =
             Intent(context, CardViewerActivity::class.java).apply {
-                putExtra(FRAGMENT_NAME_EXTRA, fragmentClass.jvmName)
-                putExtra(FRAGMENT_ARGS_EXTRA, arguments)
+                putExtra(EXTRA_FRAGMENT_NAME, fragmentClass.jvmName)
+                putExtra(EXTRA_FRAGMENT_ARGS, arguments)
             }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivity.kt
@@ -63,9 +63,9 @@ class PermissionsActivity : AnkiActivity(R.layout.activity_permissions) {
         binding.continueButton.setOnClickListener { finish() }
 
         // #20881: Activity should not be launchd without extras
-        val permissionSet = IntentCompat.getParcelableExtra(intent, PERMISSIONS_SET_EXTRA, PermissionSet::class.java)
+        val permissionSet = IntentCompat.getParcelableExtra(intent, EXTRA_PERMISSIONS_SET, PermissionSet::class.java)
         if (permissionSet == null) {
-            Timber.w("PERMISSIONS_SET_EXTRA not set; finishing")
+            Timber.w("EXTRA_PERMISSIONS_SET not set; finishing")
             showThemedToast(this, R.string.something_wrong, false)
             setResult(RESULT_CANCELED)
             finish()
@@ -92,14 +92,14 @@ class PermissionsActivity : AnkiActivity(R.layout.activity_permissions) {
     }
 
     companion object {
-        const val PERMISSIONS_SET_EXTRA = "permissionsSet"
+        const val EXTRA_PERMISSIONS_SET = "permissionsSet"
 
         fun getIntent(
             context: Context,
             permissionsSet: PermissionSet,
         ): Intent =
             Intent(context, PermissionsActivity::class.java).apply {
-                putExtra(PERMISSIONS_SET_EXTRA, permissionsSet as Parcelable)
+                putExtra(EXTRA_PERMISSIONS_SET, permissionsSet as Parcelable)
             }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ConfigAwareSingleFragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ConfigAwareSingleFragmentActivity.kt
@@ -40,8 +40,8 @@ class ConfigAwareSingleFragmentActivity : SingleFragmentActivity() {
             intentAction: String? = null,
         ): Intent =
             Intent(context, ConfigAwareSingleFragmentActivity::class.java).apply {
-                putExtra(FRAGMENT_NAME_EXTRA, fragmentClass.jvmName)
-                putExtra(FRAGMENT_ARGS_EXTRA, arguments)
+                putExtra(EXTRA_FRAGMENT_NAME, fragmentClass.jvmName)
+                putExtra(EXTRA_FRAGMENT_ARGS, arguments)
                 action = intentAction
             }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -16,7 +16,7 @@ import anki.scheduler.CardAnswer.Rating
 import com.ichi2.anki.AbstractFlashcardViewer.Companion.toAnimationTransition
 import com.ichi2.anki.AbstractFlashcardViewer.Signal
 import com.ichi2.anki.AbstractFlashcardViewer.Signal.Companion.toSignal
-import com.ichi2.anki.AnkiActivity.Companion.FINISH_ANIMATION_EXTRA
+import com.ichi2.anki.AnkiActivity.Companion.EXTRA_FINISH_ANIMATION
 import com.ichi2.anki.NoteEditorFragment.Companion.NoteEditorCaller
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.ViewerCommand
@@ -216,13 +216,13 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
                 Bundle().apply {
                     putInt(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.EDIT.value)
                     putLong(NoteEditorFragment.EXTRA_CARD_ID, viewer.currentCard!!.id)
-                    putParcelable(FINISH_ANIMATION_EXTRA, animation as Parcelable)
+                    putParcelable(EXTRA_FINISH_ANIMATION, animation as Parcelable)
                 }
             val noteEditor = openNoteEditorWithArgs(bundle)
             val actualInverseAnimation =
                 BundleCompat.getParcelable(
                     noteEditor.requireArguments(),
-                    FINISH_ANIMATION_EXTRA,
+                    EXTRA_FINISH_ANIMATION,
                     TransitionDirection::class.java,
                 )
             assertEquals(expectedInverseAnimation, actualInverseAnimation)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -40,7 +40,7 @@ import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.ui.windows.permissions.PermissionsActivity
-import com.ichi2.anki.ui.windows.permissions.PermissionsActivity.Companion.PERMISSIONS_SET_EXTRA
+import com.ichi2.anki.ui.windows.permissions.PermissionsActivity.Companion.EXTRA_PERMISSIONS_SET
 import com.ichi2.anki.utils.Destination
 import com.ichi2.anki.utils.ext.defaultConfig
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
@@ -818,7 +818,7 @@ class DeckPickerTest : RobolectricTest() {
                         equalTo(PermissionsActivity::class.java.name),
                     )
 
-                    val extra = IntentCompat.getParcelableExtra(intent, PERMISSIONS_SET_EXTRA, PermissionSet::class.java)
+                    val extra = IntentCompat.getParcelableExtra(intent, EXTRA_PERMISSIONS_SET, PermissionSet::class.java)
 
                     assertNotNull(extra)
                     assertThat(extra.permissions, equalTo(listOf(INTERNET)))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/IntroductionActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/IntroductionActivityTest.kt
@@ -20,7 +20,7 @@ import android.Manifest.permission.INTERNET
 import android.content.Intent
 import android.os.Bundle
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.anki.SingleFragmentActivity.Companion.FRAGMENT_NAME_EXTRA
+import com.ichi2.anki.SingleFragmentActivity.Companion.EXTRA_FRAGMENT_NAME
 import com.ichi2.anki.account.LoginFragment
 import com.ichi2.anki.introduction.SetupCollectionFragment
 import com.ichi2.anki.introduction.SetupCollectionFragment.CollectionSetupOption.DeckPickerWithNewCollection
@@ -73,7 +73,7 @@ class IntroductionActivityTest : RobolectricTest() {
             )
             assertThat(
                 "hosted fragment is LoginFragment",
-                intent.getStringExtra(FRAGMENT_NAME_EXTRA),
+                intent.getStringExtra(EXTRA_FRAGMENT_NAME),
                 equalTo(LoginFragment::class.jvmName),
             )
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -133,7 +133,7 @@ class ReviewerTest : RobolectricTest() {
         val actualAnimation =
             BundleCompat.getParcelable(
                 intent.extras!!,
-                AnkiActivity.FINISH_ANIMATION_EXTRA,
+                AnkiActivity.EXTRA_FINISH_ANIMATION,
                 TransitionDirection::class.java,
             )
         val expectedAnimation =

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivityTest.kt
@@ -55,7 +55,7 @@ class PermissionsActivityTest : RobolectricTest() {
     }
 
     @Test
-    fun `error toast is shown if PERMISSIONS_SET_EXTRA is missing`() {
+    fun `error toast is shown if EXTRA_PERMISSIONS_SET is missing`() {
         testInvalidActivityFinishes()
         assertThat(
             ShadowToast.getTextOfLatestToast(),


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

> [!NOTE]
> Assisted-by: Composer 2.5

## Purpose / Description
While working on a PR for fixing up naming conventions, I found some extras that have _EXTRA rather than a leading EXTRA_ in their name. It was annoying me, so here's a quick commit to fix it. I originally tried fully enforcing the leading EXTRA_ convention across all intent extras, but that got out of control really quickly, so here's a smaller incremental PR for now.

## Fixes
* Part of https://github.com/ankidroid/Anki-Android/issues/19896

## Approach
Simple renaming.

## How Has This Been Tested?
App builds, unit tests pass.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->