### PR TITLE
refactor: replace ARGS_ with ARG_, standardize requireParcelable usage

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -146,6 +146,7 @@ import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.ui.setupNoteTypeSpinner
 import com.ichi2.anki.utils.RunOnlyOnce
+import com.ichi2.anki.utils.ext.requireLong
 import com.ichi2.anki.utils.ext.sharedPrefs
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.utils.ext.window
@@ -640,7 +641,7 @@ class NoteEditorFragment :
                 return
             }
             NoteEditorCaller.EDIT -> {
-                val cardId = requireNotNull(requireArguments().getLong(EXTRA_CARD_ID)) { "EXTRA_CARD_ID" }
+                val cardId = requireArguments().requireLong(EXTRA_CARD_ID)
                 currentEditedCard = col.getCard(cardId)
                 editorNote = currentEditedCard!!.note(col)
                 addNote = false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserColumnSelectionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserColumnSelectionFragment.kt
@@ -41,6 +41,7 @@ import com.ichi2.anki.dialogs.DiscardChangesDialog
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.model.CardsOrNotes
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.utils.ext.requireParcelable
 import com.ichi2.anki.withProgress
 import dev.androidbroadcast.vbpd.viewBinding
 import timber.log.Timber
@@ -76,11 +77,9 @@ class BrowserColumnSelectionFragment : DialogFragment(R.layout.dialog_browser_co
     private val onBackPressedDispatcher
         get() = (dialog as ComponentDialog).onBackPressedDispatcher
 
-    private val cardsOrNotes: CardsOrNotes
-        get() =
-            requireNotNull(
-                BundleCompat.getParcelable(requireArguments(), ARG_MODE, CardsOrNotes::class.java),
-            )
+    private val cardsOrNotes: CardsOrNotes by lazy {
+        requireArguments().requireParcelable(ARG_MODE)
+    }
 
     private val discardChangesCallback =
         object : OnBackPressedCallback(enabled = false) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/ColumnSelectionDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/ColumnSelectionDialogFragment.kt
@@ -29,6 +29,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import com.ichi2.anki.R
 import com.ichi2.anki.databinding.ItemColumnSelectionBinding
+import com.ichi2.anki.utils.ext.requireParcelable
 import com.ichi2.utils.dp
 import com.ichi2.utils.setPaddingRelative
 import kotlinx.coroutines.launch
@@ -36,11 +37,9 @@ import timber.log.Timber
 
 class ColumnSelectionDialogFragment : DialogFragment() {
     private val viewModel: CardBrowserViewModel by activityViewModels()
-    private val columnToReplace: ColumnHeading
-        get() =
-            requireNotNull(
-                BundleCompat.getParcelable(requireArguments(), SELECTED_COLUMN, ColumnHeading::class.java),
-            )
+    private val columnToReplace: ColumnHeading by lazy {
+        requireArguments().requireParcelable(SELECTED_COLUMN)
+    }
 
     private var availableColumns: List<ColumnWithSample> = emptyList()
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/FindAndReplaceDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/FindAndReplaceDialogFragment.kt
@@ -11,7 +11,6 @@ import android.widget.ArrayAdapter
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.Companion.PRIVATE
 import androidx.appcompat.app.AlertDialog
-import androidx.core.os.BundleCompat
 import androidx.core.text.HtmlCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.setFragmentResult
@@ -33,6 +32,7 @@ import com.ichi2.anki.libanki.NoteId
 import com.ichi2.anki.notetype.ManageNotetypes
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.internationalization.sentenceCase
+import com.ichi2.anki.utils.ext.requireParcelable
 import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.anki.utils.openUrl
 import com.ichi2.utils.customView
@@ -58,15 +58,9 @@ import timber.log.Timber
 class FindAndReplaceDialogFragment : AnalyticsDialogFragment() {
     private lateinit var binding: FragmentFindReplaceBinding
 
-    private val idsFile: IdsFile
-        get() =
-            requireNotNull(
-                BundleCompat.getParcelable(
-                    requireArguments(),
-                    ARG_IDS,
-                    IdsFile::class.java,
-                ),
-            )
+    private val idsFile: IdsFile by lazy {
+        requireArguments().requireParcelable(ARG_IDS)
+    }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         binding = FragmentFindReplaceBinding.inflate(layoutInflater)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ConfirmationDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ConfirmationDialog.kt
@@ -21,6 +21,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
 import com.ichi2.anki.R
 import com.ichi2.anki.utils.ext.ifNullOrEmpty
+import com.ichi2.anki.utils.ext.requireString
 import com.ichi2.utils.create
 import com.ichi2.utils.message
 import com.ichi2.utils.negativeButton
@@ -32,11 +33,9 @@ import com.ichi2.utils.title
  * Create a new instance, call setArgs(...), setConfirm(), and setCancel() then show it via the fragment manager as usual.
  */
 class ConfirmationDialog : DialogFragment() {
-    private val message: String
-        get() =
-            requireNotNull(requireArguments().getString(ARG_MESSAGE)) {
-                ARG_MESSAGE
-            }
+    private val message: String by lazy {
+        requireArguments().requireString(ARG_MESSAGE)
+    }
 
     private val title: String
         get() =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/FieldSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/FieldSelectionDialog.kt
@@ -18,7 +18,6 @@ package com.ichi2.anki.dialogs
 
 import android.app.Dialog
 import android.os.Bundle
-import androidx.core.os.BundleCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.LifecycleOwner
@@ -50,10 +49,9 @@ class FieldSelectionDialog : DialogFragment() {
                 ARG_FIELD_NAMES
             }
 
-    val resultType get() =
-        requireNotNull(BundleCompat.getParcelable(requireArguments(), RESULT_TYPE, ResultType::class.java)) {
-            RESULT_TYPE
-        }
+    val resultType: ResultType by lazy {
+        requireArguments().requireParcelable(RESULT_TYPE)
+    }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
         MaterialAlertDialogBuilder(requireContext()).create {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/InsertFieldDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/InsertFieldDialog.kt
@@ -36,6 +36,7 @@ import com.ichi2.anki.dialogs.InsertFieldDialogViewModel.Tab
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.model.SpecialField
 import com.ichi2.anki.model.SpecialFields
+import com.ichi2.anki.utils.ext.requireString
 import dev.androidbroadcast.vbpd.viewBinding
 import org.jetbrains.annotations.VisibleForTesting
 
@@ -47,11 +48,9 @@ import org.jetbrains.annotations.VisibleForTesting
  */
 class InsertFieldDialog : DialogFragment(R.layout.dialog_insert_field) {
     private val viewModel by viewModels<InsertFieldDialogViewModel>()
-    private val requestKey
-        get() =
-            requireNotNull(requireArguments().getString(KEY_REQUEST_KEY)) {
-                KEY_REQUEST_KEY
-            }
+    private val requestKey: String by lazy {
+        requireArguments().requireString(KEY_REQUEST_KEY)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SimpleMessageDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SimpleMessageDialog.kt
@@ -33,7 +33,7 @@ class SimpleMessageDialog : AsyncDialogFragment() {
             setTitle(notificationTitle)
             setMessage(notificationMessage)
             setPositiveButton(R.string.dialog_ok) { _, _ ->
-                activity?.dismissSimpleMessageDialog(requireArguments().getBoolean(ARGS_RELOAD))
+                activity?.dismissSimpleMessageDialog(requireArguments().getBoolean(ARG_RELOAD))
             }
         }
     }
@@ -53,7 +53,7 @@ class SimpleMessageDialog : AsyncDialogFragment() {
 
     override val notificationTitle: String
         get() {
-            val title = requireArguments().getString(ARGS_TITLE)!!
+            val title = requireArguments().getString(ARG_TITLE)!!
             return if ("" != title) {
                 title
             } else {
@@ -63,21 +63,21 @@ class SimpleMessageDialog : AsyncDialogFragment() {
 
     override val notificationMessage: String?
         get() {
-            return requireArguments().getString(ARGS_MESSAGE)
+            return requireArguments().getString(ARG_MESSAGE)
         }
 
     companion object {
         /** The title of the notification/dialog */
-        private const val ARGS_TITLE = "title"
+        private const val ARG_TITLE = "arg_title"
 
         /** The content of the notification/dialog */
-        private const val ARGS_MESSAGE = "message"
+        private const val ARG_MESSAGE = "arg_message"
 
         /**
          * If the calling activity should be reloaded when 'OK' is pressed.
          * @see dismissSimpleMessageDialog
          */
-        private const val ARGS_RELOAD = "reload"
+        private const val ARG_RELOAD = "arg_reload"
 
         fun newInstance(
             title: String,
@@ -86,9 +86,9 @@ class SimpleMessageDialog : AsyncDialogFragment() {
         ): SimpleMessageDialog {
             val f = SimpleMessageDialog()
             val args = Bundle()
-            args.putString(ARGS_TITLE, title)
-            args.putString(ARGS_MESSAGE, message)
-            args.putBoolean(ARGS_RELOAD, reload)
+            args.putString(ARG_TITLE, title)
+            args.putString(ARG_MESSAGE, message)
+            args.putBoolean(ARG_RELOAD, reload)
             f.arguments = args
             return f
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
@@ -41,6 +41,7 @@ import com.ichi2.anki.libanki.NoteId
 import com.ichi2.anki.libanki.withCollapsedWhitespace
 import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.utils.ext.requireParcelable
 import com.ichi2.ui.AccessibleSearchView
 import com.ichi2.utils.DisplayUtils.resizeWhenSoftInputShown
 import com.ichi2.utils.TagsUtil
@@ -91,12 +92,7 @@ class TagsDialog : AnalyticsDialogFragment {
 
     @VisibleForTesting
     val viewModel: TagsDialogViewModel by viewModels {
-        val idsFile =
-            requireNotNull(
-                BundleCompat.getParcelable(requireArguments(), ARG_TAGS_FILE, IdsFile::class.java),
-            ) {
-                "$ARG_TAGS_FILE is required"
-            }
+        val idsFile = requireArguments().requireParcelable<IdsFile>(ARG_TAGS_FILE)
         val noteIds = idsFile.getIds()
         val checkedTags =
             requireNotNull(requireArguments().getStringArrayList(ARG_CHECKED_TAGS)) {
@@ -157,12 +153,7 @@ class TagsDialog : AnalyticsDialogFragment {
         super.onCreate(savedInstanceState)
         resizeWhenSoftInputShown(requireActivity().window)
 
-        type =
-            requireNotNull(
-                BundleCompat.getParcelable(requireArguments(), ARG_DIALOG_TYPE, DialogType::class.java),
-            ) {
-                "$ARG_DIALOG_TYPE is required"
-            }
+        type = requireArguments().requireParcelable(ARG_DIALOG_TYPE)
         isCancelable = true
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/ImageOcclusion.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/ImageOcclusion.kt
@@ -36,7 +36,7 @@ import com.ichi2.anki.dialogs.startDeckSelection
 import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.pages.viewmodel.ImageOcclusionArgs
 import com.ichi2.anki.pages.viewmodel.ImageOcclusionViewModel
-import com.ichi2.anki.pages.viewmodel.ImageOcclusionViewModel.Companion.IO_ARGS_KEY
+import com.ichi2.anki.pages.viewmodel.ImageOcclusionViewModel.Companion.ARG_IMAGE_OCCLUSION
 import com.ichi2.anki.utils.ext.launchCollectionInLifecycleScope
 import timber.log.Timber
 
@@ -62,7 +62,7 @@ class ImageOcclusion : PageFragment(R.layout.page_image_occlusion) {
 
     override val pagePath: String by lazy {
         val args =
-            BundleCompat.getParcelable(requireArguments(), IO_ARGS_KEY, ImageOcclusionArgs::class.java)
+            BundleCompat.getParcelable(requireArguments(), ARG_IMAGE_OCCLUSION, ImageOcclusionArgs::class.java)
                 ?: throw IllegalArgumentException("IO args were not setup correctly")
         val suffix =
             when (args) {
@@ -151,7 +151,7 @@ class ImageOcclusion : PageFragment(R.layout.page_image_occlusion) {
             context: Context,
             args: ImageOcclusionArgs,
         ): Intent {
-            val arguments = Bundle().apply { putParcelable(IO_ARGS_KEY, args) }
+            val arguments = Bundle().apply { putParcelable(ARG_IMAGE_OCCLUSION, args) }
             return SingleFragmentActivity.getIntent(context, ImageOcclusion::class, arguments)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/viewmodel/ImageOcclusionViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/viewmodel/ImageOcclusionViewModel.kt
@@ -88,7 +88,7 @@ class ImageOcclusionViewModel(
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
     val args: ImageOcclusionArgs =
-        checkNotNull(savedStateHandle[IO_ARGS_KEY]) { "$IO_ARGS_KEY required" }
+        checkNotNull(savedStateHandle[ARG_IMAGE_OCCLUSION]) { "$ARG_IMAGE_OCCLUSION required" }
 
     private val originalDeckId: DeckId? = (args as? ImageOcclusionArgs.Add)?.originalDeckId
 
@@ -157,6 +157,6 @@ class ImageOcclusionViewModel(
     }
 
     companion object {
-        const val IO_ARGS_KEY = "IMAGE_OCCLUSION_ARGS"
+        const val ARG_IMAGE_OCCLUSION = "arg_image_occlusion"
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerFragment.kt
@@ -97,11 +97,11 @@ class TemplatePreviewerFragment :
     suspend fun getSafeClozeOrd(): CardOrdinal = viewModel.getSafeClozeOrd()
 
     companion object {
-        const val ARGS_KEY = "templatePreviewerArgs"
+        const val ARG_KEY = "arg_key"
 
         fun newInstance(arguments: TemplatePreviewerArguments): TemplatePreviewerFragment =
             TemplatePreviewerFragment().apply {
-                val args = Bundle().apply { putParcelable(ARGS_KEY, arguments) }
+                val args = Bundle().apply { putParcelable(ARG_KEY, arguments) }
                 this.arguments = args
             }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerPage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerPage.kt
@@ -25,7 +25,7 @@ import androidx.fragment.app.commitNow
 import androidx.lifecycle.lifecycleScope
 import com.ichi2.anki.R
 import com.ichi2.anki.databinding.FragmentTemplatePreviewerContainerBinding
-import com.ichi2.anki.previewer.TemplatePreviewerFragment.Companion.ARGS_KEY
+import com.ichi2.anki.previewer.TemplatePreviewerFragment.Companion.ARG_KEY
 import com.ichi2.anki.utils.ext.doOnTabSelected
 import dev.androidbroadcast.vbpd.viewBinding
 import kotlinx.coroutines.launch
@@ -48,7 +48,7 @@ class TemplatePreviewerPage : Fragment(R.layout.fragment_template_previewer_cont
 
         val fragment: TemplatePreviewerFragment
         if (savedInstanceState == null) {
-            val arguments = BundleCompat.getParcelable(requireArguments(), ARGS_KEY, TemplatePreviewerArguments::class.java)!!
+            val arguments = BundleCompat.getParcelable(requireArguments(), ARG_KEY, TemplatePreviewerArguments::class.java)!!
             fragment = TemplatePreviewerFragment.newInstance(arguments)
             childFragmentManager.commitNow {
                 replace(R.id.fragment_container, fragment)
@@ -87,7 +87,7 @@ class TemplatePreviewerPage : Fragment(R.layout.fragment_template_previewer_cont
             CardViewerActivity.getIntent(
                 context,
                 TemplatePreviewerPage::class,
-                Bundle().apply { putParcelable(ARGS_KEY, arguments) },
+                Bundle().apply { putParcelable(ARG_KEY, arguments) },
             )
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
@@ -71,7 +71,7 @@ class TemplatePreviewerViewModel(
     internal val cardsWithEmptyFronts: Deferred<List<Boolean>>?
 
     init {
-        val arguments = savedStateHandle.require<TemplatePreviewerArguments>(TemplatePreviewerFragment.ARGS_KEY)
+        val arguments = savedStateHandle.require<TemplatePreviewerArguments>(TemplatePreviewerFragment.ARG_KEY)
         notetype = arguments.notetype
         fillEmpty = arguments.fillEmpty
         isCloze = notetype.isCloze
@@ -302,7 +302,7 @@ data class TemplatePreviewerArguments(
          */
         fun isUsable(bundle: Bundle): Boolean =
             BundleCompat
-                .getParcelable(bundle, TemplatePreviewerFragment.ARGS_KEY, TemplatePreviewerArguments::class.java)
+                .getParcelable(bundle, TemplatePreviewerFragment.ARG_KEY, TemplatePreviewerArguments::class.java)
                 ?.notetypeFile
                 ?.getNotetypeOrNull() != null
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
@@ -47,6 +47,7 @@ import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.ext.getParcelableCompat
+import com.ichi2.anki.utils.ext.requireParcelable
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.utils.showDialogFragment
 import com.ichi2.utils.DisplayUtils.resizeWhenSoftInputShown
@@ -92,11 +93,7 @@ class AddEditReminderDialog : DialogFragment() {
      * @see DialogMode
      */
     private val dialogMode: DialogMode by lazy {
-        requireNotNull(
-            requireArguments().getParcelableCompat<DialogMode>(ARG_DIALOG_MODE),
-        ) {
-            "Dialog mode cannot be null"
-        }
+        requireArguments().requireParcelable(ARG_DIALOG_MODE)
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
@@ -93,7 +93,7 @@ class AddEditReminderDialog : DialogFragment() {
      */
     private val dialogMode: DialogMode by lazy {
         requireNotNull(
-            requireArguments().getParcelableCompat<DialogMode>(ARGS_DIALOG_MODE),
+            requireArguments().getParcelableCompat<DialogMode>(ARG_DIALOG_MODE),
         ) {
             "Dialog mode cannot be null"
         }
@@ -378,7 +378,7 @@ class AddEditReminderDialog : DialogFragment() {
          *
          * @see DialogMode
          */
-        const val ARGS_DIALOG_MODE = "args_dialog_mode"
+        const val ARG_DIALOG_MODE = "arg_dialog_mode"
 
         /**
          * Fragment result key for receiving the result of a recently closed [AddEditReminderDialog].
@@ -427,7 +427,7 @@ class AddEditReminderDialog : DialogFragment() {
             AddEditReminderDialog().apply {
                 arguments =
                     Bundle().apply {
-                        putParcelable(ARGS_DIALOG_MODE, dialogMode)
+                        putParcelable(ARG_DIALOG_MODE, dialogMode)
                     }
             }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialogViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialogViewModel.kt
@@ -39,7 +39,7 @@ class AddEditReminderDialogViewModel(
      */
     private val dialogMode =
         requireNotNull(
-            savedStateHandle.get<AddEditReminderDialog.DialogMode>(AddEditReminderDialog.ARGS_DIALOG_MODE),
+            savedStateHandle.get<AddEditReminderDialog.DialogMode>(AddEditReminderDialog.ARG_DIALOG_MODE),
         ) { "dialogMode is required" }
 
     private val _time =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
@@ -43,9 +43,9 @@ import com.ichi2.anki.databinding.FragmentReminderTroubleshootingBinding
 import com.ichi2.anki.databinding.ItemTroubleshootingCheckBinding
 import com.ichi2.anki.requireAnkiActivity
 import com.ichi2.anki.settings.Prefs
-import com.ichi2.anki.utils.ext.getParcelableCompat
 import com.ichi2.anki.utils.ext.launchCollectionInLifecycleScope
 import com.ichi2.anki.utils.ext.onWindowFocusChanged
+import com.ichi2.anki.utils.ext.requireParcelable
 import com.ichi2.anki.utils.ext.setBackgroundTint
 import com.ichi2.utils.Permissions.requestPermissionThroughDialogOrSettings
 import com.ichi2.utils.dp
@@ -84,11 +84,7 @@ class ReminderTroubleshootingFragment : Fragment(R.layout.fragment_reminder_trou
      * @see ScheduleRemindersFragment.FragmentHost
      */
     private val host: ScheduleRemindersFragment.FragmentHost by lazy {
-        requireNotNull(
-            requireArguments().getParcelableCompat<ScheduleRemindersFragment.FragmentHost>(ARG_HOST),
-        ) {
-            "Host cannot be null"
-        }
+        requireArguments().requireParcelable(ARG_HOST)
     }
 
     internal val notificationPermissionLauncher: ActivityResultLauncher<String> =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
@@ -85,7 +85,7 @@ class ReminderTroubleshootingFragment : Fragment(R.layout.fragment_reminder_trou
      */
     private val host: ScheduleRemindersFragment.FragmentHost by lazy {
         requireNotNull(
-            requireArguments().getParcelableCompat<ScheduleRemindersFragment.FragmentHost>(ARGS_HOST),
+            requireArguments().getParcelableCompat<ScheduleRemindersFragment.FragmentHost>(ARG_HOST),
         ) {
             "Host cannot be null"
         }
@@ -190,13 +190,13 @@ class ReminderTroubleshootingFragment : Fragment(R.layout.fragment_reminder_trou
         /**
          * Arguments key for specifying the host of this fragment.
          */
-        private const val ARGS_HOST = "host"
+        private const val ARG_HOST = "arg_host"
 
         fun newInstance(host: ScheduleRemindersFragment.FragmentHost): ReminderTroubleshootingFragment =
             ReminderTroubleshootingFragment().apply {
                 arguments =
                     Bundle().apply {
-                        putParcelable(ARGS_HOST, host)
+                        putParcelable(ARG_HOST, host)
                     }
                 Timber.i(
                     "Creating ReminderTroubleshootingFragment with host=%s",

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
@@ -155,7 +155,7 @@ class ScheduleRemindersFragment :
      * @see ReviewReminderScope
      */
     private val scheduleRemindersScope: ReviewReminderScope by lazy {
-        (arguments ?: Bundle()).getParcelableCompat<ReviewReminderScope>(ARGS_SCOPE)
+        (arguments ?: Bundle()).getParcelableCompat<ReviewReminderScope>(ARG_SCOPE)
             ?: ReviewReminderScope.Global
     }
 
@@ -168,7 +168,7 @@ class ScheduleRemindersFragment :
      * @see FragmentHost
      */
     private val host: FragmentHost by lazy {
-        (arguments ?: Bundle()).getParcelableCompat<FragmentHost>(ARGS_HOST)
+        (arguments ?: Bundle()).getParcelableCompat<FragmentHost>(ARG_HOST)
             ?: FragmentHost.SETTINGS
     }
 
@@ -619,12 +619,12 @@ class ScheduleRemindersFragment :
         /**
          * Arguments key for passing the [ReviewReminderScope] to open this fragment with.
          */
-        private const val ARGS_SCOPE = "scope"
+        private const val ARG_SCOPE = "arg_scope"
 
         /**
          * Arguments key for passing information about the [FragmentHost] to this fragment.
          */
-        private const val ARGS_HOST = "host"
+        private const val ARG_HOST = "arg_host"
 
         /**
          * Wrapper for database access in this fragment.
@@ -655,8 +655,8 @@ class ScheduleRemindersFragment :
                     context,
                     ScheduleRemindersFragment::class,
                     Bundle().apply {
-                        putParcelable(ARGS_SCOPE, scope)
-                        putParcelable(ARGS_HOST, FragmentHost.STANDALONE_ACTIVITY)
+                        putParcelable(ARG_SCOPE, scope)
+                        putParcelable(ARG_HOST, FragmentHost.STANDALONE_ACTIVITY)
                     },
                 ).apply {
                     Timber.i("launching ScheduleRemindersFragment for %s scope", scope)
@@ -675,8 +675,8 @@ class ScheduleRemindersFragment :
             ScheduleRemindersFragment().apply {
                 arguments =
                     Bundle().apply {
-                        putParcelable(ARGS_SCOPE, scope)
-                        putParcelable(ARGS_HOST, host)
+                        putParcelable(ARG_SCOPE, scope)
+                        putParcelable(ARG_HOST, host)
                     }
                 Timber.i(
                     "Creating ScheduleRemindersFragment for %s scope, host=%s",

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsBottomSheet.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsBottomSheet.kt
@@ -68,7 +68,7 @@ class PermissionsBottomSheet : BottomSheetDialogFragment() {
         }
 
         val permissionSet =
-            requireNotNull(requireArguments().getParcelableCompat<PermissionSet>(PERMISSION_SET_ARGUMENT_KEY)) {
+            requireNotNull(requireArguments().getParcelableCompat<PermissionSet>(ARG_PERMISSION_SET)) {
                 "Permission set cannot be null"
             }
         val permissionsFragment =
@@ -91,7 +91,7 @@ class PermissionsBottomSheet : BottomSheetDialogFragment() {
         /**
          * Arguments key for the [PermissionSet] to launch this BottomSheet with.
          */
-        private const val PERMISSION_SET_ARGUMENT_KEY = "permission_set"
+        private const val ARG_PERMISSION_SET = "arg_permission_set"
 
         /**
          * Fragment result request key for dismissing this BottomSheet.
@@ -108,7 +108,7 @@ class PermissionsBottomSheet : BottomSheetDialogFragment() {
         ) {
             val bottomSheet =
                 PermissionsBottomSheet().apply {
-                    arguments = Bundle().apply { putParcelable(PERMISSION_SET_ARGUMENT_KEY, permissionsSet) }
+                    arguments = Bundle().apply { putParcelable(ARG_PERMISSION_SET, permissionsSet) }
                 }
             bottomSheet.show(fragmentManager, FRAGMENT_TAG)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsBottomSheet.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsBottomSheet.kt
@@ -30,7 +30,7 @@ import com.ichi2.anki.PermissionSet
 import com.ichi2.anki.R
 import com.ichi2.anki.databinding.FragmentPermissionsBottomSheetBinding
 import com.ichi2.anki.utils.ext.behavior
-import com.ichi2.anki.utils.ext.getParcelableCompat
+import com.ichi2.anki.utils.ext.requireParcelable
 import dev.androidbroadcast.vbpd.viewBinding
 
 /**
@@ -67,10 +67,7 @@ class PermissionsBottomSheet : BottomSheetDialogFragment() {
             dismiss()
         }
 
-        val permissionSet =
-            requireNotNull(requireArguments().getParcelableCompat<PermissionSet>(ARG_PERMISSION_SET)) {
-                "Permission set cannot be null"
-            }
+        val permissionSet = requireArguments().requireParcelable<PermissionSet>(ARG_PERMISSION_SET)
         val permissionsFragment =
             requireNotNull(permissionSet.permissionsFragment?.getDeclaredConstructor()?.newInstance()) {
                 "invalid permissionsFragment"

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
@@ -38,6 +38,7 @@ import com.ichi2.anki.preferences.requirePreference
 import com.ichi2.anki.reviewer.Binding
 import com.ichi2.anki.reviewer.MappableBinding
 import com.ichi2.anki.reviewer.MappableBinding.Companion.toPreferenceString
+import com.ichi2.anki.utils.ext.requireString
 import com.ichi2.ui.AxisPicker
 import com.ichi2.ui.GesturePicker
 import com.ichi2.ui.KeyPicker
@@ -233,10 +234,7 @@ open class ControlPreferenceDialogFragment : DialogFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val key =
-            requireNotNull(requireArguments().getString(SettingsFragment.PREF_DIALOG_KEY)) {
-                "ControlPreferenceDialogFragment must have a 'key' argument leading to its preference"
-            }
+        val key = requireArguments().requireString(SettingsFragment.PREF_DIALOG_KEY)
         preference = (targetFragment as PreferenceFragmentCompat).requirePreference(key)
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/pages/viewmodel/ImageOcclusionViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/pages/viewmodel/ImageOcclusionViewModelTest.kt
@@ -25,7 +25,7 @@ import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.NoteId
 import com.ichi2.anki.libanki.NoteTypeId
 import com.ichi2.anki.libanki.testutils.AnkiTest
-import com.ichi2.anki.pages.viewmodel.ImageOcclusionViewModel.Companion.IO_ARGS_KEY
+import com.ichi2.anki.pages.viewmodel.ImageOcclusionViewModel.Companion.ARG_IMAGE_OCCLUSION
 import com.ichi2.anki.pages.viewmodel.NoteIdBuilder.Id
 import com.ichi2.testutils.EmptyApplication
 import com.ichi2.testutils.JvmTest
@@ -188,7 +188,7 @@ fun AnkiTest.withViewModel(
 ) = runTest {
     val savedStateHandle =
         SavedStateHandle().apply {
-            this[IO_ARGS_KEY] = args
+            this[ARG_IMAGE_OCCLUSION] = args
         }
 
     block(ImageOcclusionViewModel(savedStateHandle))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/previewer/TemplatePreviewerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/previewer/TemplatePreviewerViewModelTest.kt
@@ -37,7 +37,7 @@ class TemplatePreviewerViewModelTest : JvmTest() {
     val tempDirectory = TemporaryFolder()
 
     private fun createViewModel(arguments: TemplatePreviewerArguments): TemplatePreviewerViewModel {
-        val savedStateHandle = SavedStateHandle(mapOf(TemplatePreviewerFragment.ARGS_KEY to arguments))
+        val savedStateHandle = SavedStateHandle(mapOf(TemplatePreviewerFragment.ARG_KEY to arguments))
         val viewModel = TemplatePreviewerViewModel(savedStateHandle)
         return spyk(viewModel).apply {
             // the default implementation requires the Collection media directory,


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Composer 2.5 (for ARG_ renaming grunt work)

## Purpose / Description
Per the naming conventions we've decided on, argument constant names should begin with ARG_, not ARGS_. This change standardizes instances of ARGS_ I found in the codebase. I initially tried applying the change to all argument constants in the entire repo, but as you can guess that spiralled out of control really fast. To keep the scope limited and safe, I've just looked for all instances of "ARGS_", plus any files I've touched, and fixed those.

Also, at https://github.com/ankidroid/Anki-Android/issues/19896, David suggested using `requireParcelable` more. I find the utility functions in BundleUtils very useful and have applied them everywhere possible after looking for instances of `requireNotNull` in the codebase. This includes two review reminder instances.

## Fixes
* Part of https://github.com/ankidroid/Anki-Android/issues/19896
* Addresses some small feedback at https://github.com/ankidroid/Anki-Android/pull/21140

## Approach
Renaming PR, followed by the standardization of requireParcelable, requireString, etc.
There were some `requireNotNull` instances that grabbed things like string arrays and long arrays from Bundles: no such utility function to handle these cases exists yet in BundleUtils so I just left those as is. Could be something to return to in the future, but this is very low priority.

I also believe it is better to use `lazy` to get stored arguments rather than defining a `get() =` to avoid re-computation of something that never changes.

Overall, after applying `requireParcelable` and `lazy`, I personally think a lot of argument usages are now cleaner.

## How Has This Been Tested?
- App builds
- Unit tests pass
- Card browser and note editor works: editing cards, moving columns, selecting columns, search, tags search, adding fields
- Review reminders can be edited, deleted (includes confirmation dialog); notification permission requests work

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->