### PR TITLE
Fix scroll thumb length changing on cards /tags lists of different size rows on bug

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -898,7 +898,9 @@ class CardBrowserFragment :
             toggleRowSelections.isVisible = inMultiSelect
 
             // update adapter to remove check boxes
-            cardsAdapter.notifyDataSetChanged()
+            if (shouldRefreshBrowserRows(modeChange)) {
+                cardsAdapter.notifyDataSetChanged()
+            }
             if (modeChange is SingleSelectCause.DeselectRow) {
                 cardsAdapter.notifyDataSetChanged()
                 autoScrollTo(modeChange.selection)
@@ -1919,6 +1921,17 @@ class PreviewerDestination(
     val currentIndex: Int,
     val idsFile: IdsFile,
 )
+
+/**
+ * Opening the editor from single-select does not change row rendering, so a full adapter refresh
+ * would unnecessarily invalidate the fast scroller's cached metrics. A refresh is still needed
+ * when leaving multi-select to remove the selection UI.
+ */
+internal fun shouldRefreshBrowserRows(modeChange: ChangeMultiSelectMode): Boolean {
+    val singleSelectCause = modeChange as? SingleSelectCause ?: return true
+    return singleSelectCause != SingleSelectCause.OpenNoteEditorActivity ||
+        !singleSelectCause.previouslySelectedRowIds.isNullOrEmpty()
+}
 
 @CheckResult
 fun PreviewerDestination.toIntent(context: Context) = PreviewerFragment.getIntent(context, idsFile, currentIndex)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
@@ -41,6 +41,7 @@ import com.ichi2.anki.libanki.NoteId
 import com.ichi2.anki.libanki.withCollapsedWhitespace
 import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.ui.attachFastScroller
 import com.ichi2.anki.utils.ext.requireParcelable
 import com.ichi2.ui.AccessibleSearchView
 import com.ichi2.utils.DisplayUtils.resizeWhenSoftInputShown
@@ -230,6 +231,7 @@ class TagsDialog : AnalyticsDialogFragment {
 
             tagsArrayAdapter = TagsArrayAdapter(tags) { binding.root.showMaxTagSelectedNotice(tags) }
             binding.tagsList.adapter = tagsArrayAdapter
+            binding.tagsList.attachFastScroller(R.id.tags_scroller)
             if (tags.isEmpty) {
                 binding.noTagsTextView.visibility = View.VISIBLE
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/RecyclerFastScroller.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/RecyclerFastScroller.kt
@@ -54,6 +54,7 @@ import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.view.animation.LinearInterpolator
 import android.widget.FrameLayout
 import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
@@ -128,12 +129,51 @@ class RecyclerFastScroller
 
         private var hideOverride = false
         private var adapter: RecyclerView.Adapter<*>? = null
+
+        /** Cached geometry and calibration state used to keep the thumb stable between layouts. */
+        private var cachedScrollMetrics = CachedScrollMetrics()
+
+        /** Number of visible rows during an active drag; null when the handle is not being dragged. */
+        private var dragVisibleItemCount: Int? = null
+        private val isDraggingHandle: Boolean get() = dragVisibleItemCount != null
+
+        /** Whether the list was at the bottom on the previous layout; null before the first layout. */
+        private var previousLayoutWasAtBottom: Boolean? = null
+
+        /** Active bottom-animation target; null when no such animation is running. */
+        private var handleAnimationTargetY: Float? = null
+
+        private fun invalidateScrollMetrics() {
+            cachedScrollMetrics = CachedScrollMetrics()
+            previousLayoutWasAtBottom = null
+            handleAnimationTargetY = null
+        }
+
+        private fun onAdapterDataChanged() {
+            invalidateScrollMetrics()
+            requestLayout()
+        }
+
+        /**
+         * Observes structural adapter changes that invalidate the cached scroll geometry.
+         * Content-only updates intentionally keep the current thumb size and position.
+         */
         private val adapterObserver: RecyclerView.AdapterDataObserver =
             object : RecyclerView.AdapterDataObserver() {
-                override fun onChanged() {
-                    super.onChanged()
-                    requestLayout()
-                }
+                override fun onChanged() = onAdapterDataChanged()
+
+                // Content-only row updates, such as focus or selection changes, intentionally use
+                // the default no-op callback so they cannot move or resize the scroll thumb.
+
+                override fun onItemRangeInserted(
+                    positionStart: Int,
+                    itemCount: Int,
+                ) = onAdapterDataChanged()
+
+                override fun onItemRangeRemoved(
+                    positionStart: Int,
+                    itemCount: Int,
+                ) = onAdapterDataChanged()
             }
 
         /**
@@ -263,6 +303,12 @@ class RecyclerFastScroller
                         dy: Int,
                     ) {
                         super.onScrolled(recyclerView, dx, dy)
+                        // Track normal list scrolling from real pixel deltas. While the handle is being dragged,
+                        // the offset is set from the drag position instead, so do not apply RecyclerView's dy too.
+                        if (!isDraggingHandle) {
+                            val scrollablePixels = resolveScrollablePixels(recyclerView)
+                            updateCachedScrollMetricsAfterScroll(recyclerView, dy, scrollablePixels)
+                        }
                         this@RecyclerFastScroller.show(true)
                     }
                 },
@@ -275,6 +321,7 @@ class RecyclerFastScroller
             this.adapter?.unregisterAdapterDataObserver(adapterObserver)
             adapter?.registerAdapterDataObserver(adapterObserver)
             this.adapter = adapter
+            invalidateScrollMetrics()
         }
 
         /**
@@ -339,10 +386,13 @@ class RecyclerFastScroller
             Runnable {
                 val lm = recyclerView?.layoutManager as? LinearLayoutManager ?: return@Runnable
                 val adapter = recyclerView?.adapter ?: return@Runnable
+                val visibleItemCount = dragVisibleItemCount ?: return@Runnable
 
                 try {
                     // Calculate the exact target including the decimal
-                    val (targetIndex, fraction) = (pendingScrollProportion.toDouble() * adapter.itemCount).wholeAndFraction()
+                    val (targetIndex, fraction) =
+                        computeDragTargetIndex(pendingScrollProportion, adapter.itemCount, visibleItemCount)
+                            .wholeAndFraction()
                     // Estimate height using the first visible view, this is a heuristic
                     val estimatedHeight = recyclerView?.getChildAt(0)?.height ?: 0
 
@@ -359,50 +409,63 @@ class RecyclerFastScroller
             return when (event.actionMasked) {
                 MotionEvent.ACTION_DOWN, MotionEvent.ACTION_MOVE -> {
                     // Retrieve the adapter to determine item count.
-                    val adapter = recyclerView?.adapter ?: return false
+                    val recyclerView = recyclerView ?: return false
+                    val adapter = recyclerView.adapter ?: return false
 
                     if (adapter.itemCount == 0) return false
 
                     // Force the handle to be selected since the user is touching the track (the parent container) and not the handle itself.
                     handle.isPressed = true
+                    if (event.actionMasked == MotionEvent.ACTION_DOWN || dragVisibleItemCount == null) {
+                        dragVisibleItemCount =
+                            recyclerView.childCount.coerceIn(1, adapter.itemCount)
+                    }
+                    val visibleItemCount = dragVisibleItemCount ?: return false
 
-                    // The valid scroll area is (usable track - handle.height), since the position of the handle is defined by its top edge, we subtract it.
-                    // The usable track excludes handleBottomInset (nav bar) so the handle can't be dragged into it.
+                    // Keep the handle inside the usable track above navigation bars and rounded corners.
                     val scrollableHeight = (height - handleBottomInset) - handle.height
 
-                    // Subtract half the handle's height and divide by 2 so the handle centers below the user's finger instead of hanging above or below.
-                    // Divide by the scrollableHeight to make sure that the handle doesn't go off the screen and we use coerceAtLeast to prevent divide by 0 errors
+                    // Convert the finger's Y coordinate to track progress using the handle's center,
+                    // then clamp it so the handle cannot leave the track.
                     val scrollProportion =
                         ((event.y - handle.height / 2) / scrollableHeight.coerceAtLeast(1))
                             .coerceIn(0f, 1f)
                     pendingScrollProportion = scrollProportion
-                    // Calculates the item index we want to go to by multiplying our ScrollProportion to the item count
-                    // e.g. if we are going to 50% then 0.5*itemcount gives us the index we need.
-                    // toInt prevents decimal values, and coerceIn here makes it so when we scroll all the way to the end, we don't get an out of bounds error.
+                    val scrollablePixels = resolveScrollablePixels(recyclerView)
+                    cachedScrollMetrics =
+                        if (scrollablePixels > 0) {
+                            val scrollOffset =
+                                (scrollProportion * scrollablePixels).toInt().coerceIn(0, scrollablePixels)
+                            cachedScrollMetrics.afterDrag(scrollOffset)
+                        } else {
+                            cachedScrollMetrics.copy(scrollRangeState = ScrollRangeState.Unknown)
+                        }
+                    // Leave room for the visible items so the list reaches its last screen only at
+                    // the end of the track.
                     val targetPosition =
-                        (scrollProportion * adapter.itemCount)
+                        computeDragTargetIndex(scrollProportion, adapter.itemCount, visibleItemCount)
                             .toInt()
                             .coerceIn(0, adapter.itemCount - 1)
 
                     try {
-                        (recyclerView?.layoutManager as? LinearLayoutManager)
+                        (recyclerView.layoutManager as? LinearLayoutManager)
                             ?.scrollToPositionWithOffset(targetPosition, 0)
-                            ?: recyclerView?.scrollToPosition(targetPosition)
+                            ?: recyclerView.scrollToPosition(targetPosition)
                     } catch (e: Exception) {
                         Timber.w(e, "scrollToPosition")
                     }
 
                     // destroys any redundant calls to the scrolltask and sets a small delay to improve performance
-                    recyclerView?.removeCallbacks(scrollTask)
-                    recyclerView?.postDelayed(scrollTask, 20.milliseconds)
+                    recyclerView.removeCallbacks(scrollTask)
+                    recyclerView.postDelayed(scrollTask, 20.milliseconds)
                     true
                 }
                 MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
                     handle.isSelected = false
-                    if (recyclerView != null) {
-                        recyclerView?.let { removeCallbacks(scrollTask) }
-                        scrollTask.run()
-                    }
+                    recyclerView?.removeCallbacks(scrollTask)
+                    scrollTask.run()
+                    handle.isPressed = false
+                    dragVisibleItemCount = null
                     false
                 }
                 else -> super.onTouchEvent(event)
@@ -416,69 +479,475 @@ class RecyclerFastScroller
             right: Int,
             bottom: Int,
         ) {
+            val previousHandleVisualTop = handle.y
             super.onLayout(changed, left, top, right, bottom)
-            if (recyclerView == null) return
 
-            val scrollOffset = recyclerView!!.computeVerticalScrollOffset() + appBarLayoutOffset
-            // The content range and the visible viewport come from the RecyclerView itself.
-            // Sizing & positioning the handle against the viewport (rather than the track height)
-            // keeps it proportional even when the track is shortened to clear the navigation bar,
-            // so the handle reaches the bottom of the track exactly when the list reaches its end.
-            val verticalScrollRange = recyclerView!!.computeVerticalScrollRange()
-            val verticalScrollExtent = recyclerView!!.computeVerticalScrollExtent()
+            val recyclerView = recyclerView ?: return
+            updateScrollbarLayout(recyclerView, previousHandleVisualTop)
+        }
 
-            // The track (bar) spans the full height, but the handle travels only the area above
-            // handleBottomInset so it stays clear of the navigation bar / rounded corner.
-            val fullBarHeight = bar.height
-            val trackHeight = (fullBarHeight - handleBottomInset).coerceAtLeast(0)
-            val maxScrollOffset = (verticalScrollRange - verticalScrollExtent).coerceAtLeast(1)
-            val ratio = (scrollOffset.toFloat() / maxScrollOffset).coerceIn(0f, 1f)
+        private fun updateScrollbarLayout(
+            recyclerView: RecyclerView,
+            previousHandleVisualTop: Float,
+        ) {
+            // The adapter can be set after we were attached, so make sure our data observer is
+            // registered. Without it the cached thumb size never refreshes on a data change.
+            if (recyclerView.adapter !== adapter) attachAdapter(recyclerView.adapter)
 
-            var calculatedHandleHeight = (trackHeight.toFloat() * verticalScrollExtent / verticalScrollRange).toInt()
-            if (calculatedHandleHeight < minScrollHandleHeight) {
-                calculatedHandleHeight = minScrollHandleHeight
-            }
-
-            if (calculatedHandleHeight >= trackHeight) {
-                translationX = hiddenTranslationX.toFloat()
-                hideOverride = true
+            val itemCount = recyclerView.adapter?.itemCount ?: return
+            if (itemCount == 0) {
+                hideThumb()
                 return
             }
 
+            val fullBarHeight = height
+            val trackHeight = (fullBarHeight - handleBottomInset).coerceAtLeast(0)
+            val viewportHeight = recyclerView.computeVerticalScrollExtent()
+            val lastRowBottomEdge = layoutBarToLastRow(recyclerView, fullBarHeight)
+            if (trackHeight == 0 || viewportHeight == 0) return
+
             hideOverride = false
 
-            val y = ratio * (trackHeight - calculatedHandleHeight)
+            val measuredScrollRange = recyclerView.computeVerticalScrollRange()
+            val scrollRange =
+                resolveScrollRange(
+                    itemCount = itemCount,
+                    trackHeight = trackHeight,
+                    viewportHeight = viewportHeight,
+                    width = recyclerView.width,
+                    scrollRange = measuredScrollRange,
+                )
+            if (scrollRange <= viewportHeight) {
+                hideThumb()
+                return
+            }
 
-            handle.layout(handle.left, y.toInt(), handle.right, y.toInt() + calculatedHandleHeight)
+            val scrollablePixels = scrollRange - viewportHeight
+            if (!isDraggingHandle) {
+                updateCachedScrollMetricsAfterScroll(recyclerView, dy = 0, scrollablePixels)
+            }
 
-            // The track is edge-to-edge (drawn under the navigation bar) while the bottom of the last
-            // row is below the viewport. Once that bottom scrolls into view the track follows it
-            // exactly, so they stay aligned.
-            val layoutManager = recyclerView!!.layoutManager
-            val lastPosition = (recyclerView!!.adapter?.itemCount ?: 0) - 1
-            // The last row's bottom comes from its real on-screen position
-            // Note: Offsets can't be used - LinearLayoutManager reports them in scrollbar units
+            val handleHeight = resolveHandleHeight(trackHeight, viewportHeight, scrollRange)
+            val isAtBottom =
+                !recyclerView.canScrollVertically(1) ||
+                    lastRowBottomEdge?.let { it <= trackHeight } == true
+            val ratio =
+                if (isAtBottom && !isDraggingHandle) {
+                    1f
+                } else {
+                    val scrollOffset = cachedScrollMetrics.scrollRangeState.offsetOrNull ?: return
+                    computeHandleScrollProportion(
+                        isDraggingHandle = isDraggingHandle,
+                        dragProportion = pendingScrollProportion,
+                        scrollOffset = scrollOffset,
+                        scrollRange = cachedScrollMetrics.scrollRange,
+                        viewportHeight = viewportHeight,
+                        canScrollDown = !isAtBottom,
+                        rangeCalibrated = cachedScrollMetrics.scrollRangeState is ScrollRangeState.Calibrated,
+                    )
+                }
+
+            val y = ratio * (trackHeight - handleHeight)
+            val animateToBottom =
+                shouldAnimateHandleToBottom(
+                    previousLayoutWasAtBottom = previousLayoutWasAtBottom,
+                    isAtBottom = isAtBottom,
+                    isDraggingHandle = isDraggingHandle,
+                )
+            layoutHandle(y, handleHeight, animateToBottom, previousHandleVisualTop)
+            previousLayoutWasAtBottom = isAtBottom
+        }
+
+        /**
+         * Applies handle positions immediately except for the final correction when normal scrolling
+         * reaches the real bottom. That correction is animated to avoid a visible jump; dragging always
+         * remains synchronous with the user's finger.
+         */
+        private fun layoutHandle(
+            targetY: Float,
+            handleHeight: Int,
+            animateToBottom: Boolean,
+            previousVisualTop: Float,
+        ) {
+            val targetTop = targetY.toInt()
+            handle.layout(handle.left, targetTop, handle.right, targetTop + handleHeight)
+
+            if (handleAnimationTargetY == targetTop.toFloat()) return
+
+            if (!animateToBottom) {
+                handle.animate().cancel()
+                handleAnimationTargetY = null
+                handle.translationY = 0f
+                return
+            }
+
+            if (previousVisualTop == targetTop.toFloat()) {
+                handle.translationY = 0f
+                return
+            }
+            handle.animate().cancel()
+            handle.translationY = previousVisualTop - targetTop
+            handleAnimationTargetY = targetTop.toFloat()
+            handle
+                .animate()
+                .translationY(0f)
+                .setDuration(HANDLE_POSITION_ANIMATION_DURATION_MS)
+                .setInterpolator(LinearInterpolator())
+                .withEndAction {
+                    if (handleAnimationTargetY == targetTop.toFloat()) handleAnimationTargetY = null
+                }.start()
+        }
+
+        private fun layoutBarToLastRow(
+            recyclerView: RecyclerView,
+            fullBarHeight: Int,
+        ): Int? {
+            val layoutManager = recyclerView.layoutManager
+            val lastPosition = (recyclerView.adapter?.itemCount ?: 0) - 1
             val lastRowBottomEdge =
                 lastPosition
                     .takeIf { it >= 0 }
                     ?.let { layoutManager?.findViewByPosition(it) }
                     ?.let { layoutManager!!.getDecoratedBottom(it) }
 
-            // off-screen (or not laid out) → edge-to-edge; visible → follow the row's bottom
+            // Keep the track edge-to-edge until the last row appears, then align their bottoms.
             val isEdgeToEdge = lastRowBottomEdge == null || lastRowBottomEdge >= fullBarHeight
             val barBottom = bar.top + if (isEdgeToEdge) fullBarHeight else lastRowBottomEdge
             if (bar.bottom != barBottom) {
                 bar.layout(bar.left, bar.top, bar.right, barBottom)
             }
+            return lastRowBottomEdge
+        }
+
+        // Slides the scroller off screen and stops show() bringing it back while nothing scrolls.
+        private fun hideThumb() {
+            translationX = hiddenTranslationX.toFloat()
+            hideOverride = true
+        }
+
+        private fun resolveScrollablePixels(recyclerView: RecyclerView): Int {
+            val itemCount = recyclerView.adapter?.itemCount ?: return 0
+            val trackHeight = (height - handleBottomInset).coerceAtLeast(0)
+            val viewportHeight = recyclerView.computeVerticalScrollExtent()
+            if (itemCount == 0 || trackHeight == 0 || viewportHeight == 0) return 0
+
+            val measuredScrollRange = recyclerView.computeVerticalScrollRange()
+            val scrollRange =
+                resolveScrollRange(
+                    itemCount = itemCount,
+                    trackHeight = trackHeight,
+                    viewportHeight = viewportHeight,
+                    width = recyclerView.width,
+                    scrollRange = measuredScrollRange,
+                )
+            return (scrollRange - viewportHeight).coerceAtLeast(0)
+        }
+
+        /**
+         * Maintains a stable pixel offset from actual scroll deltas instead of repeatedly using
+         * RecyclerView's changing estimate. A normal scroll from the top enables calibration; when the
+         * real bottom is reached, the accumulated distance becomes the cached scroll range.
+         */
+        private fun updateCachedScrollMetricsAfterScroll(
+            recyclerView: RecyclerView,
+            dy: Int,
+            scrollablePixels: Int,
+        ) {
+            cachedScrollMetrics =
+                if (scrollablePixels > 0) {
+                    cachedScrollMetrics.afterScroll(
+                        initialOffset = recyclerView.computeVerticalScrollOffset() + appBarLayoutOffset,
+                        dy = dy,
+                        canScrollUp = recyclerView.canScrollVertically(-1),
+                        canScrollDown = recyclerView.canScrollVertically(1),
+                    )
+                } else {
+                    cachedScrollMetrics.copy(scrollRangeState = ScrollRangeState.Unknown)
+                }
+        }
+
+        /**
+         * Scroll range for the current list, computed once and cached. RecyclerView estimates it
+         * from currently visible rows, so it can drift while scrolling variable-height rows.
+         * Recomputed when the data, bar height or width change (see [invalidateScrollMetrics]).
+         */
+        private fun resolveScrollRange(
+            itemCount: Int,
+            trackHeight: Int,
+            viewportHeight: Int,
+            width: Int,
+            scrollRange: Int,
+        ): Int {
+            if (
+                itemCount != cachedScrollMetrics.itemCount ||
+                trackHeight != cachedScrollMetrics.trackHeight ||
+                viewportHeight != cachedScrollMetrics.viewportHeight ||
+                width != cachedScrollMetrics.width
+            ) {
+                cachedScrollMetrics =
+                    CachedScrollMetrics(
+                        itemCount = itemCount,
+                        trackHeight = trackHeight,
+                        viewportHeight = viewportHeight,
+                        width = width,
+                    )
+                previousLayoutWasAtBottom = null
+                handleAnimationTargetY = null
+            }
+
+            if (cachedScrollMetrics.scrollRange == 0) {
+                cachedScrollMetrics = cachedScrollMetrics.copy(scrollRange = scrollRange)
+            }
+
+            return cachedScrollMetrics.scrollRange
+        }
+
+        private fun resolveHandleHeight(
+            trackHeight: Int,
+            viewportHeight: Int,
+            scrollRange: Int,
+        ): Int {
+            if (cachedScrollMetrics.handleHeight == 0) {
+                cachedScrollMetrics =
+                    cachedScrollMetrics.copy(
+                        handleHeight =
+                            computeThumbHeight(
+                                trackHeight = trackHeight,
+                                viewportHeight = viewportHeight,
+                                scrollRange = scrollRange,
+                                minHandleHeight = minScrollHandleHeight,
+                            ),
+                    )
+            }
+            return cachedScrollMetrics.handleHeight
         }
 
         companion object {
+            private const val HANDLE_POSITION_ANIMATION_DURATION_MS = 100L
             private val DEFAULT_AUTO_HIDE_DELAY = 1500.milliseconds
         }
     }
 
+/** Calibration stage and accumulated pixel offset for the current list. */
+@VisibleForTesting
+internal sealed interface ScrollRangeState {
+    /** No offset has been measured since the last cache invalidation. */
+    data object Unknown : ScrollRangeState
+
+    /** Scrolling started without first observing the real top. */
+    data class Uncalibrated(
+        val offset: Int,
+    ) : ScrollRangeState
+
+    /** The real top was observed and distance is being accumulated toward the bottom. */
+    data class CalibratingFromTop(
+        val offset: Int,
+    ) : ScrollRangeState
+
+    /** The full top-to-bottom distance was measured. */
+    data class Calibrated(
+        val offset: Int,
+    ) : ScrollRangeState
+}
+
+private val ScrollRangeState.offsetOrNull: Int?
+    get() =
+        when (this) {
+            ScrollRangeState.Unknown -> null
+            is ScrollRangeState.Uncalibrated -> offset
+            is ScrollRangeState.CalibratingFromTop -> offset
+            is ScrollRangeState.Calibrated -> offset
+        }
+
+/**
+ * Cached inputs, results and calibration state used to calculate stable thumb geometry.
+ *
+ * @property handleHeight calculated thumb height
+ * @property scrollRange estimated or calibrated content height
+ * @property itemCount adapter size used to detect structural changes
+ * @property trackHeight height available for handle travel above system insets
+ * @property viewportHeight visible RecyclerView height used for scroll calculations
+ * @property width list width used to detect row rewrapping
+ * @property scrollRangeState calibration stage and accumulated pixel offset
+ */
+@VisibleForTesting
+internal data class CachedScrollMetrics(
+    val handleHeight: Int = 0,
+    val scrollRange: Int = 0,
+    val itemCount: Int = RecyclerView.NO_POSITION,
+    val trackHeight: Int = 0,
+    val viewportHeight: Int = 0,
+    val width: Int = 0,
+    val scrollRangeState: ScrollRangeState = ScrollRangeState.Unknown,
+) {
+    /**
+     * Applies a normal scroll and calibrates [scrollRange] after observing the real top and bottom.
+     */
+    fun afterScroll(
+        initialOffset: Int,
+        dy: Int,
+        canScrollUp: Boolean,
+        canScrollDown: Boolean,
+    ): CachedScrollMetrics {
+        val updatedOffset =
+            scrollRangeState.offsetOrNull?.let { currentOffset ->
+                computeScrollOffsetFromDelta(currentOffset, dy, canScrollUp)
+            } ?: initialOffset.coerceAtLeast(0)
+
+        val updatedState =
+            when {
+                scrollRangeState is ScrollRangeState.Calibrated -> scrollRangeState.copy(offset = updatedOffset)
+                !canScrollUp -> ScrollRangeState.CalibratingFromTop(offset = 0)
+                !canScrollDown &&
+                    scrollRangeState is ScrollRangeState.CalibratingFromTop &&
+                    updatedOffset > 0 -> ScrollRangeState.Calibrated(updatedOffset)
+                scrollRangeState is ScrollRangeState.CalibratingFromTop ->
+                    scrollRangeState.copy(offset = updatedOffset)
+                else -> ScrollRangeState.Uncalibrated(updatedOffset)
+            }
+        val updatedScrollRange =
+            if (updatedState is ScrollRangeState.Calibrated && scrollRangeState !is ScrollRangeState.Calibrated) {
+                updatedState.offset + viewportHeight
+            } else {
+                scrollRange
+            }
+        return copy(scrollRange = updatedScrollRange, scrollRangeState = updatedState)
+    }
+
+    /** Applies a drag offset without treating the jump as a complete range measurement. */
+    fun afterDrag(scrollOffset: Int): CachedScrollMetrics {
+        val updatedState =
+            if (scrollRangeState is ScrollRangeState.Calibrated) {
+                scrollRangeState.copy(offset = scrollOffset)
+            } else {
+                ScrollRangeState.Uncalibrated(offset = scrollOffset)
+            }
+        return copy(scrollRangeState = updatedState)
+    }
+}
+
+/**
+ * Thumb height as the visible share of the content, scaled to the usable track and clamped to a
+ * usable range. Independent of scroll position, so a cached value stays valid.
+ */
+@VisibleForTesting
+internal fun computeThumbHeight(
+    trackHeight: Int,
+    viewportHeight: Int,
+    scrollRange: Int,
+    minHandleHeight: Int,
+): Int =
+    (trackHeight.toFloat() * viewportHeight / scrollRange.coerceAtLeast(1))
+        .toInt()
+        .coerceAtLeast(minHandleHeight)
+        .coerceAtMost(trackHeight)
+
+/**
+ * Scroll progress from 0f to 1f, measured in pixels so the thumb tracks the scroll smoothly on
+ * rows of different heights. Guards against a zero divisor when the list barely scrolls.
+ */
+@VisibleForTesting
+internal fun computeScrollProportion(
+    scrollOffset: Int,
+    scrollRange: Int,
+    viewportHeight: Int,
+): Float {
+    val scrollablePixels = (scrollRange - viewportHeight).coerceAtLeast(1)
+    return (scrollOffset.toFloat() / scrollablePixels).coerceIn(0f, 1f)
+}
+
+@VisibleForTesting
+internal fun computeScrollOffsetFromDelta(
+    currentOffset: Int,
+    dy: Int,
+    canScrollUp: Boolean,
+): Int {
+    if (!canScrollUp) return 0
+    return (currentOffset + dy).coerceAtLeast(0)
+}
+
+/**
+ * Maps an uncalibrated range smoothly toward, but never onto, the end of the track. RecyclerView's
+ * first range estimate can be shorter than the real content, so a linear mapping would put the
+ * thumb at the bottom too early. Once a complete top-to-bottom scroll calibrates the range, the
+ * regular linear mapping is exact.
+ */
+@VisibleForTesting
+internal fun computeDisplayScrollProportion(
+    scrollOffset: Int,
+    scrollRange: Int,
+    viewportHeight: Int,
+    canScrollDown: Boolean,
+    rangeCalibrated: Boolean,
+): Float {
+    if (!canScrollDown) return 1f
+
+    val scrollablePixels = (scrollRange - viewportHeight).coerceAtLeast(1)
+    val rawProportion = (scrollOffset.toFloat() / scrollablePixels).coerceAtLeast(0f)
+    if (rangeCalibrated) return computeScrollProportion(scrollOffset, scrollRange, viewportHeight)
+    if (rawProportion <= END_APPROACH_THRESHOLD) return rawProportion
+
+    val tail = 1f - END_APPROACH_THRESHOLD
+    val excess = (rawProportion - END_APPROACH_THRESHOLD) / tail
+    return END_APPROACH_THRESHOLD + tail * excess / (1f + excess)
+}
+
+/**
+ * Uses the finger's track position while dragging and the accumulated pixel offset otherwise.
+ * Keeping these sources separate prevents scroll callbacks caused by a drag from moving the
+ * handle away from the finger.
+ */
+@VisibleForTesting
+internal fun computeHandleScrollProportion(
+    isDraggingHandle: Boolean,
+    dragProportion: Float,
+    scrollOffset: Int,
+    scrollRange: Int,
+    viewportHeight: Int,
+    canScrollDown: Boolean,
+    rangeCalibrated: Boolean,
+): Float =
+    if (isDraggingHandle) {
+        dragProportion.coerceIn(0f, 1f)
+    } else {
+        computeDisplayScrollProportion(scrollOffset, scrollRange, viewportHeight, canScrollDown, rangeCalibrated)
+    }
+
+/**
+ * Maps drag progress to a valid first visible adapter position. Reserving the visible rows keeps
+ * the last viewport aligned with the end of the track; the exact endpoint targets the final item
+ * so the LayoutManager can clamp the list to its real bottom.
+ */
+@VisibleForTesting
+internal fun computeDragTargetIndex(
+    scrollProportion: Float,
+    itemCount: Int,
+    visibleItemCount: Int,
+): Double {
+    if (itemCount <= 0) return 0.0
+
+    val proportion = scrollProportion.coerceIn(0f, 1f)
+    if (proportion == 1f) return (itemCount - 1).toDouble()
+
+    val lastFirstVisiblePosition = itemCount - visibleItemCount.coerceIn(1, itemCount)
+    return proportion * lastFirstVisiblePosition.toDouble()
+}
+
+// Keep most of the track linear and reserve the final 4% for approaching an uncertain end smoothly.
+// 4% is heuristic that makes the thumb move smoothly on smartphone
+private const val END_APPROACH_THRESHOLD = 0.96f
+
+@VisibleForTesting
+internal fun shouldAnimateHandleToBottom(
+    previousLayoutWasAtBottom: Boolean?,
+    isAtBottom: Boolean,
+    isDraggingHandle: Boolean,
+): Boolean = previousLayoutWasAtBottom == false && !isDraggingHandle && isAtBottom
+
 fun RecyclerView.attachFastScroller(
     @IdRes id: Int,
-) = (parent as ViewGroup)
-    .findViewById<RecyclerFastScroller>(id)
-    .attachRecyclerView(this)
+) {
+    (parent as? ViewGroup)
+        ?.findViewById<RecyclerFastScroller>(id)
+        ?.attachRecyclerView(this)
+}

--- a/AnkiDroid/src/main/res/layout/dialog_tags.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_tags.xml
@@ -64,13 +64,25 @@
     </LinearLayout>
 
 
-    <androidx.recyclerview.widget.RecyclerView android:id="@+id/tags_list"
-        android:scrollbars="vertical"
+    <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:layout_above="@id/options_group"
-        android:layout_below="@id/toolbar"
-        tools:listitem="@layout/item_tag" />
+        android:layout_below="@id/toolbar">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/tags_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scrollbars="none"
+            tools:listitem="@layout/item_tag" />
+
+        <com.ichi2.anki.ui.RecyclerFastScroller
+            android:id="@+id/tags_scroller"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_alignParentEnd="true" />
+    </RelativeLayout>
 
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="wrap_content"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserFragmentTest.kt
@@ -25,6 +25,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.browser.CardBrowserViewModel.ChangeMultiSelectMode.SingleSelectCause
 import com.ichi2.anki.settings.Prefs
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.CoreMatchers.equalTo
@@ -62,6 +63,22 @@ class CardBrowserFragmentTest : RobolectricTest() {
             val offenders = shortcuts.shortcuts.map { it.label }.filterNot { it.isSentenceCase }
             assertThat("shortcut labels should be Sentence case, not Title Case", offenders, empty())
         }
+
+    @Test
+    fun `opening editor refreshes rows only when leaving multi-select`() {
+        val change = SingleSelectCause.OpenNoteEditorActivity
+        val previousSelection = change.previouslySelectedRowIds
+
+        try {
+            change.previouslySelectedRowIds = emptySet()
+            assertThat(shouldRefreshBrowserRows(change), equalTo(false))
+
+            change.previouslySelectedRowIds = setOf(CardOrNoteId(1))
+            assertThat(shouldRefreshBrowserRows(change), equalTo(true))
+        } finally {
+            change.previouslySelectedRowIds = previousSelection
+        }
+    }
 }
 
 private val capitalizedFollowingWord = Regex("""\s\p{Lu}\p{Ll}""")

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/RecyclerFastScrollerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/RecyclerFastScrollerTest.kt
@@ -1,0 +1,373 @@
+// SPDX-FileCopyrightText: 2026 Ashish Yadav <mailtoashish693@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+package com.ichi2.anki.ui
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.closeTo
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.greaterThan
+import org.hamcrest.Matchers.lessThan
+import org.junit.Test
+
+class RecyclerFastScrollerTest {
+    @Test
+    fun `thumb height is the share of the content that fits on screen`() {
+        // a quarter of the content is visible, so the thumb is a quarter of the bar
+        assertThat(
+            computeThumbHeight(trackHeight = 1000, viewportHeight = 1000, scrollRange = 4000, minHandleHeight = 48),
+            equalTo(250),
+        )
+    }
+
+    @Test
+    fun `thumb height is scaled to the track above the bottom inset`() {
+        assertThat(
+            computeThumbHeight(trackHeight = 900, viewportHeight = 1000, scrollRange = 4000, minHandleHeight = 48),
+            equalTo(225),
+        )
+    }
+
+    @Test
+    fun `thumb height never drops below the minimum`() {
+        assertThat(
+            computeThumbHeight(trackHeight = 1000, viewportHeight = 1000, scrollRange = 100_000, minHandleHeight = 48),
+            equalTo(48),
+        )
+    }
+
+    @Test
+    fun `thumb height never exceeds the bar`() {
+        assertThat(
+            computeThumbHeight(trackHeight = 1000, viewportHeight = 1000, scrollRange = 1000, minHandleHeight = 48),
+            equalTo(1000),
+        )
+    }
+
+    @Test
+    fun `thumb height stays within the bar even when the minimum is taller than the bar`() {
+        assertThat(
+            computeThumbHeight(trackHeight = 30, viewportHeight = 1000, scrollRange = 100_000, minHandleHeight = 48),
+            equalTo(30),
+        )
+    }
+
+    @Test
+    fun `proportion is zero at the top of the list`() {
+        assertThat(computeScrollProportion(scrollOffset = 0, scrollRange = 4000, viewportHeight = 1000), equalTo(0f))
+    }
+
+    @Test
+    fun `proportion reaches one at the bottom of the list`() {
+        // the last screen starts at scrollRange - viewportHeight
+        assertThat(computeScrollProportion(scrollOffset = 3000, scrollRange = 4000, viewportHeight = 1000), equalTo(1f))
+    }
+
+    @Test
+    fun `proportion tracks scrolled pixels linearly`() {
+        // half the scrollable pixels means the thumb is at the middle: this is what keeps it
+        // smooth on uneven rows, since it follows pixels rather than item index
+        assertThat(computeScrollProportion(scrollOffset = 1500, scrollRange = 4000, viewportHeight = 1000).toDouble(), closeTo(0.5, 0.0001))
+        assertThat(computeScrollProportion(scrollOffset = 750, scrollRange = 4000, viewportHeight = 1000).toDouble(), closeTo(0.25, 0.0001))
+    }
+
+    @Test
+    fun `proportion is clamped into range`() {
+        assertThat(computeScrollProportion(scrollOffset = 9999, scrollRange = 4000, viewportHeight = 1000), equalTo(1f))
+    }
+
+    @Test
+    fun `proportion does not divide by zero when the list barely scrolls`() {
+        // scrollRange == viewportHeight would be a zero divisor without the guard
+        assertThat(computeScrollProportion(scrollOffset = 0, scrollRange = 1000, viewportHeight = 1000), lessThan(1.0001f))
+    }
+
+    @Test
+    fun `scroll offset accumulates real pixel deltas`() {
+        assertThat(
+            computeScrollOffsetFromDelta(
+                currentOffset = 100,
+                dy = 25,
+                canScrollUp = true,
+            ),
+            equalTo(125),
+        )
+    }
+
+    @Test
+    fun `scroll offset can outgrow an estimate while the list can still scroll`() {
+        assertThat(
+            computeScrollOffsetFromDelta(
+                currentOffset = 995,
+                dy = 20,
+                canScrollUp = true,
+            ),
+            equalTo(1015),
+        )
+    }
+
+    @Test
+    fun `scroll offset is clamped at the start of the list`() {
+        assertThat(
+            computeScrollOffsetFromDelta(
+                currentOffset = 5,
+                dy = -20,
+                canScrollUp = true,
+            ),
+            equalTo(0),
+        )
+    }
+
+    @Test
+    fun `thumb does not reach the end while the list can still scroll`() {
+        assertThat(
+            computeDisplayScrollProportion(
+                scrollOffset = 3015,
+                scrollRange = 4000,
+                viewportHeight = 1000,
+                canScrollDown = true,
+                rangeCalibrated = false,
+            ),
+            lessThan(1f),
+        )
+    }
+
+    @Test
+    fun `thumb continues moving smoothly after passing the estimated range`() {
+        val atEstimate =
+            computeDisplayScrollProportion(
+                scrollOffset = 3000,
+                scrollRange = 4000,
+                viewportHeight = 1000,
+                canScrollDown = true,
+                rangeCalibrated = false,
+            )
+        val pastEstimate =
+            computeDisplayScrollProportion(
+                scrollOffset = 4500,
+                scrollRange = 4000,
+                viewportHeight = 1000,
+                canScrollDown = true,
+                rangeCalibrated = false,
+            )
+
+        assertThat(pastEstimate, greaterThan(atEstimate))
+        assertThat(pastEstimate, lessThan(1f))
+    }
+
+    @Test
+    fun `thumb is close to the end before the real bottom is reached`() {
+        val atEstimatedEnd =
+            computeDisplayScrollProportion(
+                scrollOffset = 3000,
+                scrollRange = 4000,
+                viewportHeight = 1000,
+                canScrollDown = true,
+                rangeCalibrated = false,
+            )
+
+        assertThat(atEstimatedEnd, greaterThan(0.97f))
+        assertThat(atEstimatedEnd, lessThan(1f))
+    }
+
+    @Test
+    fun `thumb reaches the end only at the real list edge`() {
+        assertThat(
+            computeDisplayScrollProportion(
+                scrollOffset = 4500,
+                scrollRange = 4000,
+                viewportHeight = 1000,
+                canScrollDown = false,
+                rangeCalibrated = false,
+            ),
+            equalTo(1f),
+        )
+    }
+
+    @Test
+    fun `calibrated range uses linear pixel progress`() {
+        assertThat(
+            computeDisplayScrollProportion(
+                scrollOffset = 1500,
+                scrollRange = 4000,
+                viewportHeight = 1000,
+                canScrollDown = true,
+                rangeCalibrated = true,
+            ),
+            equalTo(0.5f),
+        )
+    }
+
+    @Test
+    fun `scroll offset snaps to the start of the list`() {
+        assertThat(
+            computeScrollOffsetFromDelta(currentOffset = 100, dy = 25, canScrollUp = false),
+            equalTo(0),
+        )
+    }
+
+    @Test
+    fun `range is calibrated after a complete scroll from top to bottom`() {
+        val uncalibrated =
+            CachedScrollMetrics(viewportHeight = 1000).afterScroll(
+                initialOffset = 300,
+                dy = 0,
+                canScrollUp = true,
+                canScrollDown = true,
+            )
+        assertThat(uncalibrated.scrollRangeState, equalTo(ScrollRangeState.Uncalibrated(offset = 300)))
+
+        val calibrating =
+            uncalibrated.afterScroll(
+                initialOffset = 0,
+                dy = -300,
+                canScrollUp = false,
+                canScrollDown = true,
+            )
+        assertThat(calibrating.scrollRangeState, equalTo(ScrollRangeState.CalibratingFromTop(offset = 0)))
+
+        val middle =
+            calibrating.afterScroll(
+                initialOffset = 0,
+                dy = 700,
+                canScrollUp = true,
+                canScrollDown = true,
+            )
+        assertThat(middle.scrollRangeState, equalTo(ScrollRangeState.CalibratingFromTop(offset = 700)))
+
+        val calibrated =
+            middle.afterScroll(
+                initialOffset = 0,
+                dy = 300,
+                canScrollUp = true,
+                canScrollDown = false,
+            )
+        assertThat(calibrated.scrollRangeState, equalTo(ScrollRangeState.Calibrated(offset = 1000)))
+        assertThat(calibrated.scrollRange, equalTo(2000))
+    }
+
+    @Test
+    fun `reaching bottom without observing top does not calibrate range`() {
+        val metrics =
+            CachedScrollMetrics()
+                .afterScroll(
+                    initialOffset = 1000,
+                    dy = 0,
+                    canScrollUp = true,
+                    canScrollDown = false,
+                )
+
+        assertThat(metrics.scrollRangeState, equalTo(ScrollRangeState.Uncalibrated(offset = 1000)))
+    }
+
+    @Test
+    fun `zero-delta jump from top to bottom does not calibrate range`() {
+        val metrics =
+            CachedScrollMetrics(
+                scrollRangeState = ScrollRangeState.CalibratingFromTop(offset = 0),
+            ).afterScroll(
+                initialOffset = 0,
+                dy = 0,
+                canScrollUp = true,
+                canScrollDown = false,
+            )
+
+        assertThat(metrics.scrollRangeState, equalTo(ScrollRangeState.CalibratingFromTop(offset = 0)))
+    }
+
+    @Test
+    fun `drag aborts calibration unless range is already calibrated`() {
+        val uncalibrated =
+            CachedScrollMetrics(
+                scrollRangeState = ScrollRangeState.CalibratingFromTop(offset = 500),
+            ).afterDrag(scrollOffset = 700)
+        val calibrated =
+            CachedScrollMetrics(
+                scrollRangeState = ScrollRangeState.Calibrated(offset = 500),
+            ).afterDrag(scrollOffset = 700)
+
+        assertThat(
+            uncalibrated.scrollRangeState,
+            equalTo(ScrollRangeState.Uncalibrated(offset = 700)),
+        )
+        assertThat(
+            calibrated.scrollRangeState,
+            equalTo(ScrollRangeState.Calibrated(offset = 700)),
+        )
+    }
+
+    @Test
+    fun `handle animation is used only when normal scrolling reaches the bottom`() {
+        assertThat(
+            shouldAnimateHandleToBottom(
+                previousLayoutWasAtBottom = false,
+                isAtBottom = true,
+                isDraggingHandle = false,
+            ),
+            equalTo(true),
+        )
+        assertThat(
+            shouldAnimateHandleToBottom(
+                previousLayoutWasAtBottom = false,
+                isAtBottom = false,
+                isDraggingHandle = false,
+            ),
+            equalTo(false),
+        )
+        assertThat(
+            shouldAnimateHandleToBottom(
+                previousLayoutWasAtBottom = false,
+                isAtBottom = true,
+                isDraggingHandle = true,
+            ),
+            equalTo(false),
+        )
+        assertThat(
+            shouldAnimateHandleToBottom(
+                previousLayoutWasAtBottom = null,
+                isAtBottom = true,
+                isDraggingHandle = false,
+            ),
+            equalTo(false),
+        )
+    }
+
+    @Test
+    fun `dragged thumb follows the finger when the list reaches the bottom early`() {
+        assertThat(
+            computeHandleScrollProportion(
+                isDraggingHandle = true,
+                dragProportion = 0.9f,
+                scrollOffset = 4500,
+                scrollRange = 4000,
+                viewportHeight = 1000,
+                canScrollDown = false,
+                rangeCalibrated = false,
+            ),
+            equalTo(0.9f),
+        )
+    }
+
+    @Test
+    fun `drag target leaves room for the last visible screen`() {
+        assertThat(
+            computeDragTargetIndex(
+                scrollProportion = 0.9f,
+                itemCount = 211,
+                visibleItemCount = 11,
+            ),
+            closeTo(180.0, 0.0001),
+        )
+    }
+
+    @Test
+    fun `drag target reaches the last item only at the end of the track`() {
+        assertThat(
+            computeDragTargetIndex(
+                scrollProportion = 1f,
+                itemCount = 211,
+                visibleItemCount = 11,
+            ),
+            equalTo(210.0),
+        )
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

<!---
Uncomment this section if AI tools were used. New contributors may not use AI tools. See:
https://github.com/ankidroid/Anki-Android/blob/main/AI_POLICY.md
> [!NOTE]
> Assisted-by: ___
--->

## Purpose / Description
Fix scroll UI bug: before length changed while scrolling list of rows of different length and looked glitchy, I want to make it smooth for better view.

## Fixes
* Part of #19480

## Approach

`RecyclerView.computeVerticalScrollRange()` and `computeVerticalScrollOffset()` are estimates based on currently visible rows. With variable-height rows, these estimates can change while scrolling, which causes the scrollbar thumb to resize or jump.

This PR:

- caches the initial scroll range and thumb height so their scale remains stable while scrolling
- initializes the scroll offset from RecyclerView once, then tracks it using the actual pixel deltas (`dy`)
- invalidates cached metrics when the adapter structure, list width, or viewport height changes, while ignoring content-only row updates that do not change the list structure
- calibrates the cached range after observing a complete normal scroll from the real top to the real bottom
- approaches the end of an uncalibrated range smoothly and animates the final correction when normal scrolling reaches the real bottom
- handles thumb dragging separately from normal scrolling, keeping the thumb under the user's finger and reserving space for the final visible rows
- avoids an unnecessary full row refresh when opening the note editor from single-select mode, preventing cached scroll metrics from being reset
- applies the same custom fast scroller to the tags dialog instead of its native RecyclerView scrollbar
- makes `attachFastScroller()` a safe no-op when the requested scroller is not present in the layout
## How Has This Been Tested?

Manual UI test.
### Before:

Current main performance.

https://github.com/user-attachments/assets/946bec02-9b2b-4fdb-a6c8-aca676c8d50e

### After

Current branch performance.

https://github.com/user-attachments/assets/a164c4c3-51b6-4153-8816-12dd7d7ff150

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->