### PR TITLE
feat: enable/disable theme settings

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
@@ -135,6 +135,9 @@ class AppearanceSettingsFragment : SettingsFragment() {
         val dayThemePref = requirePreference<ListPreference>(R.string.day_theme_key)
         val nightThemePref = requirePreference<ListPreference>(R.string.night_theme_key)
 
+        dayThemePref.isEnabled = appTheme != AppTheme.NIGHT
+        nightThemePref.isEnabled = appTheme != AppTheme.DAY
+
         // Remove follow system options in android versions which do not have system dark mode
         // When minSdk reaches 29, the only necessary change is to remove this if-block
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
@@ -154,6 +157,9 @@ class AppearanceSettingsFragment : SettingsFragment() {
 
                 if (previousThemeId != Themes.currentTheme.styleResId) {
                     ActivityCompat.recreate(requireActivity())
+                } else {
+                    dayThemePref.isEnabled = newValue != getString(AppTheme.NIGHT.entryResId)
+                    nightThemePref.isEnabled = newValue != getString(AppTheme.DAY.entryResId)
                 }
             }
         }


### PR DESCRIPTION
If "Day" is chosen, disable "Night theme"

If "Night" is chosen, disable "Day theme"

If "Follow system" is chosen, keep both settings enabled

That way, it's more obvious how the settings work

## How Has This Been Tested?

Emulator 33

[Screen_recording_20260714_070720.webm](https://github.com/user-attachments/assets/487e04eb-80b7-4d90-87e6-3337cdd0ee2a)


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->