### PR TITLE
feat(deck-picker): draw tree hierarchy branch lines

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -178,6 +178,7 @@ import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.anki.utils.ext.setImageDrawableSafe
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.widgets.DeckAdapter
+import com.ichi2.anki.widgets.DeckHierarchyLinesDecoration
 import com.ichi2.anki.worker.SyncMediaWorker
 import com.ichi2.anki.worker.SyncWorker
 import com.ichi2.anki.worker.UniqueWorkNames
@@ -535,8 +536,15 @@ open class DeckPicker :
                     viewModel.requestRightClickContextMenu(deckId, x, y)
                     Timber.d("Right Click on deck recorded!! %d, %f %f", deckId, x, y)
                 },
-            )
+            ).apply {
+                highlightSelected = fragmented
+            }
         deckPickerBinding.decks.adapter = deckListAdapter
+        if (Prefs.devBottomNavEnabled) {
+            deckPickerBinding.decks.addItemDecoration(
+                DeckHierarchyLinesDecoration(this, deckListAdapter),
+            )
+        }
 
         lifecycleScope.launch { applyDeckPickerBackground() }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -24,6 +24,9 @@ import android.view.ViewGroup
 import android.widget.ImageButton
 import androidx.core.content.res.getDrawableOrThrow
 import androidx.core.content.withStyledAttributes
+import androidx.core.view.isGone
+import androidx.core.view.isInvisible
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -31,6 +34,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.databinding.ItemDeckBinding
 import com.ichi2.anki.deckpicker.DisplayDeckNode
 import com.ichi2.anki.libanki.DeckId
+import com.ichi2.utils.dp
 import kotlinx.coroutines.runBlocking
 import net.ankiweb.rsdroid.RustCleanup
 import com.ichi2.anki.common.android.R as CommonR
@@ -70,8 +74,18 @@ class DeckAdapter(
     private var selectableItemBackground: Int = 0
     private val endPadding: Int = context.resources.getDimension(R.dimen.deck_picker_right_padding).toInt()
     private val startPadding: Int = context.resources.getDimension(R.dimen.deck_picker_left_padding).toInt()
-    private val startPaddingSmall: Int = context.resources.getDimension(R.dimen.deck_picker_left_padding_small).toInt()
-    private val nestedIndent = context.resources.getDimension(R.dimen.keyline_1).toInt()
+
+    /** Left padding when the view has subdecks */
+    val startPaddingSmall: Int = context.resources.getDimension(R.dimen.deck_picker_left_padding_small).toInt()
+
+    /** Padding to apply for each depth level of a deck */
+    val nestedIndent = context.resources.getDimension(R.dimen.keyline_1).toInt()
+
+    /** The width of the expander chevron icon */
+    val expanderWidth = 48.dp.toPx(context)
+
+    /** Visual offset applied to non-root expanders without moving the deck name. */
+    val nestedExpanderOffset = 2.dp.toPx(context).toFloat()
 
     // Flags
     private var hasSubdecks = false
@@ -87,6 +101,12 @@ class DeckAdapter(
                 notifyDataSetChanged()
             }
         }
+
+    /**
+     * Whether to highlight the selected deck. Usually true for fragmented (tablet) layouts
+     * where the deck contents are shown side-by-side, but false for phones.
+     */
+    var highlightSelected: Boolean = true
 
     class ViewHolder(
         val binding: ItemDeckBinding,
@@ -132,11 +152,11 @@ class DeckAdapter(
         // Set the expander icon and padding according to whether or not there are any subdecks
         if (hasSubdecks) {
             binding.deckLayout.setPaddingRelative(startPaddingSmall, 0, endPadding, 0)
-            binding.deckExpander.visibility = View.VISIBLE
+            binding.deckExpander.isVisible = true
             // Create the correct expander for this deck
             runBlocking { setDeckExpander(binding.deckExpander, holder.binding.indentView, node) }
         } else {
-            binding.deckExpander.visibility = View.GONE
+            binding.deckExpander.isGone = true
             binding.indentView.minimumWidth = 0
             binding.deckLayout.setPaddingRelative(startPadding, 0, endPadding, 0)
         }
@@ -151,7 +171,7 @@ class DeckAdapter(
         }
         holder.binding.deckLayout.setBackgroundResource(rowCurrentDrawable)
         // set a different background color for the current selected deck
-        if (node.isSelected) {
+        if (node.isSelected && highlightSelected) {
             holder.binding.deckLayout.setBackgroundResource(rowCurrentDrawable)
             if (activityHasBackground) {
                 val background =
@@ -200,8 +220,12 @@ class DeckAdapter(
         indent: ImageButton,
         node: DisplayDeckNode,
     ) {
+        // Translation moves only the chevron; the deck name keeps its existing layout position.
+        expander.translationX = if (node.depth == 0) 0f else nestedExpanderOffset
+
         // Apply the correct expand/collapse drawable
         if (node.canCollapse) {
+            expander.isVisible = true
             expander.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
             if (node.collapsed) {
                 expander.setImageDrawable(expandImage)
@@ -211,10 +235,12 @@ class DeckAdapter(
                 expander.contentDescription = expander.context.getString(R.string.collapse)
             }
         } else {
-            expander.visibility = View.INVISIBLE
+            // Siblings must perfectly align their text with each other regardless of whether they have children.
+            // Using INVISIBLE instead of GONE maintains the identical 48dp width block that a chevron would take,
+            // ensuring the horizontal L-branch lines reach identically far and the deck text aligns seamlessly.
+            expander.isInvisible = true
             expander.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
         }
-        // Add some indenting for each nested level
         indent.minimumWidth = nestedIndent * node.depth
     }
 
@@ -267,4 +293,10 @@ private val deckNodeDiffCallback =
             oldItem: DisplayDeckNode,
             newItem: DisplayDeckNode,
         ): Boolean = oldItem == newItem
+
+        // We have to return a non-null payload to prevent cross-fading which resulted in the doubling of the chevron
+        override fun getChangePayload(
+            oldItem: DisplayDeckNode,
+            newItem: DisplayDeckNode,
+        ): Any = true
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckHierarchyLinesDecoration.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckHierarchyLinesDecoration.kt
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2026 Shaan Narendran <shaannaren06@gmail.com>
+package com.ichi2.anki.widgets
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.RectF
+import androidx.appcompat.widget.ThemeUtils
+import androidx.core.view.children
+import androidx.recyclerview.widget.RecyclerView
+import com.ichi2.anki.R
+import com.ichi2.anki.common.utils.android.systemIsInNightMode
+import com.ichi2.utils.dp
+
+@JvmInline
+private value class DepthBitSet(
+    val value: Long = 0L,
+) {
+    fun setBit(depth: Int): DepthBitSet {
+        if (depth >= 64) return this
+        return DepthBitSet(value or (1L shl depth))
+    }
+
+    fun clearDeeperThan(depth: Int): DepthBitSet {
+        if (depth >= 64) return this
+        val mask = if (depth >= 63) -1L else (1L shl (depth + 1)) - 1L
+        return DepthBitSet(value and mask)
+    }
+
+    fun hasBit(depth: Int): Boolean {
+        if (depth >= 64) return false
+        return (value and (1L shl depth)) != 0L
+    }
+}
+
+class DeckHierarchyLinesDecoration(
+    context: Context,
+    private val adapter: DeckAdapter,
+) : RecyclerView.ItemDecoration() {
+    private val paint =
+        Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            style = Paint.Style.STROKE
+            strokeCap = Paint.Cap.BUTT
+            strokeWidth = LINE_STROKE_WIDTH_DP.dp.toPx(context).toFloat()
+
+            color = ThemeUtils.getThemeAttrColor(context, com.google.android.material.R.attr.colorOnSurface)
+        }
+
+    private val targetAlpha = if (systemIsInNightMode(context)) ALPHA_DARK else ALPHA_LIGHT
+    private val layerPaint = Paint().apply { alpha = targetAlpha }
+
+    // The horizontal indent spacing between each depth level
+    private val nestedIndent = context.resources.getDimension(R.dimen.keyline_1)
+
+    // The offset to center the vertical lines with the expander chevron
+    private val expanderCenterOffset = adapter.expanderWidth / 2f
+
+    // The radius for the curved elbow when drawing leaf node L-branches
+    private val cornerRadius = 8.dp.toPx(context).toFloat()
+
+    // The gap between the end of the line and the expander chevron/deck name
+    private val iconGap = 8.dp.toPx(context).toFloat()
+
+    // Reusable path and rect for drawing the curved elbows to avoid allocations
+    private val reusablePath = Path()
+    private val reusableRect = RectF()
+
+    /**
+     * Scratch buffer used to store the bitmask of active vertical lines passing through each visible row.
+     * The index maps to the view's index in the sorted list of visible views, and the 64-bit Long stores the active depths.
+     * It dynamically resizes if the RecyclerView holds more visible items.
+     */
+    private var scratchBuffer = LongArray(50)
+
+    override fun onDrawOver(
+        c: Canvas,
+        parent: RecyclerView,
+        state: RecyclerView.State,
+    ) {
+        val childCount = parent.childCount
+        if (childCount == 0) return
+
+        val currentList = (parent.adapter as? DeckAdapter)?.currentList ?: return
+        if (currentList.isEmpty()) return
+
+        if (scratchBuffer.size < childCount) {
+            scratchBuffer = LongArray(childCount * 2)
+        }
+        // We use a 64-bit Long as a bitmask. Each bit index represents a depth level.
+        // If bit 'd' is 1, it means there is a sibling further down the list at depth 'd'
+        // so we must draw a vertical line
+        var activeLines = DepthBitSet()
+
+        // Gather visible views and sort them by adapter position to ensure we process them top-to-bottom.
+        // RecyclerView.getChildAt() order is not guaranteed to match adapter position order, especially during animations.
+        val visibleViews =
+            parent.children
+                .map { parent.getChildAdapterPosition(it) to it }
+                .filter { (pos, _) -> pos != RecyclerView.NO_POSITION }
+                .sortedBy { (pos, _) -> pos }
+                .toList()
+
+        if (visibleViews.isEmpty()) return
+
+        val maxPos = visibleViews.last().first
+
+        // Look ahead past the last visible item to find lines that continue below the screen
+        if (maxPos + 1 < currentList.size) {
+            val endPos = currentList.size
+            var minDepthSeen = (currentList.getOrNull(maxPos)?.depth ?: 63) + 1
+            for (i in maxPos + 1 until endPos) {
+                val node = currentList.getOrNull(i) ?: continue
+                val d = node.depth
+                if (d >= 64) {
+                    continue
+                }
+
+                // We only care about finding the first sibling for each depth <= maxPos.depth.
+                // Since deeper nodes are children of shallower nodes, a shallower node terminates
+                // all lines for deeper depths. Thus, we only set a bit if we find a depth that is
+                // strictly shallower than the shallowest depth we've seen so far in our look-ahead.
+                if (d < minDepthSeen) {
+                    minDepthSeen = d
+                    activeLines = activeLines.setBit(d)
+                    if (d == 0) break // Root node resets everything below it
+                }
+            }
+        }
+
+        // Scan backwards over the sorted visible items to record the active lines after each node
+        for (j in visibleViews.indices.reversed()) {
+            val (pos, view) = visibleViews[j]
+            val node = currentList.getOrNull(pos)
+            if (node == null) {
+                scratchBuffer[j] = 0L
+                continue
+            }
+
+            // We store the bitmask we made earlier in the scratch buffer for each row so that we can
+            // know which lines need to pass through this row to reach the decks after it
+            scratchBuffer[j] = activeLines.value
+
+            // We look at the last deck that we can see and store it in d
+            // eg:- if we have a child at the bottom of depth 2 our bits look like 0100
+            val d = node.depth
+            if (d < 64) {
+                // We do an or with the activeLines (activelines stores the number of lines passing through
+                // the current row) and this will give us the number of lines to draw
+                activeLines = activeLines.setBit(d).clearDeeperThan(d)
+            }
+        }
+
+        // Get the ItemAnimator to help compute drawing parameters during animations
+        val isAnimating = parent.itemAnimator?.isRunning ?: false
+
+        // Create a layer to prevent alpha compounding of overlapping lines during animations
+        val saveCount = c.saveLayer(0f, 0f, parent.width.toFloat(), parent.height.toFloat(), layerPaint)
+
+        // Loop to draw the lines
+        for (j in visibleViews.indices) {
+            val (position, view) = visibleViews[j]
+            val node = currentList.getOrNull(position)
+            if (node == null) continue
+
+            val nextNode = currentList.getOrNull(position + 1)
+            drawLinesForView(
+                c = c,
+                view = view,
+                node = node,
+                nextNode = nextNode,
+                siblingMask = scratchBuffer[j],
+                isAnimating = isAnimating,
+            )
+        }
+
+        c.restoreToCount(saveCount)
+    }
+
+    private fun drawLinesForView(
+        c: Canvas,
+        view: android.view.View,
+        node: com.ichi2.anki.deckpicker.DisplayDeckNode,
+        nextNode: com.ichi2.anki.deckpicker.DisplayDeckNode?,
+        siblingMask: Long,
+        isAnimating: Boolean,
+    ) {
+        val viewAlpha = view.alpha
+        // Hide lines entirely for views that are collapsing/disappearing
+        if (viewAlpha <= 0f) return
+
+        val context = view.context
+        // Apply a smooth fade out to lines when the item shrinks vertically
+        val heightRatio =
+            if (isAnimating && view.height < 48.dp.toPx(context)) {
+                view.height / 48.dp.toPx(context).toFloat()
+            } else {
+                1f
+            }
+        paint.alpha = (255 * viewAlpha * heightRatio).toInt().coerceIn(0, 255)
+
+        val depth = node.depth
+
+        // Handle vertical animation offsets
+        val translationY = view.translationY
+        val top = view.top + translationY
+        val bottom = view.bottom + translationY
+        val centerY = top + view.height / 2f
+
+        val bitSet = DepthBitSet(siblingMask)
+        // Helper to check the precomputed bitmask
+        val hasSibling = { targetDepth: Int ->
+            bitSet.hasBit(targetDepth)
+        }
+
+        for (level in 0 until depth - 1) {
+            if (hasSibling(level + 1)) {
+                val x = getLineX(level)
+                c.drawLine(x, top, x, bottom, paint)
+            }
+        }
+
+        if (depth > 0) {
+            val level = depth - 1
+            val x = getLineX(level)
+            val childCenterX = getLineX(depth)
+            // If the node has no children (is a leaf), the line should exactly match the visible
+            // termination point of the lines pointing to sibling chevrons.
+            val horizontalExtension = childCenterX - iconGap
+            val endX = maxOf(x + cornerRadius, horizontalExtension)
+
+            if (hasSibling(depth)) {
+                // Draw vertical line as top and bottom segments to avoid overlap at the T-junction
+                // which causes darker color from alpha overdraw
+                val strokeHalf = paint.strokeWidth / 2f
+                c.drawLine(x, top, x, centerY - strokeHalf, paint)
+                // If the view is animating out and shrinking, we shouldn't draw the bottom vertical stroke
+                // extending into empty space, as it causes a momentary visual glitch grid
+                if (!isAnimating || view.height >= 48.dp.toPx(context)) {
+                    c.drawLine(x, centerY + strokeHalf, x, bottom, paint)
+                }
+                // Draw horizontal line ending right at the vertical stroke's edge
+                c.drawLine(x - strokeHalf, centerY, endX, centerY, paint)
+            } else {
+                reusablePath.reset()
+                reusablePath.moveTo(x, top)
+                reusablePath.lineTo(x, centerY - cornerRadius)
+                reusableRect.set(x, centerY - 2 * cornerRadius, x + 2 * cornerRadius, centerY)
+                reusablePath.arcTo(reusableRect, 180f, -90f, false)
+                reusablePath.lineTo(endX, centerY)
+                c.drawPath(reusablePath, paint)
+            }
+        }
+
+        // The vertical line originating beneath the chevron must be anchored to the chevron's
+        // Y-coordinate center + offset instead of the view's center, since padding/layout might
+        // cause the chevron to not be perfectly centered relative to the view bounds
+        if (nextNode != null && nextNode.depth == depth + 1 && (!isAnimating || view.height >= 48.dp.toPx(context))) {
+            val x = getLineX(depth)
+            val chevronBottomY = centerY + iconGap
+            c.drawLine(x, chevronBottomY, x, bottom, paint)
+        }
+    }
+
+    private fun getLineX(depth: Int): Float =
+        depth * nestedIndent +
+            expanderCenterOffset +
+            if (depth == 0) 0f else adapter.nestedExpanderOffset
+
+    companion object {
+        private const val LINE_STROKE_WIDTH_DP = 2f
+        private const val ALPHA_LIGHT = 30
+        private const val ALPHA_DARK = 50
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerScreenshotTest.kt
@@ -3,6 +3,7 @@
 
 package com.ichi2.anki
 
+import android.content.Intent
 import androidx.core.content.edit
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.testutils.BackupManagerTestUtilities
@@ -47,4 +48,110 @@ class DeckPickerScreenshotTest : ScreenshotTest() {
             deckPicker.simulateEdgeToEdge()
             captureScreen("edgeToEdge_30_decks")
         }
+
+    @Test
+    fun hierarchy_lines() {
+        targetContext.sharedPrefs().edit { putBoolean("devBottomNav", true) }
+
+        val root1 = addDeck("Math")
+        addDeck("Math::Algebra")
+        addDeck("Math::Algebra::Linear")
+        addDeck("Math::Geometry")
+        val root2 = addDeck("Science")
+        addDeck("Science::Physics")
+        addDeck("Science::Physics::Kinematics")
+        addDeck("Science::Chemistry")
+
+        val deckPicker =
+            startActivityNormallyOpenCollectionWithIntent(DeckPicker::class.java, Intent()).also {
+                RobolectricTest.advanceRobolectricLooper()
+            }
+
+        // Expand root nodes to see children
+        deckPicker.viewModel.toggleDeckExpand(root1)
+        deckPicker.viewModel.toggleDeckExpand(root2)
+        RobolectricTest.advanceRobolectricLooper()
+
+        // Also expand Math::Algebra and Science::Physics to see deep nesting
+        deckPicker.viewModel.toggleDeckExpand(col.decks.id("Math::Algebra"))
+        deckPicker.viewModel.toggleDeckExpand(col.decks.id("Science::Physics"))
+        RobolectricTest.advanceRobolectricLooper()
+
+        captureScreen("hierarchy_lines")
+    }
+
+    @Test
+    fun hierarchy_lines_collapsed() {
+        targetContext.sharedPrefs().edit { putBoolean("devBottomNav", true) }
+
+        val root = addDeck("Math")
+        addDeck("Math::Algebra")
+        addDeck("Math::Algebra::Linear")
+        addDeck("Math::Geometry")
+        addDeck("Science::Physics::Kinematics")
+
+        val deckPicker =
+            startActivityNormallyOpenCollectionWithIntent(DeckPicker::class.java, Intent()).also {
+                RobolectricTest.advanceRobolectricLooper()
+            }
+
+        // Expand Math to see Algebra and Geometry, but leave Algebra collapsed
+        deckPicker.viewModel.toggleDeckExpand(root)
+        RobolectricTest.advanceRobolectricLooper()
+
+        captureScreen("hierarchy_lines_collapsed")
+    }
+
+    @Test
+    fun hierarchy_lines_deep_nesting() {
+        targetContext.sharedPrefs().edit { putBoolean("devBottomNav", true) }
+
+        val root = addDeck("Level1")
+        addDeck("Level1::Level2")
+        addDeck("Level1::Level2::Level3")
+        addDeck("Level1::Level2::Level3::Level4")
+        addDeck("Level1::Level2::Level3::Level4::Level5")
+        addDeck("Level1::Level2::Level3::Level4::Level5::Level6")
+        addDeck("Level1::Level2::Level3::Level4::Level5::Level6::Level7")
+        addDeck("Level1::Level2::Sibling")
+        addDeck("Level1::Sibling")
+
+        val deckPicker =
+            startActivityNormallyOpenCollectionWithIntent(DeckPicker::class.java, Intent()).also {
+                RobolectricTest.advanceRobolectricLooper()
+            }
+
+        // Expand all levels
+        for (i in 1..6) {
+            val name = (1..i).joinToString("::") { "Level$it" }
+            deckPicker.viewModel.toggleDeckExpand(col.decks.id(name))
+        }
+        RobolectricTest.advanceRobolectricLooper()
+
+        captureScreen("hierarchy_lines_deep_nesting")
+    }
+
+    @Test
+    fun hierarchy_lines_many_siblings() {
+        targetContext.sharedPrefs().edit { putBoolean("devBottomNav", true) }
+
+        val root = addDeck("Parent")
+        addDeck("Parent::Child1")
+        addDeck("Parent::Child2")
+        val child3 = addDeck("Parent::Child3")
+        addDeck("Parent::Child3::Subchild")
+        addDeck("Parent::Child4")
+        addDeck("Parent::Child5")
+
+        val deckPicker =
+            startActivityNormallyOpenCollectionWithIntent(DeckPicker::class.java, Intent()).also {
+                RobolectricTest.advanceRobolectricLooper()
+            }
+
+        deckPicker.viewModel.toggleDeckExpand(root)
+        deckPicker.viewModel.toggleDeckExpand(child3)
+        RobolectricTest.advanceRobolectricLooper()
+
+        captureScreen("hierarchy_lines_many_siblings")
+    }
 }


### PR DESCRIPTION
> [!NOTE]  
> Used Gemini 3.1 Pro to help write the code for the bit mask approach (horrible at math, so this was an experiment).  All comments are my own, tested completely with the emulator and with a very large deck.
<!--- Please fill the necessary details below -->
## Purpose / Description
Draws hierarchy lines for the new deck picker redesign.

## Fixes
* For GSoC 2026: Redesign Deck Picker

## Approach
We use a bit mask approach since looping through every row to draw all the lines is very inefficient, I've tried to comment it as much as possible with examples so that should explain the approach.

## How Has This Been Tested?
[Screen_recording_20260714_231431.webm](https://github.com/user-attachments/assets/5d0ee1f0-d843-4091-b057-4d1c6e72eeda)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->