### PR TITLE
fix(filtered-deck): preserve error message for InvalidSearchException…

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/filtered/FilteredDeckOptionsViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/filtered/FilteredDeckOptionsViewModel.kt
@@ -155,7 +155,13 @@ class FilteredDeckOptionsViewModel(
             buildBrowserQueryResult
                 .onFailure { throwable ->
                     updateCurrentState {
-                        currentState().copy(throwable = InvalidSearchException(cause = throwable))
+                        currentState().copy(
+                            throwable =
+                                InvalidSearchException(
+                                    cause = throwable,
+                                    message = throwable.localizedMessage,
+                                ),
+                        )
                     }
                 }.onSuccess {
                     updateCurrentState { currentState().copy(browserQuery = buildBrowserQueryResult.getOrThrow()) }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/filtered/FilteredDeckOptionsViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/filtered/FilteredDeckOptionsViewModelTest.kt
@@ -25,6 +25,7 @@ import anki.decks.filteredDeckForUpdate
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.Flag
 import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.exception.InvalidSearchException
 import com.ichi2.anki.flagCardForNote
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.Note
@@ -200,6 +201,21 @@ class FilteredDeckOptionsViewModelTest : RobolectricTest() {
                 assertThat(currentState.browserQuery, equalTo("deck:A flag:1"))
                 clearSearchInBrowser()
                 assertNull((state.value as FilteredDeckOptions).browserQuery)
+            }
+        }
+
+    @Test
+    fun `invalid search in browser produces state with error`() =
+        runTest {
+            withViewModel {
+                onSearchChange(FilterIndex.First, "\"deck:A is:new")
+                onSearchInBrowser(FilterIndex.First)
+                val currentState = state.value
+                assertInstanceOf<FilteredDeckOptions>(currentState)
+                assertNotNull(currentState.throwable)
+                assertInstanceOf<InvalidSearchException>(currentState.throwable)
+                assertNull(currentState.browserQuery)
+                clearError()
             }
         }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

<!---
Uncomment this section if AI tools were used. New contributors may not use AI tools. See:
https://github.com/ankidroid/Anki-Android/blob/main/AI_POLICY.md
> [!NOTE]
> Assisted-by: ___
--->

## Purpose / Description
Crash when trying to preview an invalid search in the filtered deck options. when a user enters an invalid search query 
(eg->"is:nee") and taps the search icon, the app crashes with "IllegalArgumentException either 'stringRes' or 'text' must be set".
## Fixes
* Fixes #21338

## Approach
The root cause is that "FilteredDeckOptionsViewModel.onSearchBrowser()" creates and exception without preserving the message from the original "BackendSearchException". The message property was null, which caused the error dialog to crash when trying to display it.
## How Has This Been Tested?

Tested the fixes on Pixel 8a(emulator android 17) and VivoV27(android 15), added regression test and also ran unit test FilteredDeckOptionsViewModelTest to ensure existing functionality is preserved.

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->