### PR TITLE
fix(tts): prefer an installed voice for locale-only tags

### DIFF
--- a/libanki/src/main/java/com/ichi2/anki/libanki/Tts.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Tts.kt
@@ -92,13 +92,11 @@ abstract class TtsPlayer : Closeable {
             rank -= 1
         }
 
-        // if no preferred voices match, we fall back on language
-        // with a rank of -100
-        for (avail in availVoices) {
-            if (avail.lang == tag.lang) {
-                return TtsVoiceMatch(voice = avail, rank = -100)
-            }
-        }
-        return null
+        // No requested voice matched, so fall back on the language with a rank of -100.
+        // Prefer one that's actually installed: Android lists voices flagged unavailable
+        // (KEY_FEATURE_NOT_INSTALLED) that fail on playback, so only use one as a last resort (#21372)
+        val langMatches = availVoices.filter { it.lang == tag.lang }
+        val fallbackVoice = langMatches.firstOrNull { !it.unavailable() } ?: langMatches.firstOrNull()
+        return fallbackVoice?.let { TtsVoiceMatch(voice = it, rank = -100) }
     }
 }

--- a/libanki/src/test/java/com/ichi2/anki/libanki/TtsTest.kt
+++ b/libanki/src/test/java/com/ichi2/anki/libanki/TtsTest.kt
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2026 Ashish Yadav <mailtoashish693@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.libanki
+
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.notNullValue
+import org.hamcrest.CoreMatchers.nullValue
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+
+/** Test for [TtsPlayer.voiceForTag] */
+class TtsTest {
+    @Test
+    fun `locale-only match prefers an installed voice over an unavailable one`() {
+        val unavailable = testVoice(name = "fr-unavailable", lang = "fr_FR", unavailable = true)
+        val installed = testVoice(name = "fr-installed", lang = "fr_FR", unavailable = false)
+        val player = testPlayer(unavailable, installed)
+
+        val match = player.voiceForTag(ttsTag("fr_FR"))
+
+        assertThat(match, notNullValue())
+        assertThat("locale-only selection should skip the unavailable voice", match!!.voice, equalTo(installed))
+    }
+
+    @Test
+    fun `locale-only match falls back to an unavailable voice when nothing else is installed`() {
+        val unavailable = testVoice(name = "fr-unavailable", lang = "fr_FR", unavailable = true)
+        val player = testPlayer(unavailable)
+
+        val match = player.voiceForTag(ttsTag("fr_FR"))
+
+        assertThat(match?.voice, equalTo(unavailable))
+    }
+
+    @Test
+    fun `locale-only match keeps the first installed voice when several are installed`() {
+        val first = testVoice(name = "fr-1", lang = "fr_FR", unavailable = false)
+        val second = testVoice(name = "fr-2", lang = "fr_FR", unavailable = false)
+        val player = testPlayer(first, second)
+
+        assertThat(player.voiceForTag(ttsTag("fr_FR"))?.voice, equalTo(first))
+    }
+
+    @Test
+    fun `locale-only fallback keeps the first unavailable voice when none are installed`() {
+        val first = testVoice(name = "fr-1", lang = "fr_FR", unavailable = true)
+        val second = testVoice(name = "fr-2", lang = "fr_FR", unavailable = true)
+        val player = testPlayer(first, second)
+
+        assertThat(player.voiceForTag(ttsTag("fr_FR"))?.voice, equalTo(first))
+    }
+
+    @Test
+    fun `no match when no voice shares the language`() {
+        val player = testPlayer(testVoice(name = "en", lang = "en_US", unavailable = false))
+
+        assertThat(player.voiceForTag(ttsTag("fr_FR")), nullValue())
+    }
+
+    @Test
+    fun `no match when there are no voices at all`() {
+        val player = testPlayer()
+
+        assertThat(player.voiceForTag(ttsTag("fr_FR")), nullValue())
+    }
+
+    private fun ttsTag(lang: String) =
+        TTSTag(fieldText = "bonjour", lang = lang, voices = emptyList(), speed = null, otherArgs = emptyList())
+
+    private fun testVoice(
+        name: String,
+        lang: String,
+        unavailable: Boolean,
+    ) = object : TtsVoice(name = name, lang = lang) {
+        override fun unavailable(): Boolean = unavailable
+    }
+
+    private fun testPlayer(vararg voices: TtsVoice) =
+        object : TtsPlayer() {
+            override fun getAvailableVoices(): List<TtsVoice> = voices.toList()
+
+            override suspend fun play(tag: TTSTag): TtsCompletionStatus = TtsCompletionStatus.success()
+
+            override fun close() {}
+        }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

> [!NOTE]
> Assisted-by: Claude Opus 4.8- Writing tests

## Purpose / Description
When a card template uses a locale-only native TTS tag such as `{{tts fr_FR:Front}}` (no explicit `voices=`), AnkiDroid could pick a voice that is not installed and fail playback with `ERROR_NOT_INSTALLED_YET`, even when an installed voice for that language was available. So I am fixing that in this PR 

## Fixes
* Fixes #21372

## Approach
See commit

## How Has This Been Tested?
Unit tests and verified on Pixel 10 (reproduced the issue then build again on fix - works fine)

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->