### PR TITLE
fix(reviewer): replace AlphaAnimation with ViewPropertyanimator in AnswerFeedbackView

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/AnswerFeedbackView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/AnswerFeedbackView.kt
@@ -19,7 +19,6 @@ import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import android.util.AttributeSet
-import android.view.animation.Animation
 import android.view.animation.AnimationUtils
 import androidx.appcompat.widget.AppCompatImageView
 import com.ichi2.anki.R
@@ -36,11 +35,12 @@ class AnswerFeedbackView : AppCompatImageView {
     private val handler = Handler(Looper.getMainLooper())
 
     /**
-     * Shows the feedback for one second
-     * with a quick fade in, brief hold, then gentle fade out.
+     * Shows the feedback with a quick fade in, brief hold, then gentle fade out.
+     * uses ViewPropertyAnimator instead of legacy AlphaAnimation to avoid compositing
+     * artifacts with WebView backdrop-filter when Frame style "Box" removes card elevation.
      */
     fun toggle() {
-        clearAnimation()
+        animate().cancel()
 
         fadeOutRunnable?.let {
             handler.removeCallbacks(it)
@@ -59,39 +59,25 @@ class AnswerFeedbackView : AppCompatImageView {
             return
         }
 
-        val fadeIn = AnimationUtils.loadAnimation(context, R.anim.answer_feedback_fade_in)
-        val fadeOut = AnimationUtils.loadAnimation(context, R.anim.answer_feedback_fade_out)
+        alpha = 0f
+        visibility = VISIBLE
 
-        fadeIn.setAnimationListener(
-            object : Animation.AnimationListener {
-                override fun onAnimationStart(animation: Animation) {
-                    visibility = VISIBLE
-                }
-
-                override fun onAnimationEnd(animation: Animation) {
-                    fadeOutRunnable =
-                        Runnable {
-                            startAnimation(fadeOut)
-                        }.also {
-                            handler.postDelayed(it, 400)
-                        }
-                }
-
-                override fun onAnimationRepeat(animation: Animation) {}
-            },
-        )
-        fadeOut.setAnimationListener(
-            object : Animation.AnimationListener {
-                override fun onAnimationStart(animation: Animation) {}
-
-                override fun onAnimationEnd(animation: Animation) {
-                    visibility = GONE
-                    fadeOutRunnable = null
-                }
-
-                override fun onAnimationRepeat(animation: Animation) {}
-            },
-        )
-        startAnimation(fadeIn)
+        animate()
+            .alpha(1f)
+            .setDuration(150)
+            .setInterpolator(AnimationUtils.loadInterpolator(context, android.R.interpolator.fast_out_slow_in))
+            .withEndAction {
+                fadeOutRunnable =
+                    Runnable {
+                        animate()
+                            .alpha(0f)
+                            .setDuration(250)
+                            .setInterpolator(AnimationUtils.loadInterpolator(context, android.R.interpolator.fast_out_linear_in))
+                            .withEndAction {
+                                visibility = GONE
+                                fadeOutRunnable = null
+                            }.start()
+                    }.also { handler.postDelayed(it, 400.milliseconds) }
+            }.start()
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/AnswerFeedbackView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/AnswerFeedbackView.kt
@@ -16,8 +16,6 @@
 package com.ichi2.anki.ui.windows.reviewer
 
 import android.content.Context
-import android.os.Handler
-import android.os.Looper
 import android.util.AttributeSet
 import android.view.animation.AnimationUtils
 import androidx.appcompat.widget.AppCompatImageView
@@ -31,8 +29,19 @@ class AnswerFeedbackView : AppCompatImageView {
     constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
     constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
 
-    private var fadeOutRunnable: Runnable? = null
-    private val handler = Handler(Looper.getMainLooper())
+    private val fadeOut =
+        Runnable {
+            if (!Animations.areAnimationsEnabled(context)) {
+                visibility = GONE
+            } else {
+                animate()
+                    .alpha(0f)
+                    .setDuration(250)
+                    .setInterpolator(AnimationUtils.loadInterpolator(context, android.R.interpolator.fast_out_linear_in))
+                    .withEndAction { visibility = GONE }
+                    .start()
+            }
+        }
 
     /**
      * Shows the feedback with a quick fade in, brief hold, then gentle fade out.
@@ -42,20 +51,11 @@ class AnswerFeedbackView : AppCompatImageView {
     fun toggle() {
         animate().cancel()
 
-        fadeOutRunnable?.let {
-            handler.removeCallbacks(it)
-            fadeOutRunnable = null
-        }
+        removeCallbacks(fadeOut)
 
         if (!Animations.areAnimationsEnabled(context)) {
             visibility = VISIBLE
-            fadeOutRunnable =
-                Runnable {
-                    visibility = GONE
-                    fadeOutRunnable = null
-                }.also {
-                    handler.postDelayed(it, 800.milliseconds)
-                }
+            postDelayed(fadeOut, 800.milliseconds)
             return
         }
 
@@ -67,17 +67,7 @@ class AnswerFeedbackView : AppCompatImageView {
             .setDuration(150)
             .setInterpolator(AnimationUtils.loadInterpolator(context, android.R.interpolator.fast_out_slow_in))
             .withEndAction {
-                fadeOutRunnable =
-                    Runnable {
-                        animate()
-                            .alpha(0f)
-                            .setDuration(250)
-                            .setInterpolator(AnimationUtils.loadInterpolator(context, android.R.interpolator.fast_out_linear_in))
-                            .withEndAction {
-                                visibility = GONE
-                                fadeOutRunnable = null
-                            }.start()
-                    }.also { handler.postDelayed(it, 400.milliseconds) }
+                postDelayed(fadeOut, 400.milliseconds)
             }.start()
     }
 }

--- a/AnkiDroid/src/main/res/anim/answer_feedback_fade_in.xml
+++ b/AnkiDroid/src/main/res/anim/answer_feedback_fade_in.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<alpha xmlns:android="http://schemas.android.com/apk/res/android"
-    android:fromAlpha="0.0"
-    android:toAlpha="1.0"
-    android:duration="150"
-    android:interpolator="@android:interpolator/fast_out_slow_in" />

--- a/AnkiDroid/src/main/res/anim/answer_feedback_fade_out.xml
+++ b/AnkiDroid/src/main/res/anim/answer_feedback_fade_out.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<alpha xmlns:android="http://schemas.android.com/apk/res/android"
-    android:fromAlpha="1.0"
-    android:toAlpha="0.0"
-    android:duration="250"
-    android:interpolator="@android:interpolator/fast_out_linear_in" />


### PR DESCRIPTION

<!--- Please fill the necessary details below -->

<!---
Uncomment this section if AI tools were used. New contributors may not use AI tools. See:
https://github.com/ankidroid/Anki-Android/blob/main/AI_POLICY.md
> [!NOTE]
> Assisted-by: ___
--->

## Purpose / Description
Fixes a dark smudge/visual artifact at the top edge of card content when flipping cards in the new study screen .                                                                                                              
The artifact appears when all the following conditions are met:                                                                                      
  - Dark mode (night theme) enabled                                                                                                                    
  - "Show answer feedback" enabled (Settings > Study Screen)                                                                                           
  - Frame style set to "Box" (Settings > Study Screen > Frame style)                                                                                   
  - Cards use custom CSS with "backdrop-filter" / translucent background
## Fixes
* Fixes #21380 

## Approach

- AlphaAnimation puts the view on a software layer, but the WebView's backdrop-filter uses a hardware backdrop root layer. Normally the card's elevation/rounded corners hide the seam, but Frame style "Box" turns both off (PreviewerHelpers.kt:setFrameStyle()), so it shows.
- Switched to ViewPropertyAnimator hardware accelerated, composites correctly with the backdrop layer. Same timing/interpolators, no visual change otherwise.
- Also removed the two now unused XML animation files.         

## How Has This Been Tested?

- Unit tests have been run and verified 
- Manually tested the fix with the version before and after on 2 devices -> (VivoV27-15) (Pixel-8a-17-emulator)


## Learning (optional, can help others)

- "ViewPropertyAnimator" is hardware-accelerated and participates in the normal layer
- "android.view.animation.Animation" forces a software layer on the view 
- WebView with "backdrop-filter" creates a hardware layer that captures what's behind it for the blur effect

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->