### PR TITLE
fix(notifications): migrate legacy due-card reminders to review remin…

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -34,6 +34,8 @@
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.GET_PACKAGE_SIZE" android:maxSdkVersion="25" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <!-- Used when granted; AlarmManagerService falls back to setWindow when unavailable. -->
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
@@ -649,6 +651,7 @@
             >
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
         </receiver>
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -53,6 +53,7 @@ import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.preferences.SharedPreferencesProvider
 import com.ichi2.anki.servicelayer.DebugInfoService
 import com.ichi2.anki.servicelayer.ThrowableFilterService
+import com.ichi2.anki.reviewreminders.LegacyNotificationMigrator
 import com.ichi2.anki.services.AlarmManagerService
 import com.ichi2.anki.services.NotificationService
 import com.ichi2.anki.settings.Prefs
@@ -67,7 +68,9 @@ import com.ichi2.widget.DayRolloverAlarm
 import com.ichi2.widget.cardanalysis.CardAnalysisWidget
 import com.ichi2.widget.deckpicker.DeckPickerWidget
 import com.ichi2.widget.restoreRecurringAlarms
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 import timber.log.Timber.DebugTree
 import java.util.Locale
@@ -322,15 +325,18 @@ open class AnkiDroidApp :
             setupNotificationChannels(applicationContext)
 
             val context = this.withAppLocale()
-            if (Prefs.newReviewRemindersEnabled) {
-                Timber.i("Setting review reminder notifications if they have not already been set")
-                applicationScope.launch {
+            applicationScope.launch(Dispatchers.IO) {
+                LegacyNotificationMigrator.migrateIfNeeded(context)
+                if (Prefs.newReviewRemindersEnabled) {
+                    Timber.i("Scheduling review reminder notifications")
                     AlarmManagerService.scheduleAllNotifications(context)
+                } else {
+                    Timber.i("AnkiDroidApp: Registering legacy notification LiveData observer")
+                    // LiveData.observeForever must run on the main thread.
+                    withContext(Dispatchers.Main) {
+                        notifications.observeForever { NotificationService.triggerNotificationFor(context) }
+                    }
                 }
-            } else {
-                // Register for notifications
-                Timber.i("AnkiDroidApp: Starting Services")
-                notifications.observeForever { NotificationService.triggerNotificationFor(context) }
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/LegacyNotificationMigrator.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/LegacyNotificationMigrator.kt
@@ -1,0 +1,162 @@
+/*
+ *  Copyright (c) 2026 AnkiDroid Contributors
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.reviewreminders
+
+import android.app.AlarmManager
+import android.content.Context
+import android.content.Intent
+import androidx.annotation.VisibleForTesting
+import androidx.core.app.PendingIntentCompat
+import androidx.core.content.edit
+import androidx.core.content.getSystemService
+import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.R
+import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.preferences.PENDING_NOTIFICATIONS_ONLY
+import com.ichi2.anki.services.NotificationService
+import com.ichi2.anki.settings.Prefs
+import timber.log.Timber
+
+/**
+ * One-time migration from the legacy daily due-card notification preference to the
+ * [ReviewReminder] system.
+ *
+ * The legacy path used [AlarmManager.setRepeating] and read a cached widget due-count from MetaDB.
+ * Both of those behaviors are unreliable on modern Android (Doze / process death), so production
+ * traffic is moved to [com.ichi2.anki.services.AlarmManagerService] + live due-count queries.
+ *
+ * Migration preserves the user's threshold and fires at the collection day-rollover hour
+ * (same wall-clock intent as the legacy daily alarm).
+ */
+object LegacyNotificationMigrator {
+    /**
+     * Promotes the review-reminder system and, when the user previously had legacy notifications
+     * enabled, creates an equivalent global [ReviewReminder].
+     *
+     * Safe to call repeatedly: subsequent invocations are no-ops once
+     * [Prefs.legacyNotificationsMigrated] is true.
+     */
+    suspend fun migrateIfNeeded(context: Context) {
+        if (Prefs.legacyNotificationsMigrated) {
+            Timber.d("Legacy notification migration already completed")
+            return
+        }
+
+        Timber.i("Starting legacy notification → review reminder migration")
+        Prefs.newReviewRemindersEnabled = true
+
+        val legacyThreshold = readLegacyThreshold(context)
+        if (legacyThreshold < PENDING_NOTIFICATIONS_ONLY) {
+            migrateEnabledLegacyPreference(context, legacyThreshold)
+        } else {
+            Timber.i("Legacy notifications were disabled; enabling review reminders UI only")
+        }
+
+        cancelLegacyRepeatingAlarm(context)
+        Prefs.legacyNotificationsMigrated = true
+        Timber.i("Legacy notification migration completed")
+    }
+
+    @VisibleForTesting
+    internal suspend fun migrateEnabledLegacyPreference(
+        context: Context,
+        legacyThreshold: Int,
+    ) {
+        val existingGlobal = ReviewRemindersDatabase.getRemindersForScope(ReviewReminderScope.Global)
+        if (!existingGlobal.isEmpty()) {
+            Timber.i(
+                "Skipping reminder creation: %d global review reminder(s) already exist",
+                existingGlobal.getRemindersList().size,
+            )
+        } else {
+            val hour = readRolloverHourOfDay(context)
+            val reminder =
+                ReviewReminder.createReviewReminder(
+                    time = ReviewReminderTime(hour, 0),
+                    cardTriggerThreshold = ReviewReminderCardTriggerThreshold(legacyThreshold),
+                    scope = ReviewReminderScope.Global,
+                    enabled = true,
+                )
+            ReviewRemindersDatabase.insertReminder(reminder)
+            Timber.i(
+                "Created migrated global review reminder id=%d threshold=%d hour=%d",
+                reminder.id.value,
+                legacyThreshold,
+                hour,
+            )
+        }
+
+        // Disable the legacy pref so the two systems cannot both appear active in settings.
+        context.sharedPrefs().edit {
+            putString(
+                context.getString(R.string.pref_notifications_minimum_cards_due_key),
+                PENDING_NOTIFICATIONS_ONLY.toString(),
+            )
+        }
+    }
+
+    @VisibleForTesting
+    internal fun readLegacyThreshold(context: Context): Int =
+        context
+            .sharedPrefs()
+            .getString(
+                context.getString(R.string.pref_notifications_minimum_cards_due_key),
+                PENDING_NOTIFICATIONS_ONLY.toString(),
+            )!!
+            .toInt()
+
+    /**
+     * Matches the hour used by the legacy [com.ichi2.anki.services.BootService.scheduleNotification]
+     * daily alarm so migrated users keep the same notification wall-clock time.
+     */
+    @VisibleForTesting
+    internal fun readRolloverHourOfDay(context: Context): Int {
+        val defValue = 4
+        return try {
+            val col = CollectionManager.getColUnsafe()
+            when (col.schedVer()) {
+                1 -> context.sharedPrefs().getInt("dayOffset", defValue)
+                2 -> col.config.get("rollover") ?: defValue
+                else -> context.sharedPrefs().getInt("dayOffset", defValue)
+            }
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to read day rollover hour for migration; using default %d", defValue)
+            defValue
+        }
+    }
+
+    /**
+     * Cancels the legacy request-code-0 [NotificationService] repeating alarm if one exists.
+     */
+    @VisibleForTesting
+    internal fun cancelLegacyRepeatingAlarm(context: Context) {
+        val pendingIntent =
+            PendingIntentCompat.getBroadcast(
+                context,
+                0,
+                Intent(context, NotificationService::class.java),
+                0,
+                false,
+            ) ?: return
+        try {
+            context.getSystemService<AlarmManager>()?.cancel(pendingIntent)
+            Timber.i("Cancelled legacy repeating notification alarm")
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to cancel legacy repeating notification alarm")
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingViewModel.kt
@@ -111,8 +111,9 @@ sealed class TroubleshootingCheck {
      * A user can request [android.Manifest.permission.SCHEDULE_EXACT_ALARM] on API 31+
      * which allows scheduling of exact alarms.
      *
-     * TODO: We do not currently support this in the manifest, but we should do
-     * before launch
+     * Declared in the manifest; [com.ichi2.anki.services.AlarmManagerService] uses exact alarms
+     * when [android.app.AlarmManager.canScheduleExactAlarms] is true and falls back to
+     * [android.app.AlarmManager.setWindow] otherwise.
      *
      * https://developer.android.com/about/versions/14/changes/schedule-exact-alarms
      */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/AlarmManagerService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/AlarmManagerService.kt
@@ -21,6 +21,7 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import androidx.annotation.VisibleForTesting
 import androidx.core.app.PendingIntentCompat
 import androidx.core.content.getSystemService
@@ -36,7 +37,9 @@ import com.ichi2.anki.runGloballyWithTimeout
 import com.ichi2.anki.utils.ext.getParcelableCompat
 import timber.log.Timber
 import java.util.Calendar
+import java.util.Date
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
@@ -169,15 +172,17 @@ class AlarmManagerService : AnkiBroadcastReceiver() {
          * Queues a review reminder to have its notification fired at its specified time. Does not check
          * if the review reminder is enabled or not, the caller must handle this.
          *
-         * Note that this only schedules the next upcoming notification, using [AlarmManager.setWindow]
-         * rather than [AlarmManager.setRepeating]. This is because [AlarmManager.setRepeating] sometimes
-         * postpones alarm firings for long periods of time, with intervals as long as one hour observed
-         * in testing. In contrast, [AlarmManager.setWindow] permits us to specify a maximum allowable
-         * length of time the OS can delay the alarm for, leading to a better UX. Each time an alarm is fired,
-         * triggering [NotificationService.sendReviewReminderNotification], this method is called again to
-         * schedule the next upcoming notification. If for some reason the next day's alarm fails to be set by
-         * the current day's notification, we fall back to setting alarms whenever the application process is started: see
-         * [com.ichi2.anki.AnkiDroidApp]'s call to [scheduleAllEnabledReviewReminderNotifications].
+         * Note that this only schedules the next upcoming notification rather than using
+         * [AlarmManager.setRepeating]. Repeating alarms are heavily deferred under Doze
+         * (hour-scale delays observed in testing). Instead we use
+         * [AlarmManager.scheduleReminderAlarm], which prefers
+         * [AlarmManager.setExactAndAllowWhileIdle] when exact alarms are permitted and falls
+         * back to [AlarmManager.setWindow] with a 10-minute window. Each time an alarm fires,
+         * triggering [NotificationService.sendReviewReminderNotification], this method is called
+         * again to schedule the next upcoming notification. If for some reason the next day's alarm
+         * fails to be set by the current day's notification, we fall back to setting alarms whenever
+         * the application process is started: see [com.ichi2.anki.AnkiDroidApp]'s call to
+         * [scheduleAllEnabledReviewReminderNotifications].
          *
          * If an old version of this review reminder with the same review reminder ID has already had
          * its notifications scheduled, this will merely update the existing notifications. If, however,
@@ -237,13 +242,16 @@ class AlarmManagerService : AnkiBroadcastReceiver() {
             }
 
             catchAlarmManagerExceptions(context) { alarmManager ->
-                alarmManager.setWindow(
-                    AlarmManager.RTC_WAKEUP,
-                    alarmTimestamp.timeInMillis,
-                    WINDOW_LENGTH_MS,
-                    pendingIntent,
+                alarmManager.scheduleReminderAlarm(
+                    triggerAtMillis = alarmTimestamp.timeInMillis,
+                    operation = pendingIntent,
                 )
-                Timber.d("Successfully scheduled review reminder notifications for ${reviewReminder.id}")
+                Timber.i(
+                    "Scheduled review reminder id=%d for %s (in %s)",
+                    reviewReminder.id.value,
+                    Date(alarmTimestamp.timeInMillis),
+                    (alarmTimestamp.timeInMillis - currentTimestamp.timeInMillis).milliseconds,
+                )
             }
         }
 
@@ -269,7 +277,7 @@ class AlarmManagerService : AnkiBroadcastReceiver() {
             Timber.v("Pending intent for ${reviewReminder.id} is $pendingIntent")
             catchAlarmManagerExceptions(context) { alarmManager ->
                 alarmManager.cancel(pendingIntent)
-                Timber.d("Successfully unscheduled review reminder notifications for ${reviewReminder.id}")
+                Timber.i("Unscheduled review reminder notifications for id=%d", reviewReminder.id.value)
             }
         }
 
@@ -366,13 +374,15 @@ class AlarmManagerService : AnkiBroadcastReceiver() {
             val alarmTimestamp = TimeManager.time.calendar()
             alarmTimestamp.add(Calendar.MINUTE, snoozeIntervalInMinutes)
             catchAlarmManagerExceptions(context) { alarmManager ->
-                alarmManager.setWindow(
-                    AlarmManager.RTC_WAKEUP,
-                    alarmTimestamp.timeInMillis,
-                    WINDOW_LENGTH_MS,
-                    pendingIntent,
+                alarmManager.scheduleReminderAlarm(
+                    triggerAtMillis = alarmTimestamp.timeInMillis,
+                    operation = pendingIntent,
                 )
-                Timber.d("Successfully scheduled snoozed review reminder notifications for ${reviewReminder.id}")
+                Timber.i(
+                    "Scheduled snooze for reminder id=%d in %d minutes",
+                    reviewReminder.id.value,
+                    snoozeIntervalInMinutes,
+                )
             }
         }
 
@@ -386,6 +396,40 @@ class AlarmManagerService : AnkiBroadcastReceiver() {
             // currently, the only scheduled notifications supported by AnkiDroid are review reminder notifications
             scheduleAllEnabledReviewReminderNotifications(context)
         }
+
+        /**
+         * Schedules an alarm that wakes the device to fire a review reminder notification.
+         *
+         * Prefer [AlarmManager.setExactAndAllowWhileIdle] when exact alarms are allowed so Doze
+         * does not defer the reminder past the study window. Fall back to [AlarmManager.setWindow]
+         * (10-minute window) when exact alarms are unavailable — e.g. Android 12+ without
+         * [android.Manifest.permission.SCHEDULE_EXACT_ALARM] granted.
+         */
+        @VisibleForTesting
+        fun AlarmManager.scheduleReminderAlarm(
+            triggerAtMillis: Long,
+            operation: PendingIntent,
+        ) {
+            if (canUseExactAlarms()) {
+                setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, operation)
+                Timber.d("Used setExactAndAllowWhileIdle for reminder alarm")
+            } else {
+                setWindow(AlarmManager.RTC_WAKEUP, triggerAtMillis, WINDOW_LENGTH_MS, operation)
+                Timber.d("Used setWindow fallback for reminder alarm (exact alarms unavailable)")
+            }
+        }
+
+        /**
+         * Whether this process may schedule exact alarms.
+         * Pre-API 31: exact alarms do not require [android.Manifest.permission.SCHEDULE_EXACT_ALARM].
+         */
+        @VisibleForTesting
+        fun AlarmManager.canUseExactAlarms(): Boolean =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                canScheduleExactAlarms()
+            } else {
+                true
+            }
 
         /**
          * Method for getting an intent to snooze a review reminder for this service.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
@@ -33,6 +33,7 @@ import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.utils.android.showThemedToast
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.preferences.PENDING_NOTIFICATIONS_ONLY
+import com.ichi2.anki.reviewreminders.LegacyNotificationMigrator
 import com.ichi2.anki.runGloballyWithTimeout
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.widget.DayRolloverAlarm
@@ -42,11 +43,12 @@ import java.util.Calendar
 import kotlin.time.Duration.Companion.seconds
 
 /**
- * BroadcastReceiver which listens to the Android system-level intent that fires when the device starts up.
- * Schedules notifications for review reminders.
+ * BroadcastReceiver which listens to system intents that require review-reminder (and widget)
+ * alarms to be (re)scheduled: boot completed, app update, and (via [DayRolloverAlarm]) time changes.
  *
- * Note that Android battery optimizations may potentially block us from receiving the [Intent.ACTION_BOOT_COMPLETED]
- * intent, which could cause review reminders to not be scheduled.
+ * Note that Android battery optimizations may potentially block us from receiving
+ * [Intent.ACTION_BOOT_COMPLETED], which could cause review reminders to not be scheduled until
+ * the next process start ([com.ichi2.anki.AnkiDroidApp] also schedules on launch).
  */
 @NeedsTest("Check on various Android versions that this can execute")
 class BootService : AnkiBroadcastReceiver() {
@@ -57,38 +59,52 @@ class BootService : AnkiBroadcastReceiver() {
         context: Context,
         intent: Intent,
     ) {
-        if (!intent.action.equals(Intent.ACTION_BOOT_COMPLETED)) {
-            Timber.w("BootService - unexpected action received, ignoring: %s", intent.action)
+        val action = intent.action
+        if (action !in SUPPORTED_ACTIONS) {
+            Timber.w("BootService - unexpected action received, ignoring: %s", action)
             return
         }
-        if (wasRun) {
-            Timber.d("BootService - Already run")
+        Timber.i("BootService received %s", action)
+
+        // Package replacement and boot must always reschedule; do not skip via wasRun for updates.
+        val isBoot = action == Intent.ACTION_BOOT_COMPLETED
+        if (isBoot && wasRun) {
+            Timber.d("BootService - Already run for this process")
             return
         }
-        if (runCatching { grantedStoragePermissions(context, showToast = false) }.getOrNull() != true) {
-            Timber.w("Boot Service did not execute - no permissions")
-            return
-        }
-        if (Prefs.newReviewRemindersEnabled) {
+
+        // Always migrate first so production traffic uses review reminders even if the
+        // developer kill-switch preference was previously persisted as false.
+        if (Prefs.newReviewRemindersEnabled || !Prefs.legacyNotificationsMigrated) {
             Timber.i("Executing Boot Service - Review reminders")
             runGloballyWithTimeout(SCHEDULE_NOTIFICATIONS_TIMEOUT) {
-                AlarmManagerService.scheduleAllNotifications(context)
+                LegacyNotificationMigrator.migrateIfNeeded(context)
+                if (Prefs.newReviewRemindersEnabled) {
+                    AlarmManagerService.scheduleAllNotifications(context)
+                }
             }
-        } else {
-            // There are cases where the app is installed, and we have access, but nothing exist yet
-            val col = getColSafe()
-            if (col == null) {
-                Timber.w("Boot Service did not execute - error loading collection")
-                return
+        }
+
+        if (!Prefs.newReviewRemindersEnabled) {
+            if (runCatching { grantedStoragePermissions(context, showToast = false) }.getOrNull() != true) {
+                Timber.w("Boot Service did not execute legacy path - no storage permissions")
+            } else {
+                val col = getColSafe()
+                if (col == null) {
+                    Timber.w("Boot Service did not execute - error loading collection")
+                } else {
+                    Timber.i("Executing Boot Service - Legacy notifications")
+                    catchAlarmManagerErrors(context) { scheduleNotification(TimeManager.time, context) }
+                    failedToShowNotifications = false
+                }
             }
-            Timber.i("Executing Boot Service")
-            catchAlarmManagerErrors(context) { scheduleNotification(TimeManager.time, context) }
-            failedToShowNotifications = false
         }
 
         restoreRecurringAlarms(context)
         DayRolloverAlarm.scheduleNext(context)
-        wasRun = true
+        if (isBoot) {
+            wasRun = true
+        }
     }
 
     @LegacyNotifications("Will be moved to AlarmManagerService")
@@ -139,9 +155,15 @@ class BootService : AnkiBroadcastReceiver() {
          */
         private val SCHEDULE_NOTIFICATIONS_TIMEOUT = 8.seconds
 
+        private val SUPPORTED_ACTIONS =
+            setOf(
+                Intent.ACTION_BOOT_COMPLETED,
+                Intent.ACTION_MY_PACKAGE_REPLACED,
+            )
+
         /**
          * This service is also run when the app is started (from [com.ichi2.anki.AnkiDroidApp],
-         * so we need to make sure that it isn't run twice.
+         * so we need to make sure that it isn't run twice for BOOT_COMPLETED in the same process.
          */
         private var wasRun = false
 
@@ -177,6 +199,10 @@ class BootService : AnkiBroadcastReceiver() {
                     false,
                 )
             if (notificationIntent != null) {
+                Timber.i(
+                    "Scheduling legacy repeating notification alarm at hour=%d",
+                    calendar.get(Calendar.HOUR_OF_DAY),
+                )
                 alarmManager.setRepeating(
                     AlarmManager.RTC_WAKEUP,
                     calendar.timeInMillis,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
@@ -44,6 +44,7 @@ import com.ichi2.anki.runGloballyWithTimeout
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.utils.ext.getParcelableCompat
 import com.ichi2.anki.utils.remainingTime
+import com.ichi2.utils.Permissions
 import com.ichi2.widget.WidgetStatus
 import net.ankiweb.rsdroid.BackendException
 import timber.log.Timber
@@ -173,6 +174,14 @@ class NotificationService : AnkiBroadcastReceiver() {
             Timber.i("sendReviewReminderNotification for ${reviewReminder.id}")
             Timber.v("Review reminder: $reviewReminder")
 
+            if (!Permissions.canPostNotifications(context)) {
+                Timber.w(
+                    "Aborting notification for review reminder %d: POST_NOTIFICATIONS not granted",
+                    reviewReminder.id.value,
+                )
+                return
+            }
+
             if (reviewReminder.scope is ReviewReminderScope.DeckSpecific) {
                 val isDeckAccessible = canUserAccessDeck(reviewReminder.scope.did)
                 if (!isDeckAccessible) {
@@ -275,7 +284,11 @@ class NotificationService : AnkiBroadcastReceiver() {
 
             val manager = context.getSystemService<NotificationManager>()
             if (manager != null) {
-                Timber.i("Sending notification with ID ${reviewReminder.id.value}")
+                Timber.i(
+                    "Posting review reminder notification tag=%s id=%d",
+                    REVIEW_REMINDER_NOTIFICATION_TAG,
+                    reviewReminder.id.value,
+                )
                 manager.notify(REVIEW_REMINDER_NOTIFICATION_TAG, reviewReminder.id.value, builder.build())
             } else {
                 Timber.w("Failed to get NotificationManager system service, aborting review reminder notification")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -279,9 +279,18 @@ open class PrefsRepository(
     // ************************************** Review Reminders ********************************** //
 
     /**
-     * Whether to enable the new review reminders notification system.
+     * Whether to enable the review reminders notification system (replaces legacy due-card notifications).
+     *
+     * Default is `true`. Kept as a developer-options kill-switch while the legacy path is retained
+     * for emergency rollback; see [legacyNotificationsMigrated].
      */
-    var newReviewRemindersEnabled by booleanPref(R.string.pref_new_review_reminders, false)
+    var newReviewRemindersEnabled by booleanPref(R.string.pref_new_review_reminders, true)
+
+    /**
+     * Whether the one-time migration from legacy `minimumCardsDueForNotification` preferences
+     * into [com.ichi2.anki.reviewreminders.ReviewReminder]s has completed.
+     */
+    var legacyNotificationsMigrated by booleanPref(R.string.pref_legacy_notifications_migrated_key, false)
 
     /**
      * Review reminder IDs are unique, starting at 0 and climbing upwards by one each time a new one is created.

--- a/AnkiDroid/src/main/java/com/ichi2/widget/DayRolloverAlarm.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/DayRolloverAlarm.kt
@@ -37,6 +37,7 @@ import com.ichi2.anki.libanki.EpochMilliseconds
 import com.ichi2.anki.libanki.sched.Scheduler
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.services.AlarmManagerService
+import com.ichi2.anki.settings.Prefs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import timber.log.Timber
@@ -64,7 +65,11 @@ class DayRolloverAlarm : AnkiBroadcastReceiver() {
                     runCatching { WidgetStatus.updateInBackground(context) }.onFailure { Timber.w(it) }
                     scheduleNextInternal(context)
                 }
-                ACTION_TIMEZONE_CHANGED, ACTION_TIME_CHANGED -> scheduleNextInternal(context)
+                ACTION_TIMEZONE_CHANGED, ACTION_TIME_CHANGED -> {
+                    Timber.i("Time/timezone changed: rescheduling day rollover and review reminders")
+                    scheduleNextInternal(context)
+                    rescheduleReviewReminders(context)
+                }
             }
         }
     }
@@ -120,6 +125,12 @@ class DayRolloverAlarm : AnkiBroadcastReceiver() {
                 PendingIntent.FLAG_UPDATE_CURRENT,
                 false,
             )
+
+        private suspend fun rescheduleReviewReminders(context: Context) {
+            if (!Prefs.newReviewRemindersEnabled) return
+            Timber.i("Rescheduling review reminders after time/timezone change")
+            AlarmManagerService.scheduleAllNotifications(context)
+        }
     }
 }
 

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -231,6 +231,7 @@
     <string name="new_congrats_screen_pref_key">new_congrats_screen</string>
     <string name="new_reviewer_options_key">newReviewerOptions</string>
     <string name="pref_new_review_reminders">newReviewReminders</string>
+    <string name="pref_legacy_notifications_migrated_key">legacyNotificationsMigrated</string>
     <string name="developer_options_enabled_by_user_key">devOptionsEnabledByUser</string>
     <string name="pref_cat_wip_key">workInProgressDevOptions</string>
     <string name="reviewer_port_pref_key">reviewerPort</string>

--- a/AnkiDroid/src/main/res/xml/preferences_developer_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_developer_options.xml
@@ -112,9 +112,10 @@
             android:key="@string/dev_card_browser_search_view"
             android:defaultValue="false"/>
         <SwitchPreferenceCompat
-            android:title="Enable new notifications"
+            android:title="Review reminders (production)"
+            android:summary="Disable only to roll back to the legacy daily due-card notification"
             android:key="@string/pref_new_review_reminders"
-            android:defaultValue="false"/>
+            android:defaultValue="true"/>
         <SwitchPreferenceCompat
             android:title="Switch Profile option"
             android:key="@string/pref_enable_switch_profile_key"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/LegacyNotificationMigratorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/LegacyNotificationMigratorTest.kt
@@ -1,0 +1,146 @@
+/*
+ *  Copyright (c) 2026 AnkiDroid Contributors
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.reviewreminders
+
+import android.content.Context
+import androidx.core.content.edit
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.R
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.preferences.PENDING_NOTIFICATIONS_ONLY
+import com.ichi2.anki.settings.Prefs
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasSize
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LegacyNotificationMigratorTest : RobolectricTest() {
+    private lateinit var context: Context
+
+    @Before
+    override fun setUp() {
+        super.setUp()
+        context = targetContext
+        Prefs.legacyNotificationsMigrated = false
+        Prefs.newReviewRemindersEnabled = false
+        ReviewRemindersDatabase.remindersSharedPrefs.edit { clear() }
+        context.sharedPrefs().edit {
+            putString(
+                context.getString(R.string.pref_notifications_minimum_cards_due_key),
+                PENDING_NOTIFICATIONS_ONLY.toString(),
+            )
+        }
+    }
+
+    @After
+    override fun tearDown() {
+        ReviewRemindersDatabase.remindersSharedPrefs.edit { clear() }
+        Prefs.legacyNotificationsMigrated = false
+        super.tearDown()
+    }
+
+    @Test
+    fun `migration is idempotent`() =
+        runTest {
+            LegacyNotificationMigrator.migrateIfNeeded(context)
+            assertThat(Prefs.legacyNotificationsMigrated, equalTo(true))
+            assertThat(Prefs.newReviewRemindersEnabled, equalTo(true))
+
+            Prefs.newReviewRemindersEnabled = false
+            LegacyNotificationMigrator.migrateIfNeeded(context)
+            // Second call must not re-enable or re-run side effects beyond the completed flag.
+            assertThat(Prefs.newReviewRemindersEnabled, equalTo(false))
+            assertThat(Prefs.legacyNotificationsMigrated, equalTo(true))
+        }
+
+    @Test
+    fun `disabled legacy notifications enable review reminders without creating a reminder`() =
+        runTest {
+            LegacyNotificationMigrator.migrateIfNeeded(context)
+
+            assertThat(Prefs.newReviewRemindersEnabled, equalTo(true))
+            assertThat(Prefs.legacyNotificationsMigrated, equalTo(true))
+            assertThat(
+                ReviewRemindersDatabase.getRemindersForScope(ReviewReminderScope.Global).getRemindersList(),
+                hasSize(0),
+            )
+        }
+
+    @Test
+    fun `enabled legacy notifications create an equivalent global reminder`() =
+        runTest {
+            val legacyThreshold = 10
+            context.sharedPrefs().edit {
+                putString(
+                    context.getString(R.string.pref_notifications_minimum_cards_due_key),
+                    legacyThreshold.toString(),
+                )
+            }
+
+            LegacyNotificationMigrator.migrateIfNeeded(context)
+
+            val reminders =
+                ReviewRemindersDatabase.getRemindersForScope(ReviewReminderScope.Global).getRemindersList()
+            assertThat(reminders, hasSize(1))
+            val reminder = reminders.single()
+            assertThat(reminder.enabled, equalTo(true))
+            assertThat(reminder.cardTriggerThreshold.threshold, equalTo(legacyThreshold))
+            assertThat(reminder.scope, equalTo(ReviewReminderScope.Global))
+            assertThat(reminder.time.minute, equalTo(0))
+            assertThat(Prefs.newReviewRemindersEnabled, equalTo(true))
+
+            // Legacy pref should be disabled after migration.
+            val migratedThreshold =
+                context
+                    .sharedPrefs()
+                    .getString(
+                        context.getString(R.string.pref_notifications_minimum_cards_due_key),
+                        null,
+                    )!!
+                    .toInt()
+            assertThat(migratedThreshold, equalTo(PENDING_NOTIFICATIONS_ONLY))
+        }
+
+    @Test
+    fun `existing global reminders are not duplicated`() =
+        runTest {
+            val existing =
+                ReviewReminder.createReviewReminder(
+                    time = ReviewReminderTime(9, 30),
+                    cardTriggerThreshold = ReviewReminderCardTriggerThreshold(1),
+                )
+            ReviewRemindersDatabase.insertReminder(existing)
+            context.sharedPrefs().edit {
+                putString(
+                    context.getString(R.string.pref_notifications_minimum_cards_due_key),
+                    "5",
+                )
+            }
+
+            LegacyNotificationMigrator.migrateIfNeeded(context)
+
+            val reminders =
+                ReviewRemindersDatabase.getRemindersForScope(ReviewReminderScope.Global).getRemindersList()
+            assertThat(reminders, hasSize(1))
+            assertThat(reminders.single().id, equalTo(existing.id))
+        }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/AlarmManagerServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/AlarmManagerServiceTest.kt
@@ -77,6 +77,9 @@ class AlarmManagerServiceTest : RobolectricTest() {
         reviewReminder = ReviewReminder.createReviewReminder(time = ReviewReminderTime(20, 0))
         reviewReminder.latestNotifTime = mockTime.intTimeMS() // Ensure the reminder is ready to have its future instance scheduled
 
+        // Default Robolectric SDK is >= S; without permission, scheduleReminderAlarm uses setWindow.
+        every { alarmManager.canScheduleExactAlarms() } returns false
+
         TimeManager.resetWith(mockTime)
         ReviewRemindersDatabase.remindersSharedPrefs.edit { clear() }
     }
@@ -87,6 +90,26 @@ class AlarmManagerServiceTest : RobolectricTest() {
         unmockkAll()
         TimeManager.reset()
         ReviewRemindersDatabase.remindersSharedPrefs.edit { clear() }
+    }
+
+    @Test
+    fun `scheduleReviewReminderNotifications calls setExactAndAllowWhileIdle when exact alarms allowed`() {
+        every { alarmManager.canScheduleExactAlarms() } returns true
+        val expectedSchedulingTime = mockTime.calendar().clone() as Calendar
+        expectedSchedulingTime.apply {
+            set(Calendar.HOUR_OF_DAY, 20)
+        }
+        AlarmManagerService.scheduleReviewReminderNotification(context, reviewReminder, attemptImmediateNotification = false)
+        verify {
+            alarmManager.setExactAndAllowWhileIdle(
+                AlarmManager.RTC_WAKEUP,
+                expectedSchedulingTime.timeInMillis,
+                any(),
+            )
+        }
+        verify(exactly = 0) {
+            alarmManager.setWindow(any(), any(), any(), any())
+        }
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NotificationServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NotificationServiceTest.kt
@@ -36,6 +36,7 @@ import com.ichi2.anki.reviewreminders.ReviewReminderScope.Global
 import com.ichi2.anki.reviewreminders.ReviewReminderTime
 import com.ichi2.anki.reviewreminders.ReviewRemindersDatabase
 import com.ichi2.anki.settings.Prefs
+import com.ichi2.utils.Permissions
 import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.mockk
@@ -107,6 +108,25 @@ class NotificationServiceTest : RobolectricTest() {
             verifyNextNotifScheduled(reviewReminderAppWide)
             reviewReminderDeckSpecific.verifyLatestNotifTime(previousTime = deckSpecificCreationTime, shouldHaveUpdated = true)
             reviewReminderAppWide.verifyLatestNotifTime(previousTime = appWideCreationTime, shouldHaveUpdated = true)
+        }
+
+    @Test
+    fun `triggering without notification permission should not fire notification but schedule next`() =
+        runTest {
+            mockkObject(Permissions)
+            every { Permissions.canPostNotifications(any()) } returns false
+
+            val did1 = addDeck("Deck", setAsSelected = true).withNotes(count = 2)
+            val reviewReminder = createTestReminder(deckId = did1)
+            val creationTime = reviewReminder.latestNotifTime
+            ReviewRemindersDatabase.insertReminder(reviewReminder)
+
+            TimeManager.resetWith(today)
+            attemptNotif(reviewReminder)
+
+            verifyNoNotifsSent()
+            verifyNextNotifScheduled(reviewReminder)
+            reviewReminder.verifyLatestNotifTime(previousTime = creationTime, shouldHaveUpdated = true)
         }
 
     @Test


### PR DESCRIPTION
# Fix: Promote Review Reminders and Migrate Legacy Due-Card Notifications

## Summary

#21385 

This PR fixes the long-standing issue where due-card notifications fail to appear unless AnkiDroid is manually opened.

After investigating the existing implementation, I found that the legacy notification flow relies on outdated scheduling behavior and stale due-card state, making it unreliable on modern Android versions. Instead of patching the legacy implementation, this PR promotes the existing review reminder system (currently behind the developer option) to the production path and performs a one-time migration of existing notification preferences.

The goal is to improve notification reliability while reusing the newer reminder architecture that already exists in the project.

## What Changed

* Enabled the new review reminder system as the default notification implementation.
* Added a one-time migration from legacy due-card notification preferences to review reminders.
* Replaced legacy scheduling with a more reliable alarm scheduling strategy, including fallback behavior when exact alarms are unavailable.
* Improved reminder rescheduling after device reboot, app update, and time/timezone changes.
* Added notification permission checks before posting reminders.
* Added structured logging to simplify future debugging.
* Preserved backward compatibility with a migration flag and developer kill-switch.
* Added unit tests covering migration, scheduling, and notification behavior.

## Why This Approach?

The existing legacy notification system has been acknowledged by the maintainers as unreliable, while the newer review reminder implementation already addresses many of those limitations.

Rather than maintaining two different notification systems, this PR builds upon the newer implementation and migrates existing users automatically. This reduces maintenance overhead and aligns the production path with the project's intended direction.

## Expected Result

Before:

* Due-card notifications often never appeared.
* Notifications usually started working only after manually opening AnkiDroid.
* Reminder scheduling was inconsistent on newer Android versions.

After:

* Review reminders are scheduled reliably without requiring the app to be opened.
* Existing users keep their notification preferences through automatic migration.
* Reminders are rescheduled correctly after reboot, app updates, and system time changes.
* Notification behavior is more consistent across modern Android releases.

## Testing

The implementation was verified by:

* Migrating existing legacy notification settings.
* Testing reminder scheduling and rescheduling.
* Verifying notification permission handling.
* Testing exact alarm fallback behavior.
* Running the relevant unit tests for migration, scheduling, and notification services.

## Notes

This PR intentionally reuses the existing review reminder implementation instead of extending the legacy notification system. The legacy path remains available as a rollback option if needed, while the new implementation becomes the default going forward.
