### PR TITLE
fix(reviewer): eliminate compositing artifact during answer feedback …

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/AnswerFeedbackView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/AnswerFeedbackView.kt
@@ -19,14 +19,26 @@ import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import android.util.AttributeSet
-import android.view.animation.Animation
-import android.view.animation.AnimationUtils
 import androidx.appcompat.widget.AppCompatImageView
-import com.ichi2.anki.R
+import androidx.interpolator.view.animation.FastOutLinearInInterpolator
+import androidx.interpolator.view.animation.FastOutSlowInInterpolator
 import com.ichi2.anki.common.android.Animations
 import com.ichi2.anki.utils.postDelayed
 import kotlin.time.Duration.Companion.milliseconds
 
+/**
+ * Brief ease-rating indicator overlaid on the reviewer WebView.
+ *
+ * Uses [android.view.ViewPropertyAnimator] (RenderNode alpha) rather than legacy
+ * [android.view.animation.Animation]. Legacy [android.view.animation.AlphaAnimation] only affects
+ * how the view is drawn each frame and does not update the RenderNode alpha used by HWUI. When
+ * Frame style is Box ([com.ichi2.anki.previewer.setFrameStyle] clears elevation / rounded outline),
+ * that drawing-time alpha composites against Chromium's `backdrop-filter` layers while the next
+ * card loads, producing a dark smudge at the top edge (issue 21380). Elevated Card style isolates
+ * children in a separate compositing layer and hides the seam. Property animation participates in
+ * normal HWUI composition and avoids the artifact without permanent hardware layers or frame-style
+ * changes.
+ */
 class AnswerFeedbackView : AppCompatImageView {
     constructor(context: Context) : this(context, null)
     constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
@@ -40,58 +52,72 @@ class AnswerFeedbackView : AppCompatImageView {
      * with a quick fade in, brief hold, then gentle fade out.
      */
     fun toggle() {
-        clearAnimation()
-
-        fadeOutRunnable?.let {
-            handler.removeCallbacks(it)
-            fadeOutRunnable = null
-        }
+        cancelPendingFeedback()
 
         if (!Animations.areAnimationsEnabled(context)) {
+            alpha = 1f
             visibility = VISIBLE
             fadeOutRunnable =
                 Runnable {
-                    visibility = GONE
-                    fadeOutRunnable = null
+                    hideFeedback()
                 }.also {
-                    handler.postDelayed(it, 800.milliseconds)
+                    handler.postDelayed(it, TOTAL_VISIBLE_DURATION)
                 }
             return
         }
 
-        val fadeIn = AnimationUtils.loadAnimation(context, R.anim.answer_feedback_fade_in)
-        val fadeOut = AnimationUtils.loadAnimation(context, R.anim.answer_feedback_fade_out)
+        alpha = 0f
+        animate()
+            .alpha(1f)
+            .setDuration(FADE_IN_MS)
+            .setInterpolator(FADE_IN_INTERPOLATOR)
+            .withStartAction { visibility = VISIBLE }
+            .withEndAction { scheduleFadeOut() }
+            .start()
+    }
 
-        fadeIn.setAnimationListener(
-            object : Animation.AnimationListener {
-                override fun onAnimationStart(animation: Animation) {
-                    visibility = VISIBLE
-                }
+    private fun scheduleFadeOut() {
+        fadeOutRunnable =
+            Runnable {
+                fadeOutRunnable = null
+                animate()
+                    .alpha(0f)
+                    .setDuration(FADE_OUT_MS)
+                    .setInterpolator(FADE_OUT_INTERPOLATOR)
+                    .withEndAction { hideFeedback() }
+                    .start()
+            }.also {
+                handler.postDelayed(it, HOLD_MS.milliseconds)
+            }
+    }
 
-                override fun onAnimationEnd(animation: Animation) {
-                    fadeOutRunnable =
-                        Runnable {
-                            startAnimation(fadeOut)
-                        }.also {
-                            handler.postDelayed(it, 400)
-                        }
-                }
+    private fun hideFeedback() {
+        visibility = GONE
+        // Reset so a later non-animated show, or a cancelled mid-fade, starts from a clean alpha.
+        alpha = 1f
+        fadeOutRunnable = null
+    }
 
-                override fun onAnimationRepeat(animation: Animation) {}
-            },
-        )
-        fadeOut.setAnimationListener(
-            object : Animation.AnimationListener {
-                override fun onAnimationStart(animation: Animation) {}
+    private fun cancelPendingFeedback() {
+        animate().cancel()
+        fadeOutRunnable?.let { handler.removeCallbacks(it) }
+        fadeOutRunnable = null
+    }
 
-                override fun onAnimationEnd(animation: Animation) {
-                    visibility = GONE
-                    fadeOutRunnable = null
-                }
+    override fun onDetachedFromWindow() {
+        cancelPendingFeedback()
+        super.onDetachedFromWindow()
+    }
 
-                override fun onAnimationRepeat(animation: Animation) {}
-            },
-        )
-        startAnimation(fadeIn)
+    companion object {
+        private const val FADE_IN_MS = 150L
+        private const val HOLD_MS = 400L
+        private const val FADE_OUT_MS = 250L
+
+        /** Matches prior fade-in + hold + fade-out when animations are disabled. */
+        private val TOTAL_VISIBLE_DURATION = (FADE_IN_MS + HOLD_MS + FADE_OUT_MS).milliseconds
+
+        private val FADE_IN_INTERPOLATOR = FastOutSlowInInterpolator()
+        private val FADE_OUT_INTERPOLATOR = FastOutLinearInInterpolator()
     }
 }

--- a/AnkiDroid/src/main/res/anim/answer_feedback_fade_in.xml
+++ b/AnkiDroid/src/main/res/anim/answer_feedback_fade_in.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<alpha xmlns:android="http://schemas.android.com/apk/res/android"
-    android:fromAlpha="0.0"
-    android:toAlpha="1.0"
-    android:duration="150"
-    android:interpolator="@android:interpolator/fast_out_slow_in" />

--- a/AnkiDroid/src/main/res/anim/answer_feedback_fade_out.xml
+++ b/AnkiDroid/src/main/res/anim/answer_feedback_fade_out.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<alpha xmlns:android="http://schemas.android.com/apk/res/android"
-    android:fromAlpha="1.0"
-    android:toAlpha="0.0"
-    android:duration="250"
-    android:interpolator="@android:interpolator/fast_out_linear_in" />

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/AnswerFeedbackViewTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/AnswerFeedbackViewTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 AnkiDroid Contributors
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.ui.windows.reviewer
+
+import android.content.Context
+import android.view.View
+import android.widget.FrameLayout
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.R
+import com.ichi2.anki.settings.Prefs
+import com.ichi2.themes.Themes
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.shadows.ShadowLooper
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@RunWith(AndroidJUnit4::class)
+class AnswerFeedbackViewTest {
+    private lateinit var context: Context
+    private lateinit var view: AnswerFeedbackView
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        Themes.setTheme(context)
+        Prefs.putBoolean(R.string.safe_display_key, false)
+        view = AnswerFeedbackView(context)
+    }
+
+    @After
+    fun tearDown() {
+        Prefs.putBoolean(R.string.safe_display_key, false)
+    }
+
+    @Test
+    fun `toggle without animations shows then hides feedback`() {
+        Prefs.putBoolean(R.string.safe_display_key, true)
+
+        view.toggle()
+
+        assertEquals(View.VISIBLE, view.visibility)
+        assertEquals(1f, view.alpha)
+
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+        assertEquals(View.GONE, view.visibility)
+        assertEquals(1f, view.alpha)
+    }
+
+    @Test
+    fun `toggle uses property animation instead of legacy Animation`() {
+        // Attach so ViewPropertyAnimator scheduling matches production.
+        FrameLayout(context).addView(view)
+
+        view.toggle()
+
+        // Legacy AlphaAnimation would set View.getAnimation(); property animation must not.
+        assertNull(view.animation)
+        ShadowLooper.idleMainLooper()
+        assertNull(view.animation)
+        assertEquals(View.VISIBLE, view.visibility)
+
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+        assertNull(view.animation)
+        assertEquals(View.GONE, view.visibility)
+        assertEquals(1f, view.alpha)
+    }
+
+    @Test
+    fun `re-toggle cancels prior fade and remains stable`() {
+        Prefs.putBoolean(R.string.safe_display_key, true)
+
+        view.toggle()
+        view.toggle()
+
+        assertEquals(View.VISIBLE, view.visibility)
+
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+        assertEquals(View.GONE, view.visibility)
+    }
+
+    @Test
+    fun `detach cancels pending hide`() {
+        Prefs.putBoolean(R.string.safe_display_key, true)
+        val parent = FrameLayout(context)
+        parent.addView(view)
+
+        view.toggle()
+        assertEquals(View.VISIBLE, view.visibility)
+
+        // Simulate leaving the reviewer while feedback is visible.
+        parent.removeView(view)
+
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+        // Detach cancelled the hide runnable; visibility is left as-is (parent is gone).
+        assertEquals(View.VISIBLE, view.visibility)
+    }
+}


### PR DESCRIPTION
# Fix dark compositing artifact during answer feedback animation in Box frame style
 #21380 
## Summary

This PR fixes the brief dark smudge that can appear at the top of the reviewer content when flipping cards under a specific combination of settings:

* Dark mode enabled
* **Show answer feedback** enabled
* **Frame style = Box**
* Card styling that uses a translucent background with `backdrop-filter`

The issue does not affect Anki Desktop and is specific to Android's rendering pipeline when the answer feedback animation overlaps with WebView compositing.

## Root Cause

After investigating the reviewer rendering flow, the artifact appears to be caused by the interaction between the legacy `AlphaAnimation` used by `AnswerFeedbackView` and the WebView's hardware-composited rendering.

When a card is rated, the answer feedback animation starts while the reviewer updates and reloads the WebView. In **Box** frame style, the `MaterialCardView` no longer has elevation or rounded outline clipping, so the feedback view and the WebView are composited differently than in the default **Card** style. This can briefly expose a dark seam when cards use `backdrop-filter` and translucent backgrounds.

The default **Card** frame style naturally avoids the issue because its elevated card rendering keeps the content isolated in its own compositing layer.

## Solution

Instead of using the legacy animation framework, this PR migrates the feedback fade animation to `ViewPropertyAnimator`, allowing the animation to participate directly in HWUI/RenderNode rendering.

The implementation also:

* preserves the existing animation timing and visual behaviour
* properly cancels any running animations before starting a new one
* performs lifecycle-safe cleanup when the view is detached
* resets animation state after cancellation to avoid stale UI state

No visual behaviour has been changed apart from eliminating the rendering artifact.

## Why this approach?

I considered a few alternatives during the investigation:

* Restoring elevation or rounded clipping for **Box** mode would change the intended appearance.
* Forcing permanent hardware layers would introduce unnecessary memory overhead.
* Removing or hiding the animation would only mask the symptom.

Using `ViewPropertyAnimator` keeps the existing user experience while aligning the animation with Android's modern rendering pipeline.

## Testing

Manually verified with the following combinations:

* ✅ Dark mode + Box + Feedback enabled + `backdrop-filter`
* ✅ Dark mode + Card + Feedback enabled
* ✅ Light mode
* ✅ Feedback disabled
* ✅ Cards with and without translucent backgrounds

Regression tests have also been added to cover the updated animation behaviour and lifecycle cleanup.

Closes #21380.
