### PR TITLE
feat(reminders): linking to OS notification settings

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/NotificationChannelTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/NotificationChannelTest.kt
@@ -22,7 +22,7 @@ import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SdkSuppress
 import com.ichi2.anki.AnkiDroidApp
-import com.ichi2.anki.Channel
+import com.ichi2.anki.NotificationChannel
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.compat.CompatHelper.Companion.sdkVersion
 import com.ichi2.anki.testutil.GrantStoragePermission
@@ -68,7 +68,7 @@ class NotificationChannelTest : InstrumentedTest() {
         for (i in channels.indices) {
             Timber.d("Found channel with id %s", channels[i].id)
         }
-        var expectedChannels = Channel.entries.size
+        var expectedChannels = NotificationChannel.entries.size
         // If we have channels but have *targeted* pre-26, there is a "miscellaneous" channel auto-defined
         if (targetAPI < 26) {
             expectedChannels += 1
@@ -85,7 +85,7 @@ class NotificationChannelTest : InstrumentedTest() {
             expectedChannels,
             greaterThanOrEqualTo(channels.size),
         )
-        for (channel in Channel.entries) {
+        for (channel in NotificationChannel.entries) {
             assertNotNull(
                 "There should be a reminder channel",
                 manager.getNotificationChannel(channel.id),

--- a/AnkiDroid/src/main/generated/baselineProfiles/baseline-prof.txt
+++ b/AnkiDroid/src/main/generated/baselineProfiles/baseline-prof.txt
@@ -8366,8 +8366,8 @@ SPLcom/ichi2/anki/NoteEditorFragment$Companion$NoteEditorCaller;->getValue()I
 Lcom/ichi2/anki/NoteEditorFragment$Companion$NoteEditorCaller$Companion;
 SPLcom/ichi2/anki/NoteEditorFragment$Companion$NoteEditorCaller$Companion;-><init>()V
 SPLcom/ichi2/anki/NoteEditorFragment$Companion$NoteEditorCaller$Companion;-><init>(Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-Lcom/ichi2/anki/NotificationChannelsKt;
-SPLcom/ichi2/anki/NotificationChannelsKt;->setupNotificationChannels(Landroid/content/Context;)V
+Lcom/ichi2/anki/NotificationChannelKt;
+SPLcom/ichi2/anki/NotificationChannelKt;->setupNotificationChannels(Landroid/content/Context;)V
 Lcom/ichi2/anki/OnErrorListener;
 Lcom/ichi2/anki/OnPageFinishedCallback;
 Lcom/ichi2/anki/PermissionSet;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -516,13 +516,12 @@ open class AnkiActivity(
             }
 
     /**
-     * Calls [.showAsyncDialogFragment] internally, using the channel
-     * [Channel.GENERAL]
+     * Calls [.showAsyncDialogFragment] internally, using the channel [NotificationChannel.GENERAL]
      *
      * @param newFragment  the AsyncDialogFragment you want to show
      */
     open fun showAsyncDialogFragment(newFragment: AsyncDialogFragment) {
-        showAsyncDialogFragment(newFragment, Channel.GENERAL)
+        showAsyncDialogFragment(newFragment, NotificationChannel.GENERAL)
     }
 
     /**
@@ -531,11 +530,11 @@ open class AnkiActivity(
      * AsyncTask completed
      *
      * @param newFragment  the AsyncDialogFragment you want to show
-     * @param channel the Channel to use for the notification
+     * @param channel the [NotificationChannel] to use for the notification
      */
     fun showAsyncDialogFragment(
         newFragment: AsyncDialogFragment,
-        channel: Channel,
+        channel: NotificationChannel,
     ) {
         try {
             showDialogFragment(newFragment)
@@ -571,7 +570,7 @@ open class AnkiActivity(
     fun showSimpleNotification(
         title: String,
         message: String?,
-        channel: Channel,
+        channel: NotificationChannel,
     ) {
         // Use the title as the ticker unless the title is simply "AnkiDroid"
         val ticker: String? =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1847,7 +1847,7 @@ open class DeckPicker :
         message: String?,
     ) {
         val newFragment: AsyncDialogFragment = newInstance(dialogType, message)
-        showAsyncDialogFragment(newFragment, Channel.SYNC)
+        showAsyncDialogFragment(newFragment, NotificationChannel.SYNC)
     }
 
     // Callback method to submit error report

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -477,12 +477,12 @@ class IntentHandler : AbstractIntentHandler() {
                                 remaining,
                                 remaining,
                             )
-                        deckPicker.showSimpleNotification(err, message, Channel.SYNC)
+                        deckPicker.showSimpleNotification(err, message, NotificationChannel.SYNC)
                     } else {
                         deckPicker.showSimpleNotification(
                             err,
                             res.getString(R.string.youre_offline),
-                            Channel.SYNC,
+                            NotificationChannel.SYNC,
                         )
                     }
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NotificationChannel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NotificationChannel.kt
@@ -17,7 +17,6 @@
 
 package com.ichi2.anki
 
-import android.app.NotificationChannel
 import android.content.Context
 import android.content.Intent
 import android.content.res.Resources
@@ -49,7 +48,7 @@ fun setupNotificationChannels(context: Context) {
     val res = context.resources
     val manager = NotificationManagerCompat.from(context)
 
-    for (channel in Channel.entries) {
+    for (channel in NotificationChannel.entries) {
         val id = channel.id
         val name = channel.getName(res)
         Timber.i("Creating notification channel with id/name: %s/%s", id, name)
@@ -74,9 +73,9 @@ fun setupNotificationChannels(context: Context) {
  *
  * @property id The unique identifier for the notification channel.
  * @property nameId The string resource ID for the localized channel name.
- * @property importance The [importance][NotificationChannel.getImportance] of the channel.
+ * @property importance The [importance][android.app.NotificationChannel.getImportance] of the channel.
  */
-enum class Channel(
+enum class NotificationChannel(
     val id: String,
     @StringRes val nameId: Int,
     val importance: Int,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -365,7 +365,7 @@ fun DeckPicker.showSyncLogMessage(
         showSimpleNotification(
             res.getString(R.string.app_name),
             res.getString(messageResource),
-            Channel.SYNC,
+            NotificationChannel.SYNC,
         )
     } else {
         if (syncMessage.isNullOrEmpty()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
@@ -37,7 +37,7 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.ichi2.anki.Channel
+import com.ichi2.anki.NotificationChannel
 import com.ichi2.anki.R
 import com.ichi2.anki.common.utils.android.getColorFromAttr
 import com.ichi2.anki.databinding.FragmentReminderTroubleshootingBinding
@@ -407,7 +407,7 @@ private fun TroubleshootingCheck.resolveAction(): ResolveCheckAction? {
             label = "Enable notification channel",
             logDescription = "opening app notification settings screen",
         ) {
-            fragment.openAppNotificationsSettingsScreen(highlightedChannel = Channel.REVIEW_REMINDERS)
+            fragment.openAppNotificationsSettingsScreen(highlightedChannel = NotificationChannel.REVIEW_REMINDERS)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
@@ -37,6 +37,7 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.ichi2.anki.Channel
 import com.ichi2.anki.R
 import com.ichi2.anki.common.utils.android.getColorFromAttr
 import com.ichi2.anki.databinding.FragmentReminderTroubleshootingBinding
@@ -47,6 +48,7 @@ import com.ichi2.anki.utils.ext.launchCollectionInLifecycleScope
 import com.ichi2.anki.utils.ext.onWindowFocusChanged
 import com.ichi2.anki.utils.ext.requireParcelable
 import com.ichi2.anki.utils.ext.setBackgroundTint
+import com.ichi2.utils.Permissions.openAppNotificationsSettingsScreen
 import com.ichi2.utils.Permissions.requestPermissionThroughDialogOrSettings
 import com.ichi2.utils.dp
 import dev.androidbroadcast.vbpd.viewBinding
@@ -311,6 +313,7 @@ private class TroubleshootingChecksAdapter(
 private fun TroubleshootingCheck.title(): String =
     when (this) {
         is TroubleshootingCheck.NotificationPermission -> "Notification permission"
+        is TroubleshootingCheck.NotificationChannelEnabled -> "Notification channel"
         is TroubleshootingCheck.DoNotDisturbOff -> "Do not disturb"
         is TroubleshootingCheck.UnrestrictedOptimizationEnabled -> "Battery optimization"
         is TroubleshootingCheck.PowerSavingModeOff -> "Power saving mode"
@@ -321,6 +324,7 @@ private fun TroubleshootingCheck.title(): String =
 private fun TroubleshootingCheck.statusName(): String? =
     when (this) {
         is TroubleshootingCheck.NotificationPermission -> if (result == CheckResult.Passed) "Granted" else "Denied"
+        is TroubleshootingCheck.NotificationChannelEnabled -> if (result == CheckResult.Passed) "Enabled" else "Disabled"
         is TroubleshootingCheck.DoNotDisturbOff -> if (result == CheckResult.Passed) "Off" else "On"
         is TroubleshootingCheck.UnrestrictedOptimizationEnabled ->
             when (result) {
@@ -338,6 +342,8 @@ private fun TroubleshootingCheck.explanation(): String? =
     when (this) {
         // no need for an explanation: the 'grant permission' action should be sufficient
         is TroubleshootingCheck.NotificationPermission -> null
+        is TroubleshootingCheck.NotificationChannelEnabled ->
+            if (result.hasIssue) "The review reminder notification channel must be enabled" else null
         is TroubleshootingCheck.DoNotDisturbOff ->
             if (result.hasIssue) "Do Not Disturb may mute reminder notifications" else null
         is TroubleshootingCheck.UnrestrictedOptimizationEnabled ->
@@ -395,6 +401,16 @@ private fun TroubleshootingCheck.resolveAction(): ResolveCheckAction? {
         }
     }
 
+    fun requestReminderNotifChannelPermission(): ResolveCheckAction? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return null
+        return ResolveCheckAction(
+            label = "Enable notification channel",
+            logDescription = "opening app notification settings screen",
+        ) {
+            fragment.openAppNotificationsSettingsScreen(highlightedChannel = Channel.REVIEW_REMINDERS)
+        }
+    }
+
     // Opens the full battery optimization list. The user must manually find the app.
     // For 'full' (non-Play) builds, ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS could be used
     // with the REQUEST_IGNORE_BATTERY_OPTIMIZATIONS manifest permission for a direct dialog,
@@ -422,6 +438,7 @@ private fun TroubleshootingCheck.resolveAction(): ResolveCheckAction? {
 
     return when (this) {
         is TroubleshootingCheck.NotificationPermission -> requestNotificationPermission()
+        is TroubleshootingCheck.NotificationChannelEnabled -> requestReminderNotifChannelPermission()
         is TroubleshootingCheck.DoNotDisturbOff -> null
         is TroubleshootingCheck.UnrestrictedOptimizationEnabled -> requestUnrestrictedBackgroundUsage()
         is TroubleshootingCheck.PowerSavingModeOff -> openBatterySaverSettings()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingRepository.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingRepository.kt
@@ -24,7 +24,7 @@ import android.content.Context
 import android.os.Build
 import android.os.PowerManager
 import androidx.core.content.getSystemService
-import com.ichi2.anki.Channel
+import com.ichi2.anki.NotificationChannel
 import com.ichi2.utils.Permissions
 import com.ichi2.utils.Permissions.arePermissionsDefinedInAnkiDroidManifest
 
@@ -52,7 +52,7 @@ class ReminderTroubleshootingRepository(
     fun isNotificationChannelEnabled(): Boolean? {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return null
         val notificationManager = context.getSystemService<NotificationManager>() ?: return null
-        val channelTest = notificationManager.getNotificationChannel(Channel.REVIEW_REMINDERS.id)
+        val channelTest = notificationManager.getNotificationChannel(NotificationChannel.REVIEW_REMINDERS.id)
         return channelTest?.importance != NotificationManager.IMPORTANCE_NONE
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingRepository.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingRepository.kt
@@ -24,6 +24,7 @@ import android.content.Context
 import android.os.Build
 import android.os.PowerManager
 import androidx.core.content.getSystemService
+import com.ichi2.anki.Channel
 import com.ichi2.utils.Permissions
 import com.ichi2.utils.Permissions.arePermissionsDefinedInAnkiDroidManifest
 
@@ -47,6 +48,13 @@ class ReminderTroubleshootingRepository(
     private val context: Context,
 ) {
     fun isNotificationPermissionGranted(): Boolean = Permissions.canPostNotifications(context)
+
+    fun isNotificationChannelEnabled(): Boolean? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return null
+        val notificationManager = context.getSystemService<NotificationManager>() ?: return null
+        val channelTest = notificationManager.getNotificationChannel(Channel.REVIEW_REMINDERS.id)
+        return channelTest?.importance != NotificationManager.IMPORTANCE_NONE
+    }
 
     fun isDoNotDisturbOff(): Boolean? {
         val notificationManager = context.getSystemService<NotificationManager>() ?: return null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingViewModel.kt
@@ -72,6 +72,14 @@ sealed class TroubleshootingCheck {
     ) : TroubleshootingCheck()
 
     /**
+     * Checks whether the notification channel for review reminders is enabled. Individual channels
+     * can be enabled or disabled by the user on certain operating systems at and above Oreo (API 26).
+     */
+    data class NotificationChannelEnabled(
+        override val result: CheckResult = CheckResult.Loading,
+    ) : TroubleshootingCheck()
+
+    /**
      * Checks whether Do Not Disturb is off.
      *
      * This is a [warning][CheckResult.Warning], not a failure, because DND may be
@@ -139,13 +147,18 @@ enum class SummaryStatus {
     /** Other checks have warnings or failures — reminders may not work correctly. */
     Warning,
 
-    /** Notification permission is denied or errored — reminders cannot work. */
+    /**
+     * The notification permission or the review reminders notification channel is
+     * denied/disabled or errored — reminders cannot work.
+     */
     Error,
 }
 
 data class ReminderTroubleshootingState(
     val notificationPermission: TroubleshootingCheck.NotificationPermission =
         TroubleshootingCheck.NotificationPermission(),
+    val notificationChannelEnabled: TroubleshootingCheck.NotificationChannelEnabled =
+        TroubleshootingCheck.NotificationChannelEnabled(),
     val doNotDisturbOff: TroubleshootingCheck.DoNotDisturbOff =
         TroubleshootingCheck.DoNotDisturbOff(),
     val batteryOptimizationDisabled: TroubleshootingCheck.UnrestrictedOptimizationEnabled =
@@ -159,6 +172,7 @@ data class ReminderTroubleshootingState(
         get() =
             listOf(
                 notificationPermission,
+                notificationChannelEnabled,
                 doNotDisturbOff,
                 batteryOptimizationDisabled,
                 powerSavingModeOff,
@@ -172,9 +186,10 @@ data class ReminderTroubleshootingState(
      */
     val summaryStatus: SummaryStatus
         get() {
-            // If the notification permission is defined, notifications cannot be shown.
-            val permissionCheck = notificationPermission.result
-            if (permissionCheck is CheckResult.Failed || permissionCheck is CheckResult.Error) {
+            // If the notification permission is denied, or the review reminders notification
+            // channel is disabled, notifications cannot be shown.
+            val blockingChecks = listOf(notificationPermission.result, notificationChannelEnabled.result)
+            if (blockingChecks.any { it is CheckResult.Failed || it is CheckResult.Error }) {
                 return SummaryStatus.Error
             }
 
@@ -203,6 +218,10 @@ class ReminderTroubleshootingViewModel(
                 notificationPermission =
                     state.value.notificationPermission.copy(
                         result = CheckResult.from(repository::isNotificationPermissionGranted, onFailure = CheckResult.Failed),
+                    ),
+                notificationChannelEnabled =
+                    state.value.notificationChannelEnabled.copy(
+                        result = CheckResult.from(repository::isNotificationChannelEnabled, onFailure = CheckResult.Failed),
                     ),
                 doNotDisturbOff =
                     state.value.doNotDisturbOff.copy(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
@@ -56,6 +56,7 @@ import com.ichi2.anki.utils.ext.getParcelableCompat
 import com.ichi2.anki.utils.ext.launchCollectionInLifecycleScope
 import com.ichi2.anki.utils.showDialogFragment
 import com.ichi2.anki.withProgress
+import com.ichi2.utils.Permissions.openAppNotificationsSettingsScreen
 import dev.androidbroadcast.vbpd.viewBinding
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
@@ -379,6 +380,10 @@ class ScheduleRemindersFragment :
                 when (menuItem.itemId) {
                     R.id.action_troubleshoot -> {
                         openTroubleshootingScreen()
+                        true
+                    }
+                    R.id.action_notification_settings -> {
+                        openAppNotificationsSettingsScreen()
                         true
                     }
                     else -> false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
@@ -23,10 +23,10 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.app.NotificationCompat
 import androidx.core.app.PendingIntentCompat
 import androidx.core.content.getSystemService
-import com.ichi2.anki.Channel
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.IntentHandler
+import com.ichi2.anki.NotificationChannel
 import com.ichi2.anki.R
 import com.ichi2.anki.canUserAccessDeck
 import com.ichi2.anki.common.android.AnkiBroadcastReceiver
@@ -258,7 +258,7 @@ class NotificationService : AnkiBroadcastReceiver() {
 
             val builder =
                 NotificationCompat
-                    .Builder(context, Channel.REVIEW_REMINDERS.id)
+                    .Builder(context, NotificationChannel.REVIEW_REMINDERS.id)
                     .setCategory(NotificationCompat.CATEGORY_REMINDER)
                     .setSmallIcon(R.drawable.ic_star_notify)
                     .setColor(context.getColor(CommonR.color.material_light_blue_700))
@@ -394,7 +394,7 @@ class NotificationService : AnkiBroadcastReceiver() {
                     NotificationCompat
                         .Builder(
                             context,
-                            Channel.GENERAL.id,
+                            NotificationChannel.GENERAL.id,
                         ).setCategory(NotificationCompat.CATEGORY_REMINDER)
                         .setSmallIcon(R.drawable.ic_star_notify)
                         .setColor(context.getColor(CommonR.color.material_light_blue_700))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
@@ -35,8 +35,8 @@ import androidx.work.WorkerParameters
 import anki.sync.MediaSyncProgress
 import anki.sync.SyncAuth
 import anki.sync.syncAuth
-import com.ichi2.anki.Channel
 import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.NotificationChannel
 import com.ichi2.anki.R
 import com.ichi2.anki.cancelMediaSync
 import com.ichi2.anki.notifications.NotificationId
@@ -153,7 +153,7 @@ class SyncMediaWorker(
 
     private fun buildNotification(block: NotificationCompat.Builder.() -> Unit): Notification =
         NotificationCompat
-            .Builder(applicationContext, Channel.SYNC.id)
+            .Builder(applicationContext, NotificationChannel.SYNC.id)
             .apply {
                 priority = NotificationCompat.PRIORITY_LOW
                 setSmallIcon(R.drawable.ic_star_notify)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncWorker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncWorker.kt
@@ -35,10 +35,10 @@ import anki.collection.Progress
 import anki.sync.SyncAuth
 import anki.sync.SyncCollectionResponse
 import anki.sync.syncAuth
-import com.ichi2.anki.Channel
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.NotificationChannel
 import com.ichi2.anki.R
 import com.ichi2.anki.cancelSync
 import com.ichi2.anki.notifications.NotificationId
@@ -221,7 +221,7 @@ class SyncWorker(
 
     private fun buildNotification(block: NotificationCompat.Builder.() -> Unit): Notification =
         NotificationCompat
-            .Builder(applicationContext, Channel.SYNC.id)
+            .Builder(applicationContext, NotificationChannel.SYNC.id)
             .apply {
                 priority = NotificationCompat.PRIORITY_LOW
                 setSmallIcon(R.drawable.ic_star_notify)

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -32,6 +32,7 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
+import com.ichi2.anki.Channel
 import com.ichi2.anki.PermissionSet
 import com.ichi2.anki.R
 import com.ichi2.anki.common.permissions.MANAGE_EXTERNAL_STORAGE
@@ -112,7 +113,15 @@ object Permissions {
             permissionRequestedFlag.setter.call(true)
             permissionRequestLauncher.launch(permission)
         } else {
-            showToastAndOpenAppSettingsScreen(R.string.manually_grant_permissions)
+            when (permission) {
+                // Add overrides for opening specific settings subscreens here as needed
+                postNotification -> {
+                    showThemedToast(requireContext(), R.string.manually_grant_permissions, false)
+                    openAppNotificationsSettingsScreen()
+                }
+                // Else, default to opening the root page of the app settings screen
+                else -> showToastAndOpenAppSettingsScreen(R.string.manually_grant_permissions)
+            }
         }
     }
 
@@ -258,6 +267,27 @@ object Permissions {
                 Uri.fromParts("package", requireActivity().packageName, null),
             ),
         )
+    }
+
+    /**
+     * Opens the Android notifications settings for AnkiDroid if the device provides this feature.
+     * Otherwise, falls back to opening the generic app settings screen.
+     *
+     * @param highlightedChannel The notification channel to highlight in the notifications settings screen,
+     * to draw the user's attention.
+     */
+    fun Fragment.openAppNotificationsSettingsScreen(highlightedChannel: Channel? = null) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Timber.i("launching ACTION_APP_NOTIFICATION_SETTINGS")
+            startActivity(
+                Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+                    putExtra(Settings.EXTRA_APP_PACKAGE, requireActivity().packageName)
+                    highlightedChannel?.let { putExtra(Settings.EXTRA_CHANNEL_ID, it.id) }
+                },
+            )
+        } else {
+            openAppSettingsScreen()
+        }
     }
 
     fun Fragment.showToastAndOpenAppSettingsScreen(

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -32,7 +32,7 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
-import com.ichi2.anki.Channel
+import com.ichi2.anki.NotificationChannel
 import com.ichi2.anki.PermissionSet
 import com.ichi2.anki.R
 import com.ichi2.anki.common.permissions.MANAGE_EXTERNAL_STORAGE
@@ -276,7 +276,7 @@ object Permissions {
      * @param highlightedChannel The notification channel to highlight in the notifications settings screen,
      * to draw the user's attention.
      */
-    fun Fragment.openAppNotificationsSettingsScreen(highlightedChannel: Channel? = null) {
+    fun Fragment.openAppNotificationsSettingsScreen(highlightedChannel: NotificationChannel? = null) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             Timber.i("launching ACTION_APP_NOTIFICATION_SETTINGS")
             startActivity(

--- a/AnkiDroid/src/main/res/menu/schedule_reminders.xml
+++ b/AnkiDroid/src/main/res/menu/schedule_reminders.xml
@@ -10,4 +10,10 @@
         android:title="Troubleshoot"
         app:showAsAction="always"
         tools:ignore="HardcodedText" />
+    <item
+        android:id="@+id/action_notification_settings"
+        android:icon="@drawable/ic_settings_black"
+        android:title="Notification settings"
+        app:showAsAction="always"
+        tools:ignore="HardcodedText" />
 </menu>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingViewModelTest.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.reviewreminders
 
 import com.ichi2.anki.reviewreminders.TroubleshootingCheck.DoNotDisturbOff
 import com.ichi2.anki.reviewreminders.TroubleshootingCheck.ExactAlarmPermission
+import com.ichi2.anki.reviewreminders.TroubleshootingCheck.NotificationChannelEnabled
 import com.ichi2.anki.reviewreminders.TroubleshootingCheck.NotificationPermission
 import com.ichi2.anki.reviewreminders.TroubleshootingCheck.PowerSavingModeOff
 import com.ichi2.anki.reviewreminders.TroubleshootingCheck.UnrestrictedOptimizationEnabled
@@ -54,6 +55,30 @@ class ReminderTroubleshootingViewModelTest {
         val viewModel = ReminderTroubleshootingViewModel(repo)
 
         assertThat(viewModel.notificationPermissionResult is CheckResult.Error, equalTo(true))
+    }
+
+    @Test
+    fun `notification channel passed when enabled`() {
+        val repo = mockRepository(notificationChannel = true)
+        val viewModel = ReminderTroubleshootingViewModel(repo)
+
+        assertThat(viewModel.notificationChannelEnabledResult, equalTo(CheckResult.Passed))
+    }
+
+    @Test
+    fun `notification channel failed when disabled`() {
+        val repo = mockRepository(notificationChannel = false)
+        val viewModel = ReminderTroubleshootingViewModel(repo)
+
+        assertThat(viewModel.notificationChannelEnabledResult, equalTo(CheckResult.Failed))
+    }
+
+    @Test
+    fun `notification channel unavailable when channels are unsupported`() {
+        val repo = mockRepository(notificationChannel = null)
+        val viewModel = ReminderTroubleshootingViewModel(repo)
+
+        assertThat(viewModel.notificationChannelEnabledResult, equalTo(CheckResult.Unavailable))
     }
 
     @Test
@@ -206,6 +231,18 @@ class ReminderTroubleshootingViewModelTest {
     }
 
     @Test
+    fun `summary status is Error when notification channel disabled`() =
+        withViewModel(notificationChannel = false) {
+            assertThat(state.value.summaryStatus, equalTo(SummaryStatus.Error))
+        }
+
+    @Test
+    fun `summary status is Ok when notification channel unavailable`() =
+        withViewModel(notificationChannel = null) {
+            assertThat(state.value.summaryStatus, equalTo(SummaryStatus.Ok))
+        }
+
+    @Test
     fun `summary status Error takes priority over other warnings`() =
         withViewModel(notificationPermission = false, doNotDisturb = false) {
             assertThat(state.value.summaryStatus, equalTo(SummaryStatus.Error))
@@ -220,17 +257,19 @@ class ReminderTroubleshootingViewModelTest {
             for (check in state.value.checks) {
                 when (check) {
                     is NotificationPermission -> count++
+                    is NotificationChannelEnabled -> count++
                     is DoNotDisturbOff -> count++
                     is UnrestrictedOptimizationEnabled -> count++
                     is PowerSavingModeOff -> count++
                     is ExactAlarmPermission -> count++
                 }
             }
-            assertThat(count, equalTo(5))
+            assertThat(count, equalTo(6))
         }
 
     private fun mockRepository(
         notificationPermission: Boolean = true,
+        notificationChannel: Boolean? = true,
         doNotDisturb: Boolean = true,
         batteryOptimization: BatteryOptimizationState = BatteryOptimizationState.Unrestricted,
         powerSavingModeOff: Boolean = true,
@@ -238,6 +277,7 @@ class ReminderTroubleshootingViewModelTest {
     ): ReminderTroubleshootingRepository =
         mockk {
             every { isNotificationPermissionGranted() } returns notificationPermission
+            every { isNotificationChannelEnabled() } returns notificationChannel
             every { isDoNotDisturbOff() } returns doNotDisturb
             every { getBatteryOptimizationState() } returns batteryOptimization
             every { isPowerSavingModeOff() } returns powerSavingModeOff
@@ -246,19 +286,31 @@ class ReminderTroubleshootingViewModelTest {
 
     private fun withViewModel(
         notificationPermission: Boolean = true,
+        notificationChannel: Boolean? = true,
         doNotDisturb: Boolean = true,
         batteryOptimization: BatteryOptimizationState = BatteryOptimizationState.Unrestricted,
         powerSavingModeOff: Boolean = true,
         exactAlarmPermission: Boolean = true,
         block: ReminderTroubleshootingViewModel.() -> Unit,
     ) {
-        val repo = mockRepository(notificationPermission, doNotDisturb, batteryOptimization, powerSavingModeOff, exactAlarmPermission)
+        val repo =
+            mockRepository(
+                notificationPermission,
+                notificationChannel,
+                doNotDisturb,
+                batteryOptimization,
+                powerSavingModeOff,
+                exactAlarmPermission,
+            )
         ReminderTroubleshootingViewModel(repo).block()
     }
 }
 
 private val ReminderTroubleshootingViewModel.notificationPermissionResult: CheckResult
     get() = state.value.notificationPermission.result
+
+private val ReminderTroubleshootingViewModel.notificationChannelEnabledResult: CheckResult
+    get() = state.value.notificationChannelEnabled.result
 
 private val ReminderTroubleshootingViewModel.doNotDisturbResult: CheckResult
     get() = state.value.doNotDisturbOff.result


### PR DESCRIPTION
## Purpose / Description
A lot of notification customization is offered by modern Android operating systems (ex. allowing notifications to bypass Do Not Disturb, flashing lights, etc.). We should provide an easy way for users to navigate to the OS settings from within AnkiDroid.

See the top left corner in the image below. I decided to put the settings icon on this screen rather than the troubleshooting screen so that 1) it's more salient, allowing more users to be aware of it, and 2) because it's not really related to troubleshooting; putting it in the troubleshooting screen's toolbar might suggest that it leads to troubleshooting settings when in reality it leads to general review reminder and notification settings.

<img width="500" height="1083" alt="Screenshot_20260726_032821_AnkiDroid" src="https://github.com/user-attachments/assets/5a78dfda-99fa-4eb1-bab9-7d902ebc5229" />

## Fixes
* Also fixes an issue where the troubleshooting screen is inaccurate: it's possible on some operating systems to disable notifications on a per-channel basis. This should be surfaced in the troubleshooting screen. See the images below:

<img width="500" height="1083" alt="Screenshot_20260726_032826_AnkiDroid" src="https://github.com/user-attachments/assets/30e1e09b-2ad0-4d31-9ab8-e34fb0e72224" />
<img width="1200" height="1920" alt="Screenshot (Jul 26, 2026 3_29_16 AM)" src="https://github.com/user-attachments/assets/13727ac6-94e2-4507-9e33-603628101ab7" />

## Approach
Augments David's very nicely designed interface in ReminderTroubleshootingFragment/Repository/ViewModel.
Creates openAppNotificationsSettingsScreen, which falls back to the normal app settings screen opener function pre-Oreo. The highlighted channel ID is technically specified in the docs, but it doesn't seem to do anything on my Lenovo tablet. Might as well supply it.

## How Has This Been Tested?
- Builds, unit tests pass.
- Permission granted, revoked, channel permission granted, revoked.
- Changing it in settings then returning to the troubleshooting page has the check instantly reload.
- Clicking on the toolbar button leads to the correct page.
- Tested on a physical Lenovo Tab M11, API 35.
- Tested on a physical Samsung S23, API 36.

## Learning
Accidentally found the channel bug while testing review reminders on my tablet. Decided to package these two changes together since they both rely on `openAppNotificationsSettingsScreen`.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->