### PR TITLE
fix: handle manually disabling notifications pre-Tiramisu

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -28,6 +28,7 @@ import androidx.annotation.RequiresApi
 import androidx.core.content.edit
 import com.ichi2.anki.backend.DatabaseCorruption
 import com.ichi2.anki.common.crashreporting.CrashReportService
+import com.ichi2.anki.common.permissions.LEGACY_POST_NOTIFICATIONS
 import com.ichi2.anki.common.permissions.hasAllPermissions
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.storage.AnkiDroidFolder
@@ -40,6 +41,7 @@ import com.ichi2.anki.servicelayer.PreferenceUpgradeService
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService.setPreferencesUpToDate
 import com.ichi2.anki.servicelayer.ScopedStorageService.isLegacyStorage
 import com.ichi2.anki.ui.windows.permissions.InternetPermissionFragment
+import com.ichi2.anki.ui.windows.permissions.LegacyNotificationsPermissionFragment
 import com.ichi2.anki.ui.windows.permissions.NotificationsPermissionFragment
 import com.ichi2.anki.ui.windows.permissions.PermissionsFragment
 import com.ichi2.anki.ui.windows.permissions.PermissionsStartingAt30Fragment
@@ -221,9 +223,19 @@ enum class PermissionSet(
 
     APP_PRIVATE(Permissions.appPrivateStartupPermissions, InternetPermissionFragment::class.java),
 
-    /** Optional. */
+    /**
+     * Optional. For devices with API >= 33.
+     * @see NotificationsPermissionFragment
+     */
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     NOTIFICATIONS(listOf(Permissions.notificationsPermission), NotificationsPermissionFragment::class.java),
+
+    /**
+     * Optional. For devices with API < 33.
+     * There is no formal permission to request, but it is possible for the user to manually disable notifications in Settings.
+     * If they want notifications, we need to direct the user to the OS settings via the [LegacyNotificationsPermissionFragment] so they can re-enable them.
+     */
+    LEGACY_NOTIFICATIONS(listOf(LEGACY_POST_NOTIFICATIONS), LegacyNotificationsPermissionFragment::class.java),
     ;
 
     fun hasRequiredPermissions(context: Context): Boolean = hasAllPermissions(context, permissions)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -16,7 +16,6 @@
 
 package com.ichi2.anki
 
-import android.Manifest
 import android.content.Context
 import android.content.SharedPreferences
 import android.database.sqlite.SQLiteDatabaseCorruptException
@@ -224,7 +223,7 @@ enum class PermissionSet(
 
     /** Optional. */
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
-    NOTIFICATIONS(listOf(Manifest.permission.POST_NOTIFICATIONS), NotificationsPermissionFragment::class.java),
+    NOTIFICATIONS(listOf(Permissions.notificationsPermission), NotificationsPermissionFragment::class.java),
     ;
 
     fun hasRequiredPermissions(context: Context): Boolean = hasAllPermissions(context, permissions)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -2,7 +2,6 @@
 
 package com.ichi2.anki
 
-import android.Manifest
 import android.content.Context
 import android.content.SharedPreferences
 import android.database.sqlite.SQLiteDatabaseCorruptException
@@ -210,7 +209,7 @@ enum class PermissionSet(
 
     /** Optional. */
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
-    NOTIFICATIONS(listOf(Manifest.permission.POST_NOTIFICATIONS), NotificationsPermissionFragment::class.java),
+    NOTIFICATIONS(listOf(Permissions.notificationsPermission), NotificationsPermissionFragment::class.java),
     ;
 
     fun hasRequiredPermissions(context: Context): Boolean = hasAllPermissions(context, permissions)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -14,6 +14,7 @@ import androidx.annotation.RequiresApi
 import androidx.core.content.edit
 import com.ichi2.anki.backend.DatabaseCorruption
 import com.ichi2.anki.common.crashreporting.CrashReportService
+import com.ichi2.anki.common.permissions.LEGACY_POST_NOTIFICATIONS
 import com.ichi2.anki.common.permissions.hasAllPermissions
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.storage.AnkiDroidFolder
@@ -26,6 +27,7 @@ import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService.setPreferencesUpToDate
 import com.ichi2.anki.ui.windows.permissions.InternetPermissionFragment
+import com.ichi2.anki.ui.windows.permissions.LegacyNotificationsPermissionFragment
 import com.ichi2.anki.ui.windows.permissions.NotificationsPermissionFragment
 import com.ichi2.anki.ui.windows.permissions.PermissionsFragment
 import com.ichi2.anki.ui.windows.permissions.PermissionsStartingAt30Fragment
@@ -207,9 +209,19 @@ enum class PermissionSet(
 
     APP_PRIVATE(Permissions.appPrivateStartupPermissions, InternetPermissionFragment::class.java),
 
-    /** Optional. */
+    /**
+     * Optional. For devices with API >= 33.
+     * @see NotificationsPermissionFragment
+     */
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     NOTIFICATIONS(listOf(Permissions.notificationsPermission), NotificationsPermissionFragment::class.java),
+
+    /**
+     * Optional. For devices with API < 33.
+     * There is no formal permission to request, but it is possible for the user to manually disable notifications in Settings.
+     * If they want notifications, we need to direct the user to the OS settings via the [LegacyNotificationsPermissionFragment] so they can re-enable them.
+     */
+    LEGACY_NOTIFICATIONS(listOf(LEGACY_POST_NOTIFICATIONS), LegacyNotificationsPermissionFragment::class.java),
     ;
 
     fun hasRequiredPermissions(context: Context): Boolean = hasAllPermissions(context, permissions)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
@@ -16,7 +16,6 @@
 
 package com.ichi2.anki.reviewreminders
 
-import android.Manifest
 import android.content.Context
 import android.content.Intent
 import android.os.Build
@@ -43,13 +42,12 @@ import com.ichi2.anki.common.utils.android.getColorFromAttr
 import com.ichi2.anki.databinding.FragmentReminderTroubleshootingBinding
 import com.ichi2.anki.databinding.ItemTroubleshootingCheckBinding
 import com.ichi2.anki.requireAnkiActivity
-import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.utils.ext.launchCollectionInLifecycleScope
 import com.ichi2.anki.utils.ext.onWindowFocusChanged
 import com.ichi2.anki.utils.ext.requireParcelable
 import com.ichi2.anki.utils.ext.setBackgroundTint
+import com.ichi2.utils.Permissions.attemptToEnableNotifications
 import com.ichi2.utils.Permissions.openAppNotificationsSettingsScreen
-import com.ichi2.utils.Permissions.requestPermissionThroughDialogOrSettings
 import com.ichi2.utils.dp
 import dev.androidbroadcast.vbpd.viewBinding
 import timber.log.Timber
@@ -386,20 +384,13 @@ private fun TroubleshootingCheck.resolveAction(): ResolveCheckAction? {
     val context = fragment.requireContext()
 
     // TODO: move labels to string resources
-    fun requestNotificationPermission(): ResolveCheckAction? {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return null
-        return ResolveCheckAction(
+    fun requestNotificationPermission(): ResolveCheckAction? =
+        ResolveCheckAction(
             label = "Grant permission",
             logDescription = "requesting POST_NOTIFICATIONS via system dialog or app settings",
         ) {
-            fragment.requestPermissionThroughDialogOrSettings(
-                activity = fragment.requireActivity(),
-                permission = Manifest.permission.POST_NOTIFICATIONS,
-                permissionRequestedFlag = Prefs::notificationsPermissionRequested,
-                permissionRequestLauncher = fragment.notificationPermissionLauncher,
-            )
+            fragment.attemptToEnableNotifications(fragment.notificationPermissionLauncher)
         }
-    }
 
     fun requestReminderNotifChannelPermission(): ResolveCheckAction? {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
@@ -2,7 +2,6 @@
 
 package com.ichi2.anki.reviewreminders
 
-import android.Manifest
 import android.content.Context
 import android.content.Intent
 import android.os.Build
@@ -33,14 +32,13 @@ import com.ichi2.anki.common.utils.android.getColorFromAttr
 import com.ichi2.anki.databinding.FragmentReminderTroubleshootingBinding
 import com.ichi2.anki.databinding.ItemTroubleshootingCheckBinding
 import com.ichi2.anki.requireAnkiActivity
-import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.utils.doOnApplyWindowInsets
 import com.ichi2.anki.utils.ext.launchCollectionInLifecycleScope
 import com.ichi2.anki.utils.ext.onWindowFocusChanged
 import com.ichi2.anki.utils.ext.requireParcelable
 import com.ichi2.anki.utils.ext.setBackgroundTint
+import com.ichi2.utils.Permissions.attemptToEnableNotifications
 import com.ichi2.utils.Permissions.openAppNotificationsSettingsScreen
-import com.ichi2.utils.Permissions.requestPermissionThroughDialogOrSettings
 import com.ichi2.utils.dp
 import dev.androidbroadcast.vbpd.viewBinding
 import timber.log.Timber
@@ -400,20 +398,13 @@ private fun TroubleshootingCheck.resolveAction(): ResolveCheckAction? {
     val context = fragment.requireContext()
 
     // TODO: move labels to string resources
-    fun requestNotificationPermission(): ResolveCheckAction? {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return null
-        return ResolveCheckAction(
+    fun requestNotificationPermission(): ResolveCheckAction? =
+        ResolveCheckAction(
             label = "Grant permission",
             logDescription = "requesting POST_NOTIFICATIONS via system dialog or app settings",
         ) {
-            fragment.requestPermissionThroughDialogOrSettings(
-                activity = fragment.requireActivity(),
-                permission = Manifest.permission.POST_NOTIFICATIONS,
-                permissionRequestedFlag = Prefs::notificationsPermissionRequested,
-                permissionRequestLauncher = fragment.notificationPermissionLauncher,
-            )
+            fragment.attemptToEnableNotifications(fragment.notificationPermissionLauncher)
         }
-    }
 
     fun requestReminderNotifChannelPermission(): ResolveCheckAction? {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingRepository.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingRepository.kt
@@ -25,7 +25,7 @@ import android.os.Build
 import android.os.PowerManager
 import androidx.core.content.getSystemService
 import com.ichi2.anki.NotificationChannel
-import com.ichi2.utils.Permissions
+import com.ichi2.anki.common.permissions.canPostNotifications
 import com.ichi2.utils.Permissions.arePermissionsDefinedInAnkiDroidManifest
 
 /**
@@ -47,7 +47,7 @@ enum class BatteryOptimizationState {
 class ReminderTroubleshootingRepository(
     private val context: Context,
 ) {
-    fun isNotificationPermissionGranted(): Boolean = Permissions.canPostNotifications(context)
+    fun isNotificationPermissionGranted(): Boolean = canPostNotifications(context)
 
     fun isNotificationChannelEnabled(): Boolean? {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -307,6 +307,25 @@ open class PrefsRepository(
 
     // *************************************** Permissions ************************************** //
 
+    // TODO: "Has the app done X" flags might not belong in the common SharedPrefs file and should maybe be pulled out.
+    // Storing these flags somewhat diverges from the intention of SharedPrefs, which is intended for user preferences.
+    // Cleaner organization / storage of these flags may be possible.
+
+    /**
+     * Whether the bottom sheet for requesting notification permissions has been shown to the user, but only for
+     * API <33. Why is this required? On API 33+, we continue showing the bottom sheet until the OS tells us we should not show it anymore
+     * (i.e. the user has denied the permission and checked "Don't ask again", or has denied the permission enough times).
+     * However, on API <33, no explicit OS notification permission is available, but the user can still disable notifications for the app in the OS settings.
+     * The bottom sheet should therefore still be shown. Since there is no longer OS feedback on whether the user has denied
+     * the request in the past, we need to keep track of this ourselves to avoid spamming the user with the bottom sheet over and over.
+     *
+     * Technically, we could just reuse [notificationsPermissionRequested] for this purpose. However, that makes
+     * [notificationsPermissionRequested] have two purposes and blurs its clear definition as "has the OS system dialog for requesting
+     * notifications been presented to the user before". On API <33, the OS system dialog for requesting notifications does not exist,
+     * and so technically [notificationsPermissionRequested] should always be false. Therefore, we keep this separate.
+     */
+    var notificationsBottomSheetShownBelowAPI33 by booleanPref(R.string.notifications_bottom_sheet_below_33, defaultValue = false)
+
     // Flags for whether the system UI dialog for requesting certain permissions has been shown before.
     // If the user has viewed the dialog at least once, we should check if they pressed "don't ask again"
     // or pressed "deny" repeatedly (via [androidx.core.app.ActivityCompat.shouldShowRequestPermissionRationale]).
@@ -328,8 +347,6 @@ open class PrefsRepository(
      * an issue for the review reminders feature, so to ensure the user is able to receive review reminder notifications after
      * a data restore / migration, a Snackbar noting that notification permissions are missing will be shown
      * on the [com.ichi2.anki.reviewreminders.ScheduleRemindersFragment] fragment if notification permissions are not granted.
-     *
-     * @see com.ichi2.anki.reviewreminders.ScheduleRemindersFragment.checkForNotificationPermissions
      */
     var notificationsPermissionRequested by booleanPref(R.string.notifications_permission_requested_key, false)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -296,6 +296,25 @@ open class PrefsRepository(
 
     // *************************************** Permissions ************************************** //
 
+    // TODO: "Has the app done X" flags might not belong in the common SharedPrefs file and should maybe be pulled out.
+    // Storing these flags somewhat diverges from the intention of SharedPrefs, which is intended for user preferences.
+    // Cleaner organization / storage of these flags may be possible.
+
+    /**
+     * Whether the bottom sheet for requesting notification permissions has been shown to the user, but only for
+     * API <33. Why is this required? On API 33+, we continue showing the bottom sheet until the OS tells us we should not show it anymore
+     * (i.e. the user has denied the permission and checked "Don't ask again", or has denied the permission enough times).
+     * However, on API <33, no explicit OS notification permission is available, but the user can still disable notifications for the app in the OS settings.
+     * The bottom sheet should therefore still be shown. Since there is no longer OS feedback on whether the user has denied
+     * the request in the past, we need to keep track of this ourselves to avoid spamming the user with the bottom sheet over and over.
+     *
+     * Technically, we could just reuse [notificationsPermissionRequested] for this purpose. However, that makes
+     * [notificationsPermissionRequested] have two purposes and blurs its clear definition as "has the OS system dialog for requesting
+     * notifications been presented to the user before". On API <33, the OS system dialog for requesting notifications does not exist,
+     * and so technically [notificationsPermissionRequested] should always be false. Therefore, we keep this separate.
+     */
+    var notificationsBottomSheetShownBelowAPI33 by booleanPref(R.string.notifications_bottom_sheet_below_33, defaultValue = false)
+
     // Flags for whether the system UI dialog for requesting certain permissions has been shown before.
     // If the user has viewed the dialog at least once, we should check if they pressed "don't ask again"
     // or pressed "deny" repeatedly (via [androidx.core.app.ActivityCompat.shouldShowRequestPermissionRationale]).
@@ -317,8 +336,6 @@ open class PrefsRepository(
      * an issue for the review reminders feature, so to ensure the user is able to receive review reminder notifications after
      * a data restore / migration, a Snackbar noting that notification permissions are missing will be shown
      * on the [com.ichi2.anki.reviewreminders.ScheduleRemindersFragment] fragment if notification permissions are not granted.
-     *
-     * @see com.ichi2.anki.reviewreminders.ScheduleRemindersFragment.checkForNotificationPermissions
      */
     var notificationsPermissionRequested by booleanPref(R.string.notifications_permission_requested_key, false)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/AllPermissionsExplanationFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/AllPermissionsExplanationFragment.kt
@@ -23,11 +23,13 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
 import androidx.core.view.isVisible
 import com.ichi2.anki.R
+import com.ichi2.anki.common.permissions.LEGACY_POST_NOTIFICATIONS
 import com.ichi2.anki.databinding.FragmentAllPermissionsExplanationBinding
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.utils.Permissions
 import com.ichi2.utils.Permissions.notificationsPermission
 import com.ichi2.utils.Permissions.requestPermissionThroughDialogOrSettings
+import com.ichi2.utils.Permissions.showToastAndOpenAppSettingsScreenForPermission
 import dev.androidbroadcast.vbpd.viewBinding
 import timber.log.Timber
 
@@ -86,6 +88,14 @@ class AllPermissionsExplanationFragment : PermissionsFragment(R.layout.fragment_
                         permissionRequestedFlag = Prefs::notificationsPermissionRequested,
                         permissionRequestLauncher = permissionRequestLauncher,
                     )
+                }
+            }
+        } else {
+            binding.legacyPostNotificationPermissionItem.apply {
+                isVisible = true
+                // If it's already granted, offer to revoke it on click; otherwise, request it
+                revokeIfGrantedOnClickElse {
+                    showToastAndOpenAppSettingsScreenForPermission(LEGACY_POST_NOTIFICATIONS, R.string.manually_grant_permissions)
                 }
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/AllPermissionsExplanationFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/AllPermissionsExplanationFragment.kt
@@ -26,6 +26,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.databinding.FragmentAllPermissionsExplanationBinding
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.utils.Permissions
+import com.ichi2.utils.Permissions.notificationsPermission
 import com.ichi2.utils.Permissions.requestPermissionThroughDialogOrSettings
 import dev.androidbroadcast.vbpd.viewBinding
 import timber.log.Timber
@@ -74,14 +75,14 @@ class AllPermissionsExplanationFragment : PermissionsFragment(R.layout.fragment_
         }
         binding.headingRequiredPermissions.isVisible = shouldRequestExternalStorage
 
-        Permissions.postNotification?.let {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             binding.postNotificationPermissionItem.apply {
                 isVisible = true
                 // If it's already granted, offer to revoke it on click; otherwise, request it
                 revokeIfGrantedOnClickElse {
                     requestPermissionThroughDialogOrSettings(
                         activity = requireActivity(),
-                        permission = it,
+                        permission = notificationsPermission,
                         permissionRequestedFlag = Prefs::notificationsPermissionRequested,
                         permissionRequestLauncher = permissionRequestLauncher,
                     )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/LegacyNotificationsPermissionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/LegacyNotificationsPermissionFragment.kt
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2026 Eric Li <ericli3690@gmail.com>
+
+package com.ichi2.anki.ui.windows.permissions
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.setFragmentResult
+import com.ichi2.anki.R
+import com.ichi2.anki.common.permissions.LEGACY_POST_NOTIFICATIONS
+import com.ichi2.anki.common.permissions.canPostNotifications
+import com.ichi2.anki.databinding.FragmentLegacyNotificationsPermissionBinding
+import com.ichi2.utils.Permissions.showToastAndOpenAppSettingsScreenForPermission
+import dev.androidbroadcast.vbpd.viewBinding
+
+/**
+ * Pre-API 33 counterpart of [NotificationsPermissionFragment], shown on the [PermissionsBottomSheet] for
+ * requesting notification permissions from the user.
+ *
+ * Below API 33 there is no notifications permission to request: notifications are implicitly granted, but the
+ * user can still turn them off in the system settings. There is therefore no permission request launcher here,
+ * as the only thing we can do is send the user to the system settings to re-enable notifications manually.
+ *
+ * Requested permissions:
+ * 1. Notifications: [LEGACY_POST_NOTIFICATIONS].
+ *   Used to view and cancel sync progress.
+ *   Used for review reminder notifications.
+ */
+class LegacyNotificationsPermissionFragment : PermissionsFragment(R.layout.fragment_legacy_notifications_permission) {
+    private val binding by viewBinding(FragmentLegacyNotificationsPermissionBinding::bind)
+
+    override fun onResume() {
+        super.onResume()
+        // onResume is called after returning from the OS settings
+        if (canPostNotifications(requireContext())) {
+            // Post a fragment result to indicate that the bottom sheet can be dismissed
+            setFragmentResult(PermissionsBottomSheet.RESULT_DISMISS, Bundle())
+        }
+    }
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        binding.legacyNotificationPermission.revokeIfGrantedOnClickElse {
+            showToastAndOpenAppSettingsScreenForPermission(LEGACY_POST_NOTIFICATIONS, R.string.manually_grant_permissions)
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/NotificationsPermissionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/NotificationsPermissionFragment.kt
@@ -23,6 +23,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
 import androidx.fragment.app.setFragmentResult
 import com.ichi2.anki.R
+import com.ichi2.anki.common.permissions.canPostNotifications
 import com.ichi2.anki.databinding.FragmentNotificationsPermissionBinding
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.utils.Permissions
@@ -55,7 +56,7 @@ class NotificationsPermissionFragment : PermissionsFragment(R.layout.fragment_no
     override fun onResume() {
         super.onResume()
         // onResume is called after returning from both the OS settings and the OS permission request dialog
-        if (Permissions.canPostNotifications(requireContext())) {
+        if (canPostNotifications(requireContext())) {
             // Post a fragment result to indicate that the bottom sheet can be dismissed
             setFragmentResult(PermissionsBottomSheet.RESULT_DISMISS, Bundle())
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/NotificationsPermissionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/NotificationsPermissionFragment.kt
@@ -26,6 +26,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.databinding.FragmentNotificationsPermissionBinding
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.utils.Permissions
+import com.ichi2.utils.Permissions.notificationsPermission
 import com.ichi2.utils.Permissions.requestPermissionThroughDialogOrSettings
 import dev.androidbroadcast.vbpd.viewBinding
 import timber.log.Timber
@@ -35,7 +36,7 @@ import timber.log.Timber
  * from the user. This permission only needs to be requested at or above API 33.
  *
  * Requested permissions:
- * 1. Notifications: [Permissions.postNotification].
+ * 1. Notifications: [Permissions.notificationsPermission].
  *   Used to view and cancel sync progress.
  *   Used for review reminder notifications.
  */
@@ -64,15 +65,13 @@ class NotificationsPermissionFragment : PermissionsFragment(R.layout.fragment_no
         view: View,
         savedInstanceState: Bundle?,
     ) {
-        Permissions.postNotification?.let {
-            binding.notificationPermission.revokeIfGrantedOnClickElse {
-                requestPermissionThroughDialogOrSettings(
-                    activity = requireActivity(),
-                    permission = it,
-                    permissionRequestedFlag = Prefs::notificationsPermissionRequested,
-                    permissionRequestLauncher = notificationPermissionLauncher,
-                )
-            }
+        binding.notificationPermission.revokeIfGrantedOnClickElse {
+            requestPermissionThroughDialogOrSettings(
+                activity = requireActivity(),
+                permission = notificationsPermission,
+                permissionRequestedFlag = Prefs::notificationsPermissionRequested,
+                permissionRequestLauncher = notificationPermissionLauncher,
+            )
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsBottomSheet.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsBottomSheet.kt
@@ -16,12 +16,10 @@
 
 package com.ichi2.anki.ui.windows.permissions
 
-import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.annotation.RequiresApi
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -41,7 +39,6 @@ import dev.androidbroadcast.vbpd.viewBinding
  * should be used to request optional permissions from the user, and can be launched as the user gradually
  * encounters features that require permissions rather than being shoved in the face of every first-time user.
  */
-@RequiresApi(Build.VERSION_CODES.TIRAMISU)
 class PermissionsBottomSheet : BottomSheetDialogFragment() {
     private val binding by viewBinding(FragmentPermissionsBottomSheetBinding::bind)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsFragment.kt
@@ -31,11 +31,12 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.setFragmentResult
 import com.ichi2.anki.R
 import com.ichi2.anki.common.annotations.NeedsTest
+import com.ichi2.anki.common.permissions.MANAGE_EXTERNAL_STORAGE
 import com.ichi2.anki.common.permissions.hasPermission
 import com.ichi2.anki.settings.Prefs
-import com.ichi2.utils.Permissions.openAppSettingsScreen
+import com.ichi2.utils.Permissions.openAppSettingsScreenForPermission
 import com.ichi2.utils.Permissions.requestPermissionThroughDialogOrSettings
-import com.ichi2.utils.Permissions.showToastAndOpenAppSettingsScreen
+import com.ichi2.utils.Permissions.showToastAndOpenAppSettingsScreenForPermission
 import timber.log.Timber
 
 /**
@@ -62,7 +63,8 @@ abstract class PermissionsFragment(
                 Timber.i("Internet permission granted")
             } else {
                 Timber.i("Internet permission denied")
-                showToastAndOpenAppSettingsScreen(
+                showToastAndOpenAppSettingsScreenForPermission(
+                    Manifest.permission.INTERNET,
                     getString(R.string.permission_required_message, getString(R.string.internet_access_title)),
                 )
             }
@@ -93,7 +95,7 @@ abstract class PermissionsFragment(
             Timber.i("launching ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION")
             launch(intent)
         } else {
-            openAppSettingsScreen()
+            openAppSettingsScreenForPermission(MANAGE_EXTERNAL_STORAGE)
         }
     }
 
@@ -138,7 +140,7 @@ abstract class PermissionsFragment(
     protected fun PermissionsItem.revokeIfGrantedOnClickElse(callback: () -> Unit) {
         setOnPermissionsRequested { areAlreadyGranted ->
             if (areAlreadyGranted) {
-                showToastAndOpenAppSettingsScreen(R.string.revoke_permissions)
+                showToastAndOpenAppSettingsScreenForPermission(permissions.singleOrNull(), R.string.revoke_permissions)
             } else {
                 callback()
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsUntil29Fragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsUntil29Fragment.kt
@@ -30,7 +30,7 @@ import com.ichi2.utils.Permissions.showToastAndOpenAppSettingsScreen
  * Permissions screen for requesting permissions until API 29.
  *
  * Requested permissions:
- * 1. Storage access: [Permissions.legacyStorageAccessPermissions].
+ * 1. Storage access: [Permissions.legacyStorageAccessStartupPermissions].
  *   Used for saving the collection in a public directory
  *   which isn't deleted when the app is uninstalled
  */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsUntil29Fragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsUntil29Fragment.kt
@@ -24,7 +24,7 @@ import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.R
 import com.ichi2.anki.databinding.FragmentPermissionsUntil29Binding
 import com.ichi2.utils.Permissions
-import com.ichi2.utils.Permissions.showToastAndOpenAppSettingsScreen
+import com.ichi2.utils.Permissions.showToastAndOpenAppSettingsScreenForPermission
 
 /**
  * Permissions screen for requesting permissions until API 29.
@@ -43,7 +43,10 @@ class PermissionsUntil29Fragment : PermissionsFragment(R.layout.fragment_permiss
                 // The permission dialog did not show up of the user denied the permission.
                 // Offers to open the OS settings section for AnkiDroid. In this section, the user can
                 // manually grant the permission.
-                showToastAndOpenAppSettingsScreen(R.string.startup_no_storage_permission)
+                showToastAndOpenAppSettingsScreenForPermission(
+                    requestedPermissions.keys.singleOrNull(),
+                    R.string.startup_no_storage_permission,
+                )
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
@@ -31,11 +31,11 @@ import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.NotificationChannel
 import com.ichi2.anki.R
 import com.ichi2.anki.cancelMediaSync
+import com.ichi2.anki.common.permissions.canPostNotifications
 import com.ichi2.anki.notifications.NotificationId
 import com.ichi2.anki.receiver.CopyToClipboardReceiver
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.ext.trySetForeground
-import com.ichi2.utils.Permissions
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import net.ankiweb.rsdroid.Backend
@@ -47,7 +47,7 @@ class SyncMediaWorker(
 ) : CoroutineWorker(context, parameters) {
     private val cancelIntent = WorkManager.getInstance(context).createCancelPendingIntent(id)
     private val notificationManager: NotificationManagerCompat? =
-        if (Permissions.canPostNotifications(context)) {
+        if (canPostNotifications(context)) {
             NotificationManagerCompat.from(context)
         } else {
             null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
@@ -39,9 +39,9 @@ import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.NotificationChannel
 import com.ichi2.anki.R
 import com.ichi2.anki.cancelMediaSync
+import com.ichi2.anki.common.permissions.canPostNotifications
 import com.ichi2.anki.notifications.NotificationId
 import com.ichi2.anki.utils.ext.trySetForeground
-import com.ichi2.utils.Permissions
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import net.ankiweb.rsdroid.Backend
@@ -53,7 +53,7 @@ class SyncMediaWorker(
 ) : CoroutineWorker(context, parameters) {
     private val cancelIntent = WorkManager.getInstance(context).createCancelPendingIntent(id)
     private val notificationManager: NotificationManagerCompat? =
-        if (Permissions.canPostNotifications(context)) {
+        if (canPostNotifications(context)) {
             NotificationManagerCompat.from(context)
         } else {
             null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncWorker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncWorker.kt
@@ -41,11 +41,11 @@ import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.NotificationChannel
 import com.ichi2.anki.R
 import com.ichi2.anki.cancelSync
+import com.ichi2.anki.common.permissions.canPostNotifications
 import com.ichi2.anki.notifications.NotificationId
 import com.ichi2.anki.setLastSyncTimeToNow
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.utils.ext.trySetForeground
-import com.ichi2.utils.Permissions
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -74,7 +74,7 @@ class SyncWorker(
     private val workManager = WorkManager.getInstance(context)
     private val cancelIntent = WorkManager.getInstance(context).createCancelPendingIntent(id)
     private val notificationManager: NotificationManagerCompat? =
-        if (Permissions.canPostNotifications(context)) {
+        if (canPostNotifications(context)) {
             NotificationManagerCompat.from(context)
         } else {
             null

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -104,6 +104,24 @@ object Permissions {
     }
 
     /**
+     * At and above API 33, the formal notification permission exists and can be requested via the usual permission flow.
+     * Below API 33, the permission is implicitly granted, but the user can still disable notifications for the app in system settings.
+     * In that case, we open the system settings screen for the user to manually enable notifications.
+     */
+    fun Fragment.attemptToEnableNotifications(notificationPermissionLauncher: ActivityResultLauncher<String>) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            requestPermissionThroughDialogOrSettings(
+                activity = requireActivity(),
+                permission = notificationsPermission,
+                permissionRequestedFlag = Prefs::notificationsPermissionRequested,
+                permissionRequestLauncher = notificationPermissionLauncher,
+            )
+        } else {
+            showToastAndOpenAppSettingsScreenForPermission(LEGACY_POST_NOTIFICATIONS, R.string.manually_grant_permissions)
+        }
+    }
+
+    /**
      * Shows the [com.ichi2.anki.ui.windows.permissions.NotificationsPermissionFragment] in the [PermissionsBottomSheet]
      * if notification permissions have not been granted. Does nothing if the permission does not need to
      * be requested (i.e. API < 33), if the permission has already been granted,

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -20,7 +20,6 @@ import android.Manifest
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.provider.Settings
@@ -28,14 +27,15 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.RequiresApi
 import androidx.annotation.StringRes
 import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import com.ichi2.anki.NotificationChannel
 import com.ichi2.anki.PermissionSet
 import com.ichi2.anki.R
+import com.ichi2.anki.common.permissions.LEGACY_POST_NOTIFICATIONS
 import com.ichi2.anki.common.permissions.MANAGE_EXTERNAL_STORAGE
+import com.ichi2.anki.common.permissions.canPostNotifications
 import com.ichi2.anki.common.permissions.hasPermission
 import com.ichi2.anki.common.utils.android.isRobolectric
 import com.ichi2.anki.common.utils.android.showThemedToast
@@ -226,10 +226,6 @@ object Permissions {
             context.arePermissionsDefinedInAnkiDroidManifest(MANAGE_EXTERNAL_STORAGE)
     }
 
-    fun canPostNotifications(context: Context): Boolean =
-        Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
-            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
-
     /**
      * Opens the Android settings for AnkiDroid if the device provide this feature.
      * Lets a user grant any missing permissions which have been permanently denied.
@@ -269,12 +265,13 @@ object Permissions {
      * Opens the Android settings screen for a specific permission. Add more branches to the `when` statement as needed.
      * If no branch matches, falls back to opening the generic app settings screen.
      *
-     * @param permission The permission to open the settings screen for.
+     * @param permission The permission to open the settings screen for. Can be [LEGACY_POST_NOTIFICATIONS] for pre-API 33 notifications.
      * Can be null to open the generic app settings screen.
      */
     fun Fragment.openAppSettingsScreenForPermission(permission: String?) {
         when {
-            (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) && (permission == notificationsPermission) ->
+            ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) && (permission == notificationsPermission)) ||
+                permission == LEGACY_POST_NOTIFICATIONS ->
                 openAppNotificationsSettingsScreen()
 
             // Else, default to opening the root page of the app settings screen

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -49,13 +49,6 @@ import timber.log.Timber
 import kotlin.reflect.KMutableProperty
 
 object Permissions {
-    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
-    val tiramisuPhotosAndVideosPermissions =
-        listOf(
-            Manifest.permission.READ_MEDIA_IMAGES,
-            Manifest.permission.READ_MEDIA_VIDEO,
-        )
-
     /**
      * The name of the "post notification" permission on API where it's defined.
      */
@@ -171,9 +164,6 @@ object Permissions {
             }
         }
     }
-
-    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
-    val tiramisuAudioPermission = Manifest.permission.READ_MEDIA_AUDIO
 
     val legacyStorageAccessStartupPermissions =
         listOf(

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -99,15 +99,7 @@ object Permissions {
             permissionRequestedFlag.setter.call(true)
             permissionRequestLauncher.launch(permission)
         } else {
-            when {
-                // Add overrides for opening specific settings subscreens here as needed
-                Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && permission == notificationsPermission -> {
-                    showThemedToast(requireContext(), R.string.manually_grant_permissions, false)
-                    openAppNotificationsSettingsScreen()
-                }
-                // Else, default to opening the root page of the app settings screen
-                else -> showToastAndOpenAppSettingsScreen(R.string.manually_grant_permissions)
-            }
+            showToastAndOpenAppSettingsScreenForPermission(permission, R.string.manually_grant_permissions)
         }
     }
 
@@ -273,15 +265,36 @@ object Permissions {
         }
     }
 
-    fun Fragment.showToastAndOpenAppSettingsScreen(
+    /**
+     * Opens the Android settings screen for a specific permission. Add more branches to the `when` statement as needed.
+     * If no branch matches, falls back to opening the generic app settings screen.
+     *
+     * @param permission The permission to open the settings screen for.
+     * Can be null to open the generic app settings screen.
+     */
+    fun Fragment.openAppSettingsScreenForPermission(permission: String?) {
+        when {
+            (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) && (permission == notificationsPermission) ->
+                openAppNotificationsSettingsScreen()
+
+            // Else, default to opening the root page of the app settings screen
+            else -> openAppSettingsScreen()
+        }
+    }
+
+    fun Fragment.showToastAndOpenAppSettingsScreenForPermission(
+        permission: String?,
         @StringRes message: Int,
     ) {
         showThemedToast(requireContext(), message, false)
-        openAppSettingsScreen()
+        openAppSettingsScreenForPermission(permission)
     }
 
-    fun Fragment.showToastAndOpenAppSettingsScreen(message: String) {
+    fun Fragment.showToastAndOpenAppSettingsScreenForPermission(
+        permission: String?,
+        message: String,
+    ) {
         showThemedToast(requireContext(), message, false)
-        openAppSettingsScreen()
+        openAppSettingsScreenForPermission(permission)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -123,9 +123,15 @@ object Permissions {
 
     /**
      * Shows the [com.ichi2.anki.ui.windows.permissions.NotificationsPermissionFragment] in the [PermissionsBottomSheet]
-     * if notification permissions have not been granted. Does nothing if the permission does not need to
-     * be requested (i.e. API < 33), if the permission has already been granted,
-     * or if the user has previously denied the permission and selected "Don't ask again".
+     * if notification permissions have not been granted.
+     *
+     * Does nothing if the permission has already been granted.
+     * Always shows the bottom sheet the first time it detects that the permission has not been granted.
+     * Does nothing on API 33+ if the user has previously denied the permission and selected "Don't ask again".
+     * Does nothing on API <33 if the user has seen the bottom sheet once before.
+     *
+     * Even though the explicit permission is exclusive to API 33+, this method is still useful for API <33 because the user can
+     * manually disable notifications for the app in system settings.
      *
      * @param activity Used for checking whether notification permissions have been granted, or if the user has clicked
      * "Don't ask again" on previous requests.
@@ -137,20 +143,32 @@ object Permissions {
         fragmentManager: FragmentManager,
         callback: () -> Unit,
     ) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+        if (canPostNotifications(context = activity)) return
 
-        if (
-            !canPostNotifications(context = activity) &&
-            canPermissionBeRequested(
-                activity,
-                notificationsPermission,
-                Prefs::notificationsPermissionRequested,
-            )
-        ) {
-            Timber.i("Showing notifications bottom sheet")
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val canRequest =
+                canPermissionBeRequested(
+                    activity,
+                    notificationsPermission,
+                    permissionRequestedFlag = Prefs::notificationsPermissionRequested,
+                )
+            if (!canRequest) {
+                Timber.i("Not showing notifications permissions bottom sheet: permission permanently denied")
+                return
+            }
+            Timber.i("Showing notifications permissions bottom sheet: API >= 33")
             PermissionsBottomSheet.launch(fragmentManager, PermissionSet.NOTIFICATIONS)
-            callback()
+        } else {
+            if (Prefs.notificationsBottomSheetShownBelowAPI33) {
+                Timber.i("Not showing notifications permissions bottom sheet: already attempted")
+                return
+            }
+            Timber.i("Showing notifications permissions bottom sheet: API < 33")
+            PermissionsBottomSheet.launch(fragmentManager, PermissionSet.LEGACY_NOTIFICATIONS)
+            Prefs.notificationsBottomSheetShownBelowAPI33 = true
         }
+
+        callback()
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -49,15 +49,8 @@ import timber.log.Timber
 import kotlin.reflect.KMutableProperty
 
 object Permissions {
-    /**
-     * The name of the "post notification" permission on API where it's defined.
-     */
-    val postNotification =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            Manifest.permission.POST_NOTIFICATIONS
-        } else {
-            null
-        }
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    val notificationsPermission: String = Manifest.permission.POST_NOTIFICATIONS
 
     /**
      * Returns whether AnkiDroid is able to request a permission from the user.
@@ -106,9 +99,9 @@ object Permissions {
             permissionRequestedFlag.setter.call(true)
             permissionRequestLauncher.launch(permission)
         } else {
-            when (permission) {
+            when {
                 // Add overrides for opening specific settings subscreens here as needed
-                postNotification -> {
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && permission == notificationsPermission -> {
                     showThemedToast(requireContext(), R.string.manually_grant_permissions, false)
                     openAppNotificationsSettingsScreen()
                 }
@@ -134,19 +127,19 @@ object Permissions {
         fragmentManager: FragmentManager,
         callback: () -> Unit,
     ) {
-        postNotification?.let { notificationPermission ->
-            if (
-                !canPostNotifications(context = activity) &&
-                canPermissionBeRequested(
-                    activity,
-                    notificationPermission,
-                    Prefs::notificationsPermissionRequested,
-                )
-            ) {
-                Timber.i("Showing notifications bottom sheet")
-                PermissionsBottomSheet.launch(fragmentManager, PermissionSet.NOTIFICATIONS)
-                callback()
-            }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+
+        if (
+            !canPostNotifications(context = activity) &&
+            canPermissionBeRequested(
+                activity,
+                notificationsPermission,
+                Prefs::notificationsPermissionRequested,
+            )
+        ) {
+            Timber.i("Showing notifications bottom sheet")
+            PermissionsBottomSheet.launch(fragmentManager, PermissionSet.NOTIFICATIONS)
+            callback()
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -36,15 +36,8 @@ import timber.log.Timber
 import kotlin.reflect.KMutableProperty
 
 object Permissions {
-    /**
-     * The name of the "post notification" permission on API where it's defined.
-     */
-    val postNotification =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            Manifest.permission.POST_NOTIFICATIONS
-        } else {
-            null
-        }
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    val notificationsPermission: String = Manifest.permission.POST_NOTIFICATIONS
 
     /**
      * Returns whether AnkiDroid is able to request a permission from the user.
@@ -93,9 +86,9 @@ object Permissions {
             permissionRequestedFlag.setter.call(true)
             permissionRequestLauncher.launch(permission)
         } else {
-            when (permission) {
+            when {
                 // Add overrides for opening specific settings subscreens here as needed
-                postNotification -> {
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && permission == notificationsPermission -> {
                     showThemedToast(requireContext(), R.string.manually_grant_permissions, false)
                     openAppNotificationsSettingsScreen()
                 }
@@ -121,19 +114,19 @@ object Permissions {
         fragmentManager: FragmentManager,
         callback: () -> Unit,
     ) {
-        postNotification?.let { notificationPermission ->
-            if (
-                !canPostNotifications(context = activity) &&
-                canPermissionBeRequested(
-                    activity,
-                    notificationPermission,
-                    Prefs::notificationsPermissionRequested,
-                )
-            ) {
-                Timber.i("Showing notifications bottom sheet")
-                PermissionsBottomSheet.launch(fragmentManager, PermissionSet.NOTIFICATIONS)
-                callback()
-            }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+
+        if (
+            !canPostNotifications(context = activity) &&
+            canPermissionBeRequested(
+                activity,
+                notificationsPermission,
+                Prefs::notificationsPermissionRequested,
+            )
+        ) {
+            Timber.i("Showing notifications bottom sheet")
+            PermissionsBottomSheet.launch(fragmentManager, PermissionSet.NOTIFICATIONS)
+            callback()
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -110,9 +110,15 @@ object Permissions {
 
     /**
      * Shows the [com.ichi2.anki.ui.windows.permissions.NotificationsPermissionFragment] in the [PermissionsBottomSheet]
-     * if notification permissions have not been granted. Does nothing if the permission does not need to
-     * be requested (i.e. API < 33), if the permission has already been granted,
-     * or if the user has previously denied the permission and selected "Don't ask again".
+     * if notification permissions have not been granted.
+     *
+     * Does nothing if the permission has already been granted.
+     * Always shows the bottom sheet the first time it detects that the permission has not been granted.
+     * Does nothing on API 33+ if the user has previously denied the permission and selected "Don't ask again".
+     * Does nothing on API <33 if the user has seen the bottom sheet once before.
+     *
+     * Even though the explicit permission is exclusive to API 33+, this method is still useful for API <33 because the user can
+     * manually disable notifications for the app in system settings.
      *
      * @param activity Used for checking whether notification permissions have been granted, or if the user has clicked
      * "Don't ask again" on previous requests.
@@ -124,20 +130,32 @@ object Permissions {
         fragmentManager: FragmentManager,
         callback: () -> Unit,
     ) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+        if (canPostNotifications(context = activity)) return
 
-        if (
-            !canPostNotifications(context = activity) &&
-            canPermissionBeRequested(
-                activity,
-                notificationsPermission,
-                Prefs::notificationsPermissionRequested,
-            )
-        ) {
-            Timber.i("Showing notifications bottom sheet")
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val canRequest =
+                canPermissionBeRequested(
+                    activity,
+                    notificationsPermission,
+                    permissionRequestedFlag = Prefs::notificationsPermissionRequested,
+                )
+            if (!canRequest) {
+                Timber.i("Not showing notifications permissions bottom sheet: permission permanently denied")
+                return
+            }
+            Timber.i("Showing notifications permissions bottom sheet: API >= 33")
             PermissionsBottomSheet.launch(fragmentManager, PermissionSet.NOTIFICATIONS)
-            callback()
+        } else {
+            if (Prefs.notificationsBottomSheetShownBelowAPI33) {
+                Timber.i("Not showing notifications permissions bottom sheet: already attempted")
+                return
+            }
+            Timber.i("Showing notifications permissions bottom sheet: API < 33")
+            PermissionsBottomSheet.launch(fragmentManager, PermissionSet.LEGACY_NOTIFICATIONS)
+            Prefs.notificationsBottomSheetShownBelowAPI33 = true
         }
+
+        callback()
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -91,6 +91,24 @@ object Permissions {
     }
 
     /**
+     * At and above API 33, the formal notification permission exists and can be requested via the usual permission flow.
+     * Below API 33, the permission is implicitly granted, but the user can still disable notifications for the app in system settings.
+     * In that case, we open the system settings screen for the user to manually enable notifications.
+     */
+    fun Fragment.attemptToEnableNotifications(notificationPermissionLauncher: ActivityResultLauncher<String>) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            requestPermissionThroughDialogOrSettings(
+                activity = requireActivity(),
+                permission = notificationsPermission,
+                permissionRequestedFlag = Prefs::notificationsPermissionRequested,
+                permissionRequestLauncher = notificationPermissionLauncher,
+            )
+        } else {
+            showToastAndOpenAppSettingsScreenForPermission(LEGACY_POST_NOTIFICATIONS, R.string.manually_grant_permissions)
+        }
+    }
+
+    /**
      * Shows the [com.ichi2.anki.ui.windows.permissions.NotificationsPermissionFragment] in the [PermissionsBottomSheet]
      * if notification permissions have not been granted. Does nothing if the permission does not need to
      * be requested (i.e. API < 33), if the permission has already been granted,

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -36,13 +36,6 @@ import timber.log.Timber
 import kotlin.reflect.KMutableProperty
 
 object Permissions {
-    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
-    val tiramisuPhotosAndVideosPermissions =
-        listOf(
-            Manifest.permission.READ_MEDIA_IMAGES,
-            Manifest.permission.READ_MEDIA_VIDEO,
-        )
-
     /**
      * The name of the "post notification" permission on API where it's defined.
      */
@@ -158,9 +151,6 @@ object Permissions {
             }
         }
     }
-
-    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
-    val tiramisuAudioPermission = Manifest.permission.READ_MEDIA_AUDIO
 
     val legacyStorageAccessStartupPermissions =
         listOf(

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -7,7 +7,6 @@ import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.provider.Settings
@@ -15,14 +14,15 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.RequiresApi
 import androidx.annotation.StringRes
 import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import com.ichi2.anki.NotificationChannel
 import com.ichi2.anki.PermissionSet
 import com.ichi2.anki.R
+import com.ichi2.anki.common.permissions.LEGACY_POST_NOTIFICATIONS
 import com.ichi2.anki.common.permissions.MANAGE_EXTERNAL_STORAGE
+import com.ichi2.anki.common.permissions.canPostNotifications
 import com.ichi2.anki.common.permissions.hasPermission
 import com.ichi2.anki.common.utils.android.isRobolectric
 import com.ichi2.anki.common.utils.android.showThemedToast
@@ -213,10 +213,6 @@ object Permissions {
             context.arePermissionsDefinedInAnkiDroidManifest(MANAGE_EXTERNAL_STORAGE)
     }
 
-    fun canPostNotifications(context: Context): Boolean =
-        Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
-            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
-
     /**
      * Opens the Android settings for AnkiDroid if the device provide this feature.
      * Lets a user grant any missing permissions which have been permanently denied.
@@ -270,12 +266,13 @@ object Permissions {
      * Opens the Android settings screen for a specific permission. Add more branches to the `when` statement as needed.
      * If no branch matches, falls back to opening the generic app settings screen.
      *
-     * @param permission The permission to open the settings screen for.
+     * @param permission The permission to open the settings screen for. Can be [LEGACY_POST_NOTIFICATIONS] for pre-API 33 notifications.
      * Can be null to open the generic app settings screen.
      */
     fun Fragment.openAppSettingsScreenForPermission(permission: String?) {
         when {
-            (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) && (permission == notificationsPermission) ->
+            ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) && (permission == notificationsPermission)) ||
+                permission == LEGACY_POST_NOTIFICATIONS ->
                 openAppNotificationsSettingsScreen()
 
             // Else, default to opening the root page of the app settings screen

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -86,15 +86,7 @@ object Permissions {
             permissionRequestedFlag.setter.call(true)
             permissionRequestLauncher.launch(permission)
         } else {
-            when {
-                // Add overrides for opening specific settings subscreens here as needed
-                Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && permission == notificationsPermission -> {
-                    showThemedToast(requireContext(), R.string.manually_grant_permissions, false)
-                    openAppNotificationsSettingsScreen()
-                }
-                // Else, default to opening the root page of the app settings screen
-                else -> showToastAndOpenAppSettingsScreen(R.string.manually_grant_permissions)
-            }
+            showToastAndOpenAppSettingsScreenForPermission(permission, R.string.manually_grant_permissions)
         }
     }
 
@@ -274,15 +266,36 @@ object Permissions {
     fun Fragment.openAppNotificationsSettingsScreen(highlightedChannel: NotificationChannel? = null) =
         requireActivity().openAppNotificationsSettingsScreen(highlightedChannel)
 
-    fun Fragment.showToastAndOpenAppSettingsScreen(
+    /**
+     * Opens the Android settings screen for a specific permission. Add more branches to the `when` statement as needed.
+     * If no branch matches, falls back to opening the generic app settings screen.
+     *
+     * @param permission The permission to open the settings screen for.
+     * Can be null to open the generic app settings screen.
+     */
+    fun Fragment.openAppSettingsScreenForPermission(permission: String?) {
+        when {
+            (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) && (permission == notificationsPermission) ->
+                openAppNotificationsSettingsScreen()
+
+            // Else, default to opening the root page of the app settings screen
+            else -> openAppSettingsScreen()
+        }
+    }
+
+    fun Fragment.showToastAndOpenAppSettingsScreenForPermission(
+        permission: String?,
         @StringRes message: Int,
     ) {
         showThemedToast(requireContext(), message, false)
-        openAppSettingsScreen()
+        openAppSettingsScreenForPermission(permission)
     }
 
-    fun Fragment.showToastAndOpenAppSettingsScreen(message: String) {
+    fun Fragment.showToastAndOpenAppSettingsScreenForPermission(
+        permission: String?,
+        message: String,
+    ) {
         showThemedToast(requireContext(), message, false)
-        openAppSettingsScreen()
+        openAppSettingsScreenForPermission(permission)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -264,12 +264,12 @@ object Permissions {
      * @param highlightedChannel The notification channel to highlight in the notifications settings screen,
      * to draw the user's attention.
      */
-    fun Fragment.openAppNotificationsSettingsScreen(highlightedChannel: NotificationChannel? = null) {
+    fun Activity.openAppNotificationsSettingsScreen(highlightedChannel: NotificationChannel? = null) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             Timber.i("launching ACTION_APP_NOTIFICATION_SETTINGS")
             startActivity(
                 Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
-                    putExtra(Settings.EXTRA_APP_PACKAGE, requireActivity().packageName)
+                    putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
                     highlightedChannel?.let { putExtra(Settings.EXTRA_CHANNEL_ID, it.id) }
                 },
             )
@@ -277,6 +277,9 @@ object Permissions {
             openAppSettingsScreen()
         }
     }
+
+    fun Fragment.openAppNotificationsSettingsScreen(highlightedChannel: NotificationChannel? = null) =
+        requireActivity().openAppNotificationsSettingsScreen(highlightedChannel)
 
     fun Fragment.showToastAndOpenAppSettingsScreen(
         @StringRes message: Int,

--- a/AnkiDroid/src/main/res/layout/fragment_all_permissions_explanation.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_all_permissions_explanation.xml
@@ -51,6 +51,18 @@
         />
 
     <com.ichi2.anki.ui.windows.permissions.PermissionsItem
+        android:id="@+id/legacy_post_notification_permission_item"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:permissionTitle="@string/notification_pref"
+        app:permissionSummary="@string/notifications_permission_explanation"
+        app:permissionIcon="@drawable/ic_notifications"
+        app:permission="@string/legacy_post_notification_permission"
+        android:visibility="gone"
+        tools:visibility="visible"
+        />
+
+    <com.ichi2.anki.ui.windows.permissions.PermissionsItem
         android:id="@+id/record_audio_permission_item"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/AnkiDroid/src/main/res/layout/fragment_legacy_notifications_permission.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_legacy_notifications_permission.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".ui.windows.permissions.LegacyNotificationsPermissionFragment">
+
+    <com.ichi2.anki.ui.windows.permissions.PermissionsItem
+        android:id="@+id/legacy_notification_permission"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:permissionTitle="@string/notification_pref"
+        app:permissionSummary="@string/notifications_permission_explanation"
+        app:permissionIcon="@drawable/ic_notifications"
+        app:permission="@string/legacy_post_notification_permission" />
+
+</LinearLayout>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -364,6 +364,9 @@
         <item>android.permission.WRITE_EXTERNAL_STORAGE</item>
     </string-array>
     <string name="post_notification_permission">android.permission.POST_NOTIFICATIONS</string>
+
+    <!-- See LEGACY_POST_NOTIFICATIONS. -->
+    <string name="legacy_post_notification_permission">NOTIFICATIONS_BEFORE_API_33_DUMMY_SENTINEL</string>
     <string name="record_audio_permission">android.permission.RECORD_AUDIO</string>
 
 

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -367,6 +367,9 @@
         <item>android.permission.WRITE_EXTERNAL_STORAGE</item>
     </string-array>
     <string name="post_notification_permission">android.permission.POST_NOTIFICATIONS</string>
+
+    <!-- See LEGACY_POST_NOTIFICATIONS. -->
+    <string name="legacy_post_notification_permission">NOTIFICATIONS_BEFORE_API_33_DUMMY_SENTINEL</string>
     <string name="record_audio_permission">android.permission.RECORD_AUDIO</string>
 
 

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -221,6 +221,7 @@
     <string name="reminder_notifs_request_shown_key">reminderNotifsRequestShown</string>
     <string name="review_reminder_deserialization_errors_key">reviewReminderDeserializationErrors</string>
     <!-- Notifications -->
+    <string name="notifications_bottom_sheet_below_33">notificationsBottomSheetBelow33</string>
     <string name="notifications_permission_requested_key">notificationsPermissionRequested</string>
     <string name="record_audio_permission_requested_key">recordAudioPermissionRequested</string>
     <!-- Developer options -->

--- a/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
@@ -33,6 +33,7 @@ import androidx.test.filters.SdkSuppress
 import com.ichi2.anki.PermissionSet
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ui.windows.permissions.PermissionsBottomSheet
+import com.ichi2.utils.Permissions.openAppSettingsScreenForPermission
 import com.ichi2.utils.Permissions.requestPermissionThroughDialogOrSettings
 import io.mockk.every
 import io.mockk.mockk
@@ -148,6 +149,26 @@ class PermissionsTest {
         setCanPermissionBeRequested(false)
         showBottomSheetShouldFail()
         verify(exactly = 2) { PermissionsBottomSheet.launch(fragmentManager, PermissionSet.NOTIFICATIONS) }
+    }
+
+    @Test
+    fun `openAppSettingsScreenForPermission opens the generic app settings screen for a null permission`() {
+        fragment.openAppSettingsScreenForPermission(null)
+        verifyOSSettingsWasOpened()
+    }
+
+    @Test
+    fun `openAppSettingsScreenForPermission opens the generic app settings screen for an unhandled permission`() {
+        fragment.openAppSettingsScreenForPermission(DUMMY_PERMISSION_STRING)
+        verifyOSSettingsWasOpened()
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.TIRAMISU)
+    fun `openAppSettingsScreenForPermission for the notifications permission at API 33+ opens the notif settings screen`() {
+        fragment.openAppSettingsScreenForPermission(Permissions.notificationsPermission)
+        verifyOSSettingsWasOpened(openedActivityAction = Settings.ACTION_APP_NOTIFICATION_SETTINGS)
     }
 
     private fun setPermissionsGranted(granted: Boolean) {

--- a/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
@@ -79,12 +79,14 @@ class PermissionsTest {
         mockkStatic(NotificationManagerCompat::class)
 
         Prefs.notificationsPermissionRequested = false
+        Prefs.notificationsBottomSheetShownBelowAPI33 = false
     }
 
     @After
     fun tearDown() {
         unmockkAll()
         Prefs.notificationsPermissionRequested = false
+        Prefs.notificationsBottomSheetShownBelowAPI33 = false
     }
 
     @Test
@@ -152,15 +154,7 @@ class PermissionsTest {
     }
 
     @Test
-    @Config(sdk = [Build.VERSION_CODES.TIRAMISU - 1])
-    fun `showNotificationsPermissionBottomSheetIfNeeded does nothing below API 33`() {
-        setPermissionsGranted(false)
-        setCanPermissionBeRequested(true)
-        showBottomSheetShouldFail()
-    }
-
-    @Test
-    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU, Build.VERSION_CODES.TIRAMISU - 1])
     fun `showNotificationsPermissionBottomSheetIfNeeded does nothing if permission is granted`() {
         setPermissionsGranted(true)
         setCanPermissionBeRequested(true)
@@ -170,7 +164,7 @@ class PermissionsTest {
     @Test
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     @SdkSuppress(minSdkVersion = Build.VERSION_CODES.TIRAMISU)
-    fun `showNotificationsPermissionBottomSheetIfNeeded works on first call and afterward only if system allows it`() {
+    fun `showNotificationsPermissionBottomSheetIfNeeded for API at 33+ works on first call and afterward only if system allows it`() {
         mockkObject(PermissionsBottomSheet)
 
         setPermissionsGranted(false)
@@ -182,6 +176,23 @@ class PermissionsTest {
         setCanPermissionBeRequested(false)
         showBottomSheetShouldFail()
         verify(exactly = 2) { PermissionsBottomSheet.launch(fragmentManager, PermissionSet.NOTIFICATIONS) }
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU - 1])
+    fun `showNotificationsPermissionBottomSheetIfNeeded for API before 33 only works on first call if cannot send notifications`() {
+        mockkObject(PermissionsBottomSheet)
+
+        setPermissionsGranted(false)
+        setCanPermissionBeRequested(true)
+        showBottomSheetShouldSucceed()
+        assertThat(Prefs.notificationsBottomSheetShownBelowAPI33, equalTo(true))
+        showBottomSheetShouldFail()
+
+        setCanPermissionBeRequested(false)
+        showBottomSheetShouldFail()
+        verify(exactly = 1) { PermissionsBottomSheet.launch(fragmentManager, PermissionSet.LEGACY_NOTIFICATIONS) }
+        assertThat(Prefs.notificationsBottomSheetShownBelowAPI33, equalTo(true))
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
@@ -34,7 +34,6 @@ import com.ichi2.anki.PermissionSet
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ui.windows.permissions.PermissionsBottomSheet
 import com.ichi2.utils.Permissions.requestPermissionThroughDialogOrSettings
-import com.ichi2.utils.Permissions.showToastAndOpenAppSettingsScreen
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -65,6 +64,7 @@ class PermissionsTest {
         context = getApplicationContext()
         activity = mockk(relaxed = true)
         fragment = mockk(relaxed = true)
+        every { fragment.requireContext() } returns context
         fragmentManager = mockk(relaxed = true)
         permissionRequestLauncher = mockk(relaxed = true)
         permissionsSpy = spyk(Permissions)
@@ -100,7 +100,17 @@ class PermissionsTest {
     }
 
     @Test
-    fun `requestPermissionThroughDialogOrSettings requests permission if we can request it`() {
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.TIRAMISU)
+    fun `requestPermissionThroughDialogOrSettings for notif permission opens notif settings screen if we can't request the permission`() {
+        Prefs.notificationsPermissionRequested = true // not first call
+        setCanPermissionBeRequested(false)
+        triggerPermissionRequest(permission = Permissions.notificationsPermission)
+        verifyOSSettingsWasOpened(openedActivityAction = Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+    }
+
+    @Test
+    fun `requestPermissionThroughDialogOrSettings requests permission on subsequent calls if we can request it`() {
         Prefs.notificationsPermissionRequested = true // not first call
         setCanPermissionBeRequested(true)
         triggerPermissionRequest()
@@ -149,28 +159,28 @@ class PermissionsTest {
         every { ActivityCompat.shouldShowRequestPermissionRationale(any(), any()) } returns canBeRequested
     }
 
-    private fun triggerPermissionRequest() {
+    private fun triggerPermissionRequest(permission: String = DUMMY_PERMISSION_STRING) {
         fragment.requestPermissionThroughDialogOrSettings(
             activity,
-            DUMMY_PERMISSION_STRING,
+            permission,
             Prefs::notificationsPermissionRequested,
             permissionRequestLauncher,
         )
+        assertThat("requested flag should always be true after requesting", Prefs.notificationsPermissionRequested, equalTo(true))
     }
 
-    private fun verifyPermissionWasRequested() {
-        assertThat("requested flag should always be true after requesting", Prefs.notificationsPermissionRequested, equalTo(true))
-        verify(exactly = 1) { permissionRequestLauncher.launch(DUMMY_PERMISSION_STRING) }
-        verify(exactly = 0) { fragment.showToastAndOpenAppSettingsScreen(any<Int>()) }
+    private fun verifyPermissionWasRequested(permission: String = DUMMY_PERMISSION_STRING) {
+        verify(exactly = 1) { permissionRequestLauncher.launch(permission) }
+        // No settings screen should be opened if the permission could be requested directly
+        verify(exactly = 0) { fragment.startActivity(any()) }
     }
 
-    private fun verifyOSSettingsWasOpened() {
-        assertThat("requested flag should always be true after requesting", Prefs.notificationsPermissionRequested, equalTo(true))
-        verify(exactly = 0) { permissionRequestLauncher.launch(DUMMY_PERMISSION_STRING) }
+    private fun verifyOSSettingsWasOpened(openedActivityAction: String = Settings.ACTION_APPLICATION_DETAILS_SETTINGS) {
+        verify(exactly = 0) { permissionRequestLauncher.launch(any()) }
 
         val intentSlot = slot<Intent>()
         verify(exactly = 1) { fragment.startActivity(capture(intentSlot)) }
-        assertThat(intentSlot.captured.action, equalTo(Settings.ACTION_APPLICATION_DETAILS_SETTINGS))
+        assertThat(intentSlot.captured.action, equalTo(openedActivityAction))
     }
 
     private fun showBottomSheetShouldFail() {

--- a/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
@@ -19,12 +19,11 @@ package com.ichi2.utils
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.os.Build
 import android.provider.Settings
 import androidx.activity.result.ActivityResultLauncher
 import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
+import androidx.core.app.NotificationManagerCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
@@ -76,8 +75,8 @@ class PermissionsTest {
         // No need to test the behaviour of the shouldShowRequestPermissionRationale system API,
         // as that's not our code, so we just mock its behaviour
         mockkStatic(ActivityCompat::class)
-        // Similarly with ContextCompat.checkSelfPermission
-        mockkStatic(ContextCompat::class)
+        // Similarly with NotificationManagerCompat.areNotificationsEnabled
+        mockkStatic(NotificationManagerCompat::class)
 
         Prefs.notificationsPermissionRequested = false
     }
@@ -229,8 +228,7 @@ class PermissionsTest {
     }
 
     private fun setPermissionsGranted(granted: Boolean) {
-        val permissionStatus = if (granted) PackageManager.PERMISSION_GRANTED else PackageManager.PERMISSION_DENIED
-        every { ContextCompat.checkSelfPermission(any(), any()) } returns permissionStatus
+        every { NotificationManagerCompat.from(any()).areNotificationsEnabled() } returns granted
     }
 
     private fun setCanPermissionBeRequested(canBeRequested: Boolean) {

--- a/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
@@ -31,6 +31,8 @@ import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SdkSuppress
 import com.ichi2.anki.PermissionSet
+import com.ichi2.anki.R
+import com.ichi2.anki.common.permissions.LEGACY_POST_NOTIFICATIONS
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ui.windows.permissions.PermissionsBottomSheet
 import com.ichi2.utils.Permissions.openAppSettingsScreenForPermission
@@ -169,6 +171,29 @@ class PermissionsTest {
     fun `openAppSettingsScreenForPermission for the notifications permission at API 33+ opens the notif settings screen`() {
         fragment.openAppSettingsScreenForPermission(Permissions.notificationsPermission)
         verifyOSSettingsWasOpened(openedActivityAction = Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU, Build.VERSION_CODES.TIRAMISU - 1])
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.O)
+    fun `openAppSettingsScreenForPermission for the legacy notifications sentinel opens the notif settings screen`() {
+        fragment.openAppSettingsScreenForPermission(LEGACY_POST_NOTIFICATIONS)
+        verifyOSSettingsWasOpened(openedActivityAction = Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.O - 1])
+    fun `openAppSettingsScreenForPermission for the legacy notifications sentinel before API 26 opens the generic app settings screen`() {
+        fragment.openAppSettingsScreenForPermission(LEGACY_POST_NOTIFICATIONS)
+        verifyOSSettingsWasOpened()
+    }
+
+    @Test
+    fun `legacy_post_notification_permission resource matches the LEGACY_POST_NOTIFICATIONS constant`() {
+        assertThat(
+            context.getString(R.string.legacy_post_notification_permission),
+            equalTo(LEGACY_POST_NOTIFICATIONS),
+        )
     }
 
     private fun setPermissionsGranted(granted: Boolean) {

--- a/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
@@ -35,6 +35,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.common.permissions.LEGACY_POST_NOTIFICATIONS
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ui.windows.permissions.PermissionsBottomSheet
+import com.ichi2.utils.Permissions.attemptToEnableNotifications
 import com.ichi2.utils.Permissions.openAppSettingsScreenForPermission
 import com.ichi2.utils.Permissions.requestPermissionThroughDialogOrSettings
 import io.mockk.every
@@ -118,6 +119,37 @@ class PermissionsTest {
         setCanPermissionBeRequested(true)
         triggerPermissionRequest()
         verifyPermissionWasRequested()
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.TIRAMISU)
+    fun `attemptToEnableNotifications for API at 33+ requests the notifications permission`() {
+        Prefs.notificationsPermissionRequested = false
+        fragment.attemptToEnableNotifications(permissionRequestLauncher)
+        verifyPermissionWasRequested(permission = Permissions.notificationsPermission)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.TIRAMISU)
+    fun `attemptToEnableNotifications for API at 33+ opens notif settings screen if we can't request the permission`() {
+        Prefs.notificationsPermissionRequested = true // not first call
+        setCanPermissionBeRequested(false)
+        fragment.attemptToEnableNotifications(permissionRequestLauncher)
+        verifyOSSettingsWasOpened(openedActivityAction = Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU - 1])
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.O)
+    fun `attemptToEnableNotifications for API before 33 opens notif settings screen without requesting a permission`() {
+        fragment.attemptToEnableNotifications(permissionRequestLauncher)
+        // The notifications permission does not exist below API 33, so it should never be requested
+        verify(exactly = 0) { permissionRequestLauncher.launch(any()) }
+        // The OS request dialog should not have been opened
+        assertThat(Prefs.notificationsPermissionRequested, equalTo(false))
+        verifyOSSettingsWasOpened(openedActivityAction = Settings.ACTION_APP_NOTIFICATION_SETTINGS)
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
@@ -6,12 +6,11 @@ package com.ichi2.utils
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.os.Build
 import android.provider.Settings
 import androidx.activity.result.ActivityResultLauncher
 import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
+import androidx.core.app.NotificationManagerCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
@@ -69,8 +68,8 @@ class PermissionsTest {
         // No need to test the behaviour of the shouldShowRequestPermissionRationale system API,
         // as that's not our code, so we just mock its behaviour
         mockkStatic(ActivityCompat::class)
-        // Similarly with ContextCompat.checkSelfPermission
-        mockkStatic(ContextCompat::class)
+        // Similarly with NotificationManagerCompat.areNotificationsEnabled
+        mockkStatic(NotificationManagerCompat::class)
 
         Prefs.notificationsPermissionRequested = false
     }
@@ -230,8 +229,7 @@ class PermissionsTest {
     }
 
     private fun setPermissionsGranted(granted: Boolean) {
-        val permissionStatus = if (granted) PackageManager.PERMISSION_GRANTED else PackageManager.PERMISSION_DENIED
-        every { ContextCompat.checkSelfPermission(any(), any()) } returns permissionStatus
+        every { NotificationManagerCompat.from(any()).areNotificationsEnabled() } returns granted
     }
 
     private fun setCanPermissionBeRequested(canBeRequested: Boolean) {

--- a/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
@@ -23,6 +23,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.common.permissions.LEGACY_POST_NOTIFICATIONS
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ui.windows.permissions.PermissionsBottomSheet
+import com.ichi2.utils.Permissions.attemptToEnableNotifications
 import com.ichi2.utils.Permissions.openAppSettingsScreen
 import com.ichi2.utils.Permissions.openAppSettingsScreenForPermission
 import com.ichi2.utils.Permissions.requestPermissionThroughDialogOrSettings
@@ -119,6 +120,37 @@ class PermissionsTest {
         setCanPermissionBeRequested(true)
         triggerPermissionRequest()
         verifyPermissionWasRequested()
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.TIRAMISU)
+    fun `attemptToEnableNotifications for API at 33+ requests the notifications permission`() {
+        Prefs.notificationsPermissionRequested = false
+        fragment.attemptToEnableNotifications(permissionRequestLauncher)
+        verifyPermissionWasRequested(permission = Permissions.notificationsPermission)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.TIRAMISU)
+    fun `attemptToEnableNotifications for API at 33+ opens notif settings screen if we can't request the permission`() {
+        Prefs.notificationsPermissionRequested = true // not first call
+        setCanPermissionBeRequested(false)
+        fragment.attemptToEnableNotifications(permissionRequestLauncher)
+        verifyOSSettingsWasOpened(openedActivityAction = Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU - 1])
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.O)
+    fun `attemptToEnableNotifications for API before 33 opens notif settings screen without requesting a permission`() {
+        fragment.attemptToEnableNotifications(permissionRequestLauncher)
+        // The notifications permission does not exist below API 33, so it should never be requested
+        verify(exactly = 0) { permissionRequestLauncher.launch(any()) }
+        // The OS request dialog should not have been opened
+        assertThat(Prefs.notificationsPermissionRequested, equalTo(false))
+        verifyOSSettingsWasOpened(openedActivityAction = Settings.ACTION_APP_NOTIFICATION_SETTINGS)
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
@@ -22,6 +22,7 @@ import com.ichi2.anki.PermissionSet
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ui.windows.permissions.PermissionsBottomSheet
 import com.ichi2.utils.Permissions.openAppSettingsScreen
+import com.ichi2.utils.Permissions.openAppSettingsScreenForPermission
 import com.ichi2.utils.Permissions.requestPermissionThroughDialogOrSettings
 import io.mockk.every
 import io.mockk.mockk
@@ -149,6 +150,26 @@ class PermissionsTest {
         setCanPermissionBeRequested(false)
         showBottomSheetShouldFail()
         verify(exactly = 2) { PermissionsBottomSheet.launch(fragmentManager, PermissionSet.NOTIFICATIONS) }
+    }
+
+    @Test
+    fun `openAppSettingsScreenForPermission opens the generic app settings screen for a null permission`() {
+        fragment.openAppSettingsScreenForPermission(null)
+        verifyOSSettingsWasOpened()
+    }
+
+    @Test
+    fun `openAppSettingsScreenForPermission opens the generic app settings screen for an unhandled permission`() {
+        fragment.openAppSettingsScreenForPermission(DUMMY_PERMISSION_STRING)
+        verifyOSSettingsWasOpened()
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.TIRAMISU)
+    fun `openAppSettingsScreenForPermission for the notifications permission at API 33+ opens the notif settings screen`() {
+        fragment.openAppSettingsScreenForPermission(Permissions.notificationsPermission)
+        verifyOSSettingsWasOpened(openedActivityAction = Settings.ACTION_APP_NOTIFICATION_SETTINGS)
     }
 
     private fun setPermissionsGranted(granted: Boolean) {

--- a/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
@@ -45,7 +45,6 @@ import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
 class PermissionsTest {
-    private lateinit var activity: Activity
     private lateinit var fragmentActivity: FragmentActivity
     private lateinit var context: Context
     private lateinit var fragment: Fragment
@@ -56,7 +55,6 @@ class PermissionsTest {
     @Before
     fun setUp() {
         context = getApplicationContext()
-        activity = mockk(relaxed = true)
         fragmentActivity = mockk(relaxed = true)
         fragment = mockk(relaxed = true)
         every { fragment.requireActivity() } returns fragmentActivity
@@ -154,7 +152,7 @@ class PermissionsTest {
 
     private fun triggerPermissionRequest() {
         fragment.requestPermissionThroughDialogOrSettings(
-            activity,
+            fragmentActivity,
             DUMMY_PERMISSION_STRING,
             Prefs::notificationsPermissionRequested,
             permissionRequestLauncher,
@@ -177,13 +175,13 @@ class PermissionsTest {
     }
 
     private fun showBottomSheetShouldFail() {
-        permissionsSpy.showNotificationsPermissionBottomSheetIfNeeded(activity, fragmentManager) {
+        permissionsSpy.showNotificationsPermissionBottomSheetIfNeeded(fragmentActivity, fragmentManager) {
             throw IllegalStateException("callback should not be called")
         }
     }
 
     private fun showBottomSheetShouldSucceed() {
-        permissionsSpy.showNotificationsPermissionBottomSheetIfNeeded(activity, fragmentManager) {
+        permissionsSpy.showNotificationsPermissionBottomSheetIfNeeded(fragmentActivity, fragmentManager) {
             Prefs.notificationsPermissionRequested = true
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
@@ -19,6 +19,8 @@ import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SdkSuppress
 import com.ichi2.anki.PermissionSet
+import com.ichi2.anki.R
+import com.ichi2.anki.common.permissions.LEGACY_POST_NOTIFICATIONS
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ui.windows.permissions.PermissionsBottomSheet
 import com.ichi2.utils.Permissions.openAppSettingsScreen
@@ -170,6 +172,29 @@ class PermissionsTest {
     fun `openAppSettingsScreenForPermission for the notifications permission at API 33+ opens the notif settings screen`() {
         fragment.openAppSettingsScreenForPermission(Permissions.notificationsPermission)
         verifyOSSettingsWasOpened(openedActivityAction = Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU, Build.VERSION_CODES.TIRAMISU - 1])
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.O)
+    fun `openAppSettingsScreenForPermission for the legacy notifications sentinel opens the notif settings screen`() {
+        fragment.openAppSettingsScreenForPermission(LEGACY_POST_NOTIFICATIONS)
+        verifyOSSettingsWasOpened(openedActivityAction = Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.O - 1])
+    fun `openAppSettingsScreenForPermission for the legacy notifications sentinel before API 26 opens the generic app settings screen`() {
+        fragment.openAppSettingsScreenForPermission(LEGACY_POST_NOTIFICATIONS)
+        verifyOSSettingsWasOpened()
+    }
+
+    @Test
+    fun `legacy_post_notification_permission resource matches the LEGACY_POST_NOTIFICATIONS constant`() {
+        assertThat(
+            context.getString(R.string.legacy_post_notification_permission),
+            equalTo(LEGACY_POST_NOTIFICATIONS),
+        )
     }
 
     private fun setPermissionsGranted(granted: Boolean) {

--- a/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
@@ -23,7 +23,6 @@ import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ui.windows.permissions.PermissionsBottomSheet
 import com.ichi2.utils.Permissions.openAppSettingsScreen
 import com.ichi2.utils.Permissions.requestPermissionThroughDialogOrSettings
-import com.ichi2.utils.Permissions.showToastAndOpenAppSettingsScreen
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -57,6 +56,7 @@ class PermissionsTest {
         context = getApplicationContext()
         fragmentActivity = mockk(relaxed = true)
         fragment = mockk(relaxed = true)
+        every { fragment.requireContext() } returns context
         every { fragment.requireActivity() } returns fragmentActivity
         fragmentManager = mockk(relaxed = true)
         permissionRequestLauncher = mockk(relaxed = true)
@@ -101,7 +101,17 @@ class PermissionsTest {
     }
 
     @Test
-    fun `requestPermissionThroughDialogOrSettings requests permission if we can request it`() {
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.TIRAMISU)
+    fun `requestPermissionThroughDialogOrSettings for notif permission opens notif settings screen if we can't request the permission`() {
+        Prefs.notificationsPermissionRequested = true // not first call
+        setCanPermissionBeRequested(false)
+        triggerPermissionRequest(permission = Permissions.notificationsPermission)
+        verifyOSSettingsWasOpened(openedActivityAction = Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+    }
+
+    @Test
+    fun `requestPermissionThroughDialogOrSettings requests permission on subsequent calls if we can request it`() {
         Prefs.notificationsPermissionRequested = true // not first call
         setCanPermissionBeRequested(true)
         triggerPermissionRequest()
@@ -150,28 +160,28 @@ class PermissionsTest {
         every { ActivityCompat.shouldShowRequestPermissionRationale(any(), any()) } returns canBeRequested
     }
 
-    private fun triggerPermissionRequest() {
+    private fun triggerPermissionRequest(permission: String = DUMMY_PERMISSION_STRING) {
         fragment.requestPermissionThroughDialogOrSettings(
             fragmentActivity,
-            DUMMY_PERMISSION_STRING,
+            permission,
             Prefs::notificationsPermissionRequested,
             permissionRequestLauncher,
         )
+        assertThat("requested flag should always be true after requesting", Prefs.notificationsPermissionRequested, equalTo(true))
     }
 
-    private fun verifyPermissionWasRequested() {
-        assertThat("requested flag should always be true after requesting", Prefs.notificationsPermissionRequested, equalTo(true))
-        verify(exactly = 1) { permissionRequestLauncher.launch(DUMMY_PERMISSION_STRING) }
-        verify(exactly = 0) { fragment.showToastAndOpenAppSettingsScreen(any<Int>()) }
+    private fun verifyPermissionWasRequested(permission: String = DUMMY_PERMISSION_STRING) {
+        verify(exactly = 1) { permissionRequestLauncher.launch(permission) }
+        // No settings screen should be opened if the permission could be requested directly
+        verify(exactly = 0) { fragmentActivity.startActivity(any()) }
     }
 
-    private fun verifyOSSettingsWasOpened() {
-        assertThat("requested flag should always be true after requesting", Prefs.notificationsPermissionRequested, equalTo(true))
-        verify(exactly = 0) { permissionRequestLauncher.launch(DUMMY_PERMISSION_STRING) }
+    private fun verifyOSSettingsWasOpened(openedActivityAction: String = Settings.ACTION_APPLICATION_DETAILS_SETTINGS) {
+        verify(exactly = 0) { permissionRequestLauncher.launch(any()) }
 
         val intentSlot = slot<Intent>()
         verify(exactly = 1) { fragmentActivity.startActivity(capture(intentSlot)) }
-        assertThat(intentSlot.captured.action, equalTo(Settings.ACTION_APPLICATION_DETAILS_SETTINGS))
+        assertThat(intentSlot.captured.action, equalTo(openedActivityAction))
     }
 
     private fun showBottomSheetShouldFail() {

--- a/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
@@ -72,12 +72,14 @@ class PermissionsTest {
         mockkStatic(NotificationManagerCompat::class)
 
         Prefs.notificationsPermissionRequested = false
+        Prefs.notificationsBottomSheetShownBelowAPI33 = false
     }
 
     @After
     fun tearDown() {
         unmockkAll()
         Prefs.notificationsPermissionRequested = false
+        Prefs.notificationsBottomSheetShownBelowAPI33 = false
     }
 
     @Test
@@ -153,15 +155,7 @@ class PermissionsTest {
     }
 
     @Test
-    @Config(sdk = [Build.VERSION_CODES.TIRAMISU - 1])
-    fun `showNotificationsPermissionBottomSheetIfNeeded does nothing below API 33`() {
-        setPermissionsGranted(false)
-        setCanPermissionBeRequested(true)
-        showBottomSheetShouldFail()
-    }
-
-    @Test
-    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU, Build.VERSION_CODES.TIRAMISU - 1])
     fun `showNotificationsPermissionBottomSheetIfNeeded does nothing if permission is granted`() {
         setPermissionsGranted(true)
         setCanPermissionBeRequested(true)
@@ -171,7 +165,7 @@ class PermissionsTest {
     @Test
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     @SdkSuppress(minSdkVersion = Build.VERSION_CODES.TIRAMISU)
-    fun `showNotificationsPermissionBottomSheetIfNeeded works on first call and afterward only if system allows it`() {
+    fun `showNotificationsPermissionBottomSheetIfNeeded for API at 33+ works on first call and afterward only if system allows it`() {
         mockkObject(PermissionsBottomSheet)
 
         setPermissionsGranted(false)
@@ -183,6 +177,23 @@ class PermissionsTest {
         setCanPermissionBeRequested(false)
         showBottomSheetShouldFail()
         verify(exactly = 2) { PermissionsBottomSheet.launch(fragmentManager, PermissionSet.NOTIFICATIONS) }
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU - 1])
+    fun `showNotificationsPermissionBottomSheetIfNeeded for API before 33 only works on first call if cannot send notifications`() {
+        mockkObject(PermissionsBottomSheet)
+
+        setPermissionsGranted(false)
+        setCanPermissionBeRequested(true)
+        showBottomSheetShouldSucceed()
+        assertThat(Prefs.notificationsBottomSheetShownBelowAPI33, equalTo(true))
+        showBottomSheetShouldFail()
+
+        setCanPermissionBeRequested(false)
+        showBottomSheetShouldFail()
+        verify(exactly = 1) { PermissionsBottomSheet.launch(fragmentManager, PermissionSet.LEGACY_NOTIFICATIONS) }
+        assertThat(Prefs.notificationsBottomSheetShownBelowAPI33, equalTo(true))
     }
 
     @Test

--- a/common/android/src/main/java/com/ichi2/anki/common/permissions/Permissions.kt
+++ b/common/android/src/main/java/com/ichi2/anki/common/permissions/Permissions.kt
@@ -4,10 +4,12 @@
 
 package com.ichi2.anki.common.permissions
 
+import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.content.ContextCompat
+import timber.log.Timber
 
 /**
  * Whether the app is granted [permission].
@@ -24,6 +26,16 @@ fun hasPermission(
         return isExternalStorageManager()
     }
 
+    if (permission == LEGACY_POST_NOTIFICATIONS) {
+        // hack: just in case hasPermission is ever called with LEGACY_POST_NOTIFICATIONS
+        // checkSelfPermission only works on API 33+
+        val canPostNotifs = canPostNotifications(context)
+        Timber.w(
+            "hasPermission called with legacy permissions sentinel; not technically a permission. Returning whether notifications are enabled: $canPostNotifs",
+        )
+        return canPostNotifs
+    }
+
     return ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
 }
 
@@ -34,3 +46,14 @@ fun hasAllPermissions(
     context: Context,
     permissions: Collection<String>,
 ): Boolean = permissions.all { hasPermission(context, it) }
+
+/**
+ * Dummy sentinel "permission" string which represents the permission to send notifications on API <33.
+ * On API <33, there is no explicit manifest permission for notifications, but they can be toggled off by the user in system settings.
+ * See `legacy_post_notification_permission`
+ */
+const val LEGACY_POST_NOTIFICATIONS: String = "NOTIFICATIONS_BEFORE_API_33_DUMMY_SENTINEL"
+
+fun canPostNotifications(context: Context): Boolean =
+    Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+        ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED

--- a/common/android/src/main/java/com/ichi2/anki/common/permissions/Permissions.kt
+++ b/common/android/src/main/java/com/ichi2/anki/common/permissions/Permissions.kt
@@ -4,10 +4,10 @@
 
 package com.ichi2.anki.common.permissions
 
-import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
+import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import timber.log.Timber
 
@@ -54,6 +54,4 @@ fun hasAllPermissions(
  */
 const val LEGACY_POST_NOTIFICATIONS: String = "NOTIFICATIONS_BEFORE_API_33_DUMMY_SENTINEL"
 
-fun canPostNotifications(context: Context): Boolean =
-    Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
-        ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
+fun canPostNotifications(context: Context): Boolean = NotificationManagerCompat.from(context).areNotificationsEnabled()


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 5

## Purpose / Description
I discovered that the function we were using for checking if notification permissions have been granted is flawed below API 33. Recall that it was:

```kotlin
Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) ==
PackageManager.PERMISSION_GRANTED
```

However, it is actually NOT the case that devices below API 33 unconditionally allow notifications to fire. It is possible to enter the settings and manually disable the ability for an app to fire notifications, meaning the above was returning a false positive. The correct API call is `NotificationManagerCompat.from(context).areNotificationsEnabled()`, which is equivalent to the old check at and above API 33, but which also handles pre-Tiramisu devices correctly.

Below: Google Pixel, API 25, OS settings page for notifications:
<img width="281" height="167" alt="image" src="https://github.com/user-attachments/assets/41ca1599-18b7-4c09-808a-dc5fa6318252" />

The "new" UI is simply to handle the legacy notification case. No visual changes:
<img width="308" height="267" alt="image" src="https://github.com/user-attachments/assets/958ff811-66cb-4e9d-94ab-71a52c93cfd0" />
<img width="307" height="267" alt="image" src="https://github.com/user-attachments/assets/59f68e34-e281-48a1-9b7f-2ef76258d6dd" />

## Fixes
* Fixes a false positive on the review reminder troubleshooting page that stated reminders were working on pre-Tiramisu devices when they were not.

## Approach
See commit messages.

## How Has This Been Tested?
- Initial install and launch works
- Unit tests
- Manually granting and revoking permissions is updated accordingly
- Buttons within review reminders UI and troubleshooting UI for enabling and revoking permissions works
- BottomSheet shows correctly both before and after API 33
- Permission explanation screen works correctly both before and after API 33
- Tested on a physical Lenovo Tab M11, API 35
- Tested on a physical Samsung S23, API 36
- Tested on an emulated Pixel, API 25
- Tested on an emulated Pixel 6 Pro, API 31

## Learning
- Discovered while working on https://github.com/ankidroid/Anki-Android/pull/21398
- For notes on why I decided to create a separate pref for the BottomSheet, see the new pref's docstring
- I'm kind of unhappy that I had to create a new dummy fake permission string for legacy notifications to enable `openAppSettingsScreenForPermission`, but I can't see any other way to do it. It doesn't cause any problems in the codebase right now, but it's kind of hacky. Being able to use `singleOrNull` in PermissionItems is nice, though. If anyone has a better idea, please let me know.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->