### PR TITLE
Set counts text alignment to end for deck widget

### DIFF
--- a/AnkiDroid/src/main/res/layout/widget_item_deck_main.xml
+++ b/AnkiDroid/src/main/res/layout/widget_item_deck_main.xml
@@ -4,6 +4,7 @@
     android:layout_height="wrap_content"
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="horizontal"
+    android:paddingHorizontal="12dp"
     android:theme="@style/Theme.Material3.DynamicColors.DayNight">
 
     <TextView
@@ -14,7 +15,6 @@
         android:height="48dp"
         android:paddingBottom="2dp"
         android:paddingEnd="12dp"
-        android:paddingStart="15dp"
         android:paddingTop="10dp"
         android:textColor="?android:attr/textColorPrimary"
         android:textSize="22sp"
@@ -32,6 +32,7 @@
         android:textColor="@color/flag_reviewer_blue"
         android:textSize="20sp"
         android:text=""
+        android:gravity="end"
         android:ellipsize="end"
         android:maxLines="1"
         tools:text="50" />
@@ -45,6 +46,7 @@
         android:textColor="@color/material_red_A700"
         android:textSize="20sp"
         android:text=""
+        android:gravity="end"
         android:ellipsize="end"
         android:maxLines="1"
         tools:text="50" />
@@ -54,10 +56,10 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:paddingEnd="5dp"
         android:textColor="@color/flag_reviewer_green"
         android:textSize="20sp"
         android:text=""
+        android:gravity="end"
         android:ellipsize="end"
         android:maxLines="1"
         tools:text="50" />


### PR DESCRIPTION
## Purpose / Description

Small change to align the counts text to the end in the deck picker widget as asked by Danika_Dakika. I also modified the horizontal padding to be consistent at both ends.

Before/After:

<img width="539" height="181" alt="Screenshot from 2026-07-28 07-29-02" src="https://github.com/user-attachments/assets/ff6359e8-a371-4649-9fb3-eb473899dc1b" />
<img width="539" height="181" alt="Screenshot from 2026-07-28 07-27-56" src="https://github.com/user-attachments/assets/102f237a-eda6-4600-86ba-44393dec4648" />

Before/After:

<img width="556" height="189" alt="Screenshot from 2026-07-28 20-13-01" src="https://github.com/user-attachments/assets/47269cd8-1617-4198-b713-dd565171fef0" />
<img width="556" height="189" alt="Screenshot from 2026-07-28 20-11-27" src="https://github.com/user-attachments/assets/217127ab-b839-44a3-947d-c6555ed625b7" />


I plan to look at #18524 to see if we can do something about the clipping of entries.

## Fixes
* Related to #18524

## How Has This Been Tested?

Checked how the widget looks with the changes.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
