### PR TITLE
fix(pages): resync congrats screen after filtered deck rebuild

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
@@ -11,9 +11,11 @@ import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.setFragmentResultListener
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import anki.collection.OpChanges
 import anki.scheduler.UnburyDeckRequest
 import com.google.android.material.appbar.MaterialToolbar
@@ -45,6 +47,7 @@ import com.ichi2.utils.show
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import kotlin.math.round
 
@@ -59,14 +62,16 @@ class CongratsPage :
         ChangeManager.subscribe(this)
     }
 
+    // TODO: move this to the ViewModel
     override fun opExecuted(
         changes: OpChanges,
         handler: Any?,
     ) {
-        // typically due to 'day rollover'
-        if (changes.studyQueues) {
-            Timber.i("refreshing: study queues updated")
-            webViewLayout.post { webViewLayout.reload() }
+        // typically due to 'day rollover'. handler !== viewModel excludes changes this
+        // screen caused itself (eg. unburying), which are already handled directly
+        if (changes.studyQueues && handler !== viewModel) {
+            Timber.i("study queues updated")
+            viewModel.onStudyQueuesChanged()
         }
     }
 
@@ -123,6 +128,28 @@ class CongratsPage :
                 navigate(destination)
             }.launchIn(lifecycleScope)
 
+        // a rebuild triggered elsewhere (eg. deck options) while this screen wasn't visible may
+        // have been missed, so recheck on every STARTED entry instead of trusting only the
+        // opExecuted callback. Launched from inside repeatOnLifecycle so the collector is
+        // guaranteed active before it emits (congratsRefreshState has no replay cache, so
+        // emitting with no active collector silently drops the event).
+        // viewLifecycleOwner (not the fragment's own lifecycle) is required by lint - see
+        // UnsafeRepeatOnLifecycleDetector.
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch { viewModel.refreshIfNeeded() }
+                viewModel.congratsRefreshState.collect { state ->
+                    when (state) {
+                        CongratsRefreshState.ReloadPage -> {
+                            Timber.d("congrats: reloading page after rebuild")
+                            webViewLayout.post { webViewLayout.reload() }
+                        }
+                        CongratsRefreshState.DeckHasCardsToStudy -> openStudyOptionsAndFinish()
+                    }
+                }
+            }
+        }
+
         with(view.findViewById<MaterialToolbar>(R.id.toolbar)) {
             inflateMenu(R.menu.congrats)
             menu.findItem(R.id.action_open_deck_options)?.title = TR.sentenceCase.deckOptions
@@ -150,6 +177,7 @@ class CongratsPage :
         )
 
     private fun openStudyOptionsAndFinish() {
+        Timber.i("opening study options")
         navigate(StudyOptionsDestination)
         requireActivity().finish()
     }
@@ -251,7 +279,7 @@ class CongratsViewModel :
     }
 
     private suspend fun unburyAndStudy(mode: UnburyDeckRequest.Mode) {
-        undoableOp {
+        undoableOp(handler = this) {
             sched.unburyDeck(decks.getCurrentId(), mode)
         }
         unburyState.emit(UnburyState.OpenStudy)
@@ -264,10 +292,57 @@ class CongratsViewModel :
             deckOptionsDestination.emit(DeckOptionsDestination(deckId, isFiltered))
         }
     }
+
+    val congratsRefreshState = MutableSharedFlow<CongratsRefreshState>()
+
+    // set when onStudyQueuesChanged() has nothing to emit to (screen not STARTED, so
+    // congratsRefreshState has no collector and would silently drop the event) - consumed
+    // and cleared by refreshIfNeeded() on the next STARTED
+    private var missedRefresh = false
+
+    fun onStudyQueuesChanged() {
+        launchCatchingIO {
+            if (congratsRefreshState.subscriptionCount.value == 0) {
+                missedRefresh = true
+                return@launchCatchingIO
+            }
+            emitRefreshState()
+        }
+    }
+
+    /** Called every time the screen becomes STARTED. [isDeckFinished] is cheap so it's always
+     * run, but the (latency-sensitive) reload/navigation only happens if something was actually
+     * missed while unwatched, or the deck no longer needs the congrats page. */
+    suspend fun refreshIfNeeded() {
+        // desktop's Overview re-checks sched._is_finished() on every refresh instead of
+        // assuming the deck is still done - do the same before reloading the congrats page
+        val stillFinished = isDeckFinished()
+        if (!missedRefresh && stillFinished) return
+        missedRefresh = false
+        congratsRefreshState.emit(
+            if (stillFinished) CongratsRefreshState.ReloadPage else CongratsRefreshState.DeckHasCardsToStudy,
+        )
+    }
+
+    private suspend fun emitRefreshState() {
+        missedRefresh = false
+        val stillFinished = isDeckFinished()
+        congratsRefreshState.emit(
+            if (stillFinished) CongratsRefreshState.ReloadPage else CongratsRefreshState.DeckHasCardsToStudy,
+        )
+    }
+
+    private suspend fun isDeckFinished(): Boolean = withCol { sched.counts().count() == 0 }
 }
 
 sealed class UnburyState {
     data object OpenStudy : UnburyState()
 
     data object SelectMode : UnburyState()
+}
+
+sealed class CongratsRefreshState {
+    data object ReloadPage : CongratsRefreshState()
+
+    data object DeckHasCardsToStudy : CongratsRefreshState()
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/pages/CongratsPageTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/pages/CongratsPageTest.kt
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package com.ichi2.anki.pages
+
+import androidx.lifecycle.Lifecycle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.StudyOptionsActivity
+import com.ichi2.anki.observability.undoableOp
+import com.ichi2.testutils.launchFragmentInContainer
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class CongratsPageTest : RobolectricTest() {
+    // https://github.com/ankidroid/Anki-Android/pull/21409#pullrequestreview-3568785419
+    @Test
+    fun `resuming after a background rebuild refills the deck - navigates to study options`() =
+        runTest {
+            addBasicNote("Front", "Back")
+            val deckId = addDynamicDeck("Filtered", "")
+            withCol { sched.emptyFilteredDeck(deckId) }
+
+            val scenario = launchFragmentInContainer<CongratsPage>()
+            scenario.moveToState(Lifecycle.State.CREATED)
+
+            // rebuild happens while the screen isn't visible - nobody is collecting congratsRefreshState
+            undoableOp { sched.rebuildFilteredDeck(deckId) }
+
+            scenario.moveToState(Lifecycle.State.RESUMED)
+            advanceUntilIdle()
+
+            scenario.onFragment { fragment ->
+                val next = shadowOf(fragment.requireActivity()).nextStartedActivity
+                assertEquals(StudyOptionsActivity::class.java.name, next?.component?.className)
+            }
+        }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/pages/CongratsViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/pages/CongratsViewModelTest.kt
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package com.ichi2.anki.pages
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.RobolectricTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+
+// https://github.com/ankidroid/Anki-Android/issues/21393
+@RunWith(AndroidJUnit4::class)
+class CongratsViewModelTest : RobolectricTest() {
+    private val viewModel = CongratsViewModel()
+
+    @Test
+    fun `onStudyQueuesChanged - navigates away once rebuild refills an emptied filtered deck`() =
+        runTest {
+            addBasicNote("Front", "Back")
+            val deckId = addDynamicDeck("Filtered", "")
+            withCol { sched.emptyFilteredDeck(deckId) }
+
+            withCol { sched.rebuildFilteredDeck(deckId) }
+
+            viewModel.congratsRefreshState.test {
+                viewModel.onStudyQueuesChanged()
+                assertEquals(CongratsRefreshState.DeckHasCardsToStudy, awaitItem())
+            }
+        }
+
+    @Test
+    fun `onStudyQueuesChanged - reloads the page when rebuild finds no cards`() =
+        runTest {
+            addBasicNote("Front", "Back")
+            val deckId = addDynamicDeck("Filtered", "deck:NonExistentDeck")
+
+            withCol { sched.rebuildFilteredDeck(deckId) }
+
+            viewModel.congratsRefreshState.test {
+                viewModel.onStudyQueuesChanged()
+                assertEquals(CongratsRefreshState.ReloadPage, awaitItem())
+            }
+        }
+}


### PR DESCRIPTION
## Purpose / Description
The congrats screen for a filtered deck stays stuck on "Congratulations" after rebuilding, even when the rebuild pulls cards back in.

## Fixes
* Fixes #21393

## Approach
`CongratsPage` reloaded its own congrats WebView route on every `studyQueues` change without checking if the deck was actually still empty. `CongratsViewModel` now checks `sched.counts()` first and navigates to `StudyOptionsActivity` instead of reloading when the deck has cards due. Desktop's `Overview` already does this same check on every refresh, AnkiDroid's split-screen version just never ported it over.

## How Has This Been Tested?
Added `CongratsViewModelTest`, reproducing the repro steps from the issue (fill deck, empty it, rebuild). Ran the full unit test suite locally. Manually reproduced and verified the fix on a Pixel 7 emulator, API 33.

## Learning (optional, can help others)
Compared against desktop's `qt/aqt/overview.py` to see how it avoids this class of bug: it re-checks `sched._is_finished()` on every refresh instead of assuming the previous state still holds.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
