### PR TITLE
Fix #20846: Show current note type in Change Note Type dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
@@ -167,6 +167,8 @@ class ChangeNoteTypeDialog : AnalyticsDialogFragment(R.layout.dialog_change_note
     }
 
     private fun setupNoteTypeSpinner(binding: DialogChangeNoteTypeBinding) {
+        binding.CardEditorModelText.text = "${viewModel.inputNoteType.name} \u2192 "
+
         binding.destNoteTypeSpinner.apply {
             adapter = createNoteTypeAdapter()
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
@@ -212,6 +212,11 @@ class ChangeNoteTypeDialog : AnalyticsDialogFragment(R.layout.dialog_change_note
                 val noteType = getItem(position)!!
                 text = noteType.name
                 setTextColor(if (noteType.isCloze) clozeColor else defaultViewTextColor)
+                isSingleLine = false
+                ellipsize = null
+                layoutParams = layoutParams?.apply {
+                    height = ViewGroup.LayoutParams.WRAP_CONTENT
+                } ?: ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
             }
 
             override fun getDropDownView(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
@@ -167,7 +167,9 @@ class ChangeNoteTypeDialog : AnalyticsDialogFragment(R.layout.dialog_change_note
     }
 
     private fun setupNoteTypeSpinner(binding: DialogChangeNoteTypeBinding) {
-        binding.CardEditorModelText.text = "${viewModel.inputNoteType.name} \u2192 "
+        // Use a left arrow for RTL languages (like Arabic) and a right arrow for LTR
+        val arrow = if (resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_RTL) "\u2190 " else "\u2192 "
+        binding.CardEditorModelText.text = "${viewModel.inputNoteType.name} $arrow"
 
         binding.destNoteTypeSpinner.apply {
             adapter = createNoteTypeAdapter()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
@@ -34,6 +34,7 @@ import android.widget.Spinner
 import androidx.annotation.CheckResult
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
+import androidx.core.text.BidiFormatter
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -167,8 +168,7 @@ class ChangeNoteTypeDialog : AnalyticsDialogFragment(R.layout.dialog_change_note
     }
 
     private fun setupNoteTypeSpinner(binding: DialogChangeNoteTypeBinding) {
-        // Using drawableEnd in XML instead of a unicode arrow for perfect vertical centering
-        binding.CardEditorModelText.text = viewModel.inputNoteType.name
+        binding.CardEditorModelText.text = BidiFormatter.getInstance().unicodeWrap(viewModel.inputNoteType.name)
 
         binding.destNoteTypeSpinner.apply {
             adapter = createNoteTypeAdapter()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
@@ -34,7 +34,9 @@ import android.widget.Spinner
 import androidx.annotation.CheckResult
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
+import androidx.core.text.BidiFormatter
 import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -50,6 +52,7 @@ import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CrashReportData.Companion.toCrashReportData
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
+import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.databinding.DialogChangeNoteTypeBinding
 import com.ichi2.anki.databinding.DialogFieldsBinding
 import com.ichi2.anki.databinding.DialogTemplatesBinding
@@ -94,6 +97,7 @@ import timber.log.Timber
  *
  * @see ChangeNoteTypeViewModel
  */
+@NeedsTest("Screenshot baseline for Change Note Type Dialog UI")
 class ChangeNoteTypeDialog : AnalyticsDialogFragment(R.layout.dialog_change_note_type) {
     private val viewModel: ChangeNoteTypeViewModel by viewModels { defaultViewModelProviderFactory }
 
@@ -167,6 +171,8 @@ class ChangeNoteTypeDialog : AnalyticsDialogFragment(R.layout.dialog_change_note
     }
 
     private fun setupNoteTypeSpinner(binding: DialogChangeNoteTypeBinding) {
+        binding.CardEditorModelText.text = BidiFormatter.getInstance().unicodeWrap(viewModel.inputNoteType.name)
+
         binding.destNoteTypeSpinner.apply {
             adapter = createNoteTypeAdapter()
 
@@ -177,6 +183,10 @@ class ChangeNoteTypeDialog : AnalyticsDialogFragment(R.layout.dialog_change_note
                 BasicItemSelectedListener { position, id: NoteTypeId ->
                     viewModel.setOutputNoteTypeId(id)
                 }
+        }
+
+        binding.toCard.setOnClickListener {
+            binding.destNoteTypeSpinner.performClick()
         }
     }
 
@@ -209,6 +219,12 @@ class ChangeNoteTypeDialog : AnalyticsDialogFragment(R.layout.dialog_change_note
                 val noteType = getItem(position)!!
                 text = noteType.name
                 setTextColor(if (noteType.isCloze) clozeColor else defaultViewTextColor)
+                isSingleLine = false
+                ellipsize = null
+                updateLayoutParams {
+                    height = ViewGroup.LayoutParams.WRAP_CONTENT
+                }
+                setPaddingRelative(0, paddingTop, paddingEnd, paddingBottom)
             }
 
             override fun getDropDownView(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
@@ -167,9 +167,8 @@ class ChangeNoteTypeDialog : AnalyticsDialogFragment(R.layout.dialog_change_note
     }
 
     private fun setupNoteTypeSpinner(binding: DialogChangeNoteTypeBinding) {
-        // Use a left arrow for RTL languages (like Arabic) and a right arrow for LTR
-        val arrow = if (resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_RTL) "\u2190 " else "\u2192 "
-        binding.CardEditorModelText.text = "${viewModel.inputNoteType.name} $arrow"
+        // Using drawableEnd in XML instead of a unicode arrow for perfect vertical centering
+        binding.CardEditorModelText.text = viewModel.inputNoteType.name
 
         binding.destNoteTypeSpinner.apply {
             adapter = createNoteTypeAdapter()

--- a/AnkiDroid/src/main/res/drawable/ic_arrow_right_alt_24.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_arrow_right_alt_24.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
+    android:width="20dp"
+    android:height="20dp"
     android:viewportWidth="24"
     android:viewportHeight="24"
     android:autoMirrored="true">

--- a/AnkiDroid/src/main/res/drawable/ic_arrow_right_alt_24.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_arrow_right_alt_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:autoMirrored="true">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M16.01,11H4v2h12.01v3L20,12l-3.99,-4z"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_arrow_right_alt_24.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_arrow_right_alt_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:autoMirrored="true">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M16.01,11H4v2h12.01v3L20,12l-3.99,-4z"/>
+</vector>

--- a/AnkiDroid/src/main/res/layout/dialog_change_note_type.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_change_note_type.xml
@@ -74,13 +74,12 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:layout_marginStart="8dp"
-                android:layout_marginEnd="8dp"
                 android:gravity="start|center_vertical"
                 android:textDirection="locale"
                 android:textStyle="bold"
                 android:drawablePadding="8dp"
-                app:drawableEndCompat="@drawable/ic_chevron_right_black"
-                app:drawableTint="?android:attr/textColorPrimary" /> <!--Using ic_chevron_right which is vertically centred-->
+                app:drawableEndCompat="@drawable/ic_arrow_right_alt_24"
+                app:drawableTint="?android:attr/textColorPrimary" />
             <Spinner
                 android:id="@+id/dest_note_type_spinner"
                 android:layout_width="match_parent"

--- a/AnkiDroid/src/main/res/layout/dialog_change_note_type.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_change_note_type.xml
@@ -66,8 +66,6 @@
             android:paddingTop="4dp"
             android:paddingStart="24dp"
             android:paddingEnd="24dp">
-            <!-- Added locale text direction so the English text (e.g. "Basic") in RTL language is not treated as LTR string -->
-            <!--Padding of 8dp for equal spacing from both the note types-->
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/CardEditorModelText"
                 android:layout_width="wrap_content"
@@ -75,7 +73,6 @@
                 android:layout_gravity="center"
                 android:layout_marginStart="8dp"
                 android:gravity="start|center_vertical"
-                android:textDirection="locale"
                 android:textStyle="bold"
                 android:drawablePadding="8dp"
                 app:drawableEndCompat="@drawable/ic_arrow_right_alt_24"

--- a/AnkiDroid/src/main/res/layout/dialog_change_note_type.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_change_note_type.xml
@@ -66,6 +66,7 @@
             android:paddingTop="4dp"
             android:paddingStart="24dp"
             android:paddingEnd="24dp">
+            <!-- Added locale text direction so the English text (e.g. "Basic") in RTL language is not treated as LTR string -->
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/CardEditorModelText"
                 android:layout_width="wrap_content"
@@ -73,8 +74,9 @@
                 android:layout_gravity="center"
                 android:layout_marginStart="8dp"
                 android:gravity="start|center_vertical"
+                android:textDirection="locale"
                 android:textStyle="bold"
-                tools:text="Basic → " />
+                android:text="@string/CardEditorModel" /> <!--The change was made to visualize the layout. Reverted it back.-->
             <Spinner
                 android:id="@+id/dest_note_type_spinner"
                 android:layout_width="match_parent"

--- a/AnkiDroid/src/main/res/layout/dialog_change_note_type.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_change_note_type.xml
@@ -67,16 +67,20 @@
             android:paddingStart="24dp"
             android:paddingEnd="24dp">
             <!-- Added locale text direction so the English text (e.g. "Basic") in RTL language is not treated as LTR string -->
+            <!--Padding of 8dp for equal spacing from both the note types-->
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/CardEditorModelText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:layout_marginStart="8dp"
+                android:layout_marginEnd="8dp"
                 android:gravity="start|center_vertical"
                 android:textDirection="locale"
                 android:textStyle="bold"
-                android:text="@string/CardEditorModel" /> <!--The change was made to visualize the layout. Reverted it back.-->
+                android:drawablePadding="8dp"
+                app:drawableEndCompat="@drawable/ic_chevron_right_black"
+                app:drawableTint="?android:attr/textColorPrimary" /> <!--Using ic_chevron_right which is vertically centred-->
             <Spinner
                 android:id="@+id/dest_note_type_spinner"
                 android:layout_width="match_parent"

--- a/AnkiDroid/src/main/res/layout/dialog_change_note_type.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_change_note_type.xml
@@ -63,23 +63,114 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:paddingTop="4dp"
-            android:paddingStart="24dp"
-            android:paddingEnd="24dp">
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/CardEditorModelText"
+            android:baselineAligned="false"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp">
+
+            <!-- FROM Card -->
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                app:cardBackgroundColor="?attr/colorButtonNormal"
+                app:cardElevation="0dp"
+                app:cardCornerRadius="12dp"
+                app:strokeWidth="0dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical"
+                    android:padding="16dp">
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/change_note_type_from"
+                        android:textAllCaps="true"
+                        android:textColor="?android:attr/textColorSecondary"
+                        android:textAppearance="?attr/textAppearanceLabelSmall"
+                        android:layout_marginBottom="8dp"/>
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/CardEditorModelText"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:textDirection="locale"
+                        android:textStyle="bold"
+                        android:textAppearance="?attr/textAppearanceBodyLarge" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <!-- Center Arrow -->
+            <FrameLayout
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:layout_marginStart="8dp"
-                android:gravity="start|center_vertical"
-                android:textStyle="bold"
-                android:text="@string/CardEditorModel" />
-            <Spinner
-                android:id="@+id/dest_note_type_spinner"
-                android:layout_width="match_parent"
-                android:layout_height="?minTouchTargetSize"
-                />
+                android:layout_height="match_parent"
+                android:paddingHorizontal="12dp">
+
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_gravity="center"
+                    android:src="@drawable/ic_arrow_right_alt_24"
+                    app:tint="?android:attr/textColorSecondary"
+                    android:importantForAccessibility="no" />
+            </FrameLayout>
+
+            <!-- TO Card -->
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/to_card"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                app:cardBackgroundColor="@android:color/transparent"
+                app:strokeColor="?attr/colorPrimary"
+                app:strokeWidth="2dp"
+                app:cardElevation="0dp"
+                app:cardCornerRadius="12dp"
+                android:clickable="true"
+                android:focusable="true"
+                android:foreground="?attr/selectableItemBackground">
+
+                <RelativeLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:padding="16dp">
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/to_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/change_note_type_to"
+                        android:textAllCaps="true"
+                        android:textColor="?attr/colorPrimary"
+                        android:textAppearance="?attr/textAppearanceLabelSmall"
+                        android:layout_marginBottom="8dp"/>
+
+                    <Spinner
+                        android:id="@+id/dest_note_type_spinner"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_below="@id/to_label"
+                        android:layout_toStartOf="@+id/to_dropdown_arrow"
+                        android:layout_alignParentStart="true"
+                        android:background="@null"
+                        android:padding="0dp"
+                        android:minHeight="0dp" />
+
+                    <ImageView
+                        android:id="@+id/to_dropdown_arrow"
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:layout_alignParentEnd="true"
+                        android:layout_alignTop="@id/dest_note_type_spinner"
+                        android:layout_alignBottom="@id/dest_note_type_spinner"
+                        android:src="@drawable/ic_expand_more_black_24dp_xml"
+                        app:tint="?attr/colorPrimary" />
+                </RelativeLayout>
+            </com.google.android.material.card.MaterialCardView>
         </LinearLayout>
 
         <com.google.android.material.tabs.TabLayout

--- a/AnkiDroid/src/main/res/layout/dialog_change_note_type.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_change_note_type.xml
@@ -68,19 +68,23 @@
             android:paddingEnd="24dp">
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/CardEditorModelText"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:layout_weight="1"
                 android:layout_gravity="center"
                 android:layout_marginStart="8dp"
                 android:gravity="start|center_vertical"
+                android:textDirection="locale"
                 android:textStyle="bold"
                 android:drawablePadding="8dp"
                 app:drawableEndCompat="@drawable/ic_arrow_right_alt_24"
                 app:drawableTint="?android:attr/textColorPrimary" />
             <Spinner
                 android:id="@+id/dest_note_type_spinner"
-                android:layout_width="match_parent"
-                android:layout_height="?minTouchTargetSize"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:minHeight="?minTouchTargetSize"
+                android:layout_weight="1"
                 />
         </LinearLayout>
 

--- a/AnkiDroid/src/main/res/layout/dialog_change_note_type.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_change_note_type.xml
@@ -74,7 +74,7 @@
                 android:layout_marginStart="8dp"
                 android:gravity="start|center_vertical"
                 android:textStyle="bold"
-                android:text="@string/CardEditorModel" />
+                tools:text="Basic → " />
             <Spinner
                 android:id="@+id/dest_note_type_spinner"
                 android:layout_width="match_parent"

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -288,4 +288,8 @@ also changes the interval of the card"
     <string name="special_field_card_id_help" comment="%s: either blank or ' %s'">The ID of the card%s</string>
     <string name="special_field_card_help" comment="%s: either blank or ' %s'">The name of the card template%s</string>
     <string name="special_field_type_help" comment="%s: either blank or ' %s'">The name of the note type%s</string>
+
+    <!-- Change Note Type Dialog -->
+    <string name="change_note_type_from" comment="Label indicating the original note type before changing it">From</string>
+    <string name="change_note_type_to" comment="Label indicating the new note type to change to">To</string>
 </resources>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

<!---
Uncomment this section if AI tools were used. New contributors may not use AI tools. See:
https://github.com/ankidroid/Anki-Android/blob/main/AI_POLICY.md
> [!NOTE]
> Assisted-by: ___
--->

## Purpose / Description
When converting a note's type, there was previously no visual indicator of what the *current* note type was on the "Change Note Type" screen. This PR utilizes the available space to explicitly show the current note type's name along the destination note type (e.g., `Basic → Basic (and reversed)`), providing better context to the user.

## Fixes
* Fixes #20846

## Approach
* **`dialog_change_note_type.xml`**: Removed the hardcoded `@string/CardEditorModel` ("Type:") attribute from `CardEditorModelText` and replaced it with a `tools:text` preview so the layout can be populated dynamically.
* **`ChangeNoteTypeDialog.kt`**: In `setupNoteTypeSpinner()`, programmatically set `CardEditorModelText` to display the current note type's name appended with a right-pointing arrow (`\u2192`). This sits right next to the destination note type dropdown, creating a cohesive visual transition.

## How Has This Been Tested?

Tested locally on an Android emulator
1. Opened the app and navigated to the **Card Browser**.
2. Selected an existing card and chose **Change Note Type** from the action menu.
3. Verified that the top left of the dialog correctly displays `[Current Note Type] → [Dropdown]` without text clipping or layout distortion.

## Learning (optional, can help others)
N/A

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->
<img width="329" height="680" alt="Screenshot 2026-08-01 172435" src="https://github.com/user-attachments/assets/0c8ab8b7-3817-4ea8-860a-2321e5fbff90" />
