### PR TITLE
fix: apiHostSpecVersion returns -1 when AnkiDroid isn't installed

### DIFF
--- a/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
+++ b/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
@@ -218,8 +218,10 @@ public class AddContentApi(
     /**
      * Get the number of notes that exist for the specified model ID
      * @param mid id of the model to be used
-     * @return number of notes that exist with that model ID or -1 if there was a problem
+     * @return number of notes that exist with that model ID, or 0 if the query failed
      */
+    // TODO: return null on failure once we can make a breaking change: 0 is ambiguous with a
+    //  model that genuinely has no notes
     public fun getNoteCount(mid: Long): Int = compat.queryNotes(mid)?.use { cursor -> cursor.count } ?: 0
 
     /**

--- a/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
+++ b/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
@@ -583,9 +583,9 @@ public class AddContentApi(
                         FlashCardsContract.AUTHORITY,
                         PackageManager.GET_META_DATA,
                     )
-                }
+                } ?: return ANKIDROID_NOT_INSTALLED
 
-            return if (info?.metaData != null &&
+            return if (info.metaData != null &&
                 info.metaData.containsKey(PROVIDER_SPEC_META_DATA_KEY)
             ) {
                 info.metaData.getInt(PROVIDER_SPEC_META_DATA_KEY)
@@ -788,6 +788,7 @@ public class AddContentApi(
         private const val TEST_TAG = "PREVIEW_NOTE"
         private const val PROVIDER_SPEC_META_DATA_KEY = "com.ichi2.anki.provider.spec"
         private const val DEFAULT_PROVIDER_SPEC_VALUE = 1 // for when meta-data key does not exist
+        private const val ANKIDROID_NOT_INSTALLED = -1
         private val PROJECTION =
             arrayOf(
                 Note._ID,

--- a/api/src/test/java/com/ichi2/anki/api/AddContentApiTest.kt
+++ b/api/src/test/java/com/ichi2/anki/api/AddContentApiTest.kt
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+package com.ichi2.anki.api
+
+import android.content.pm.ProviderInfo
+import android.os.Bundle
+import com.ichi2.anki.FlashCardsContract
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+
+/**
+ * This module's manifest registers no content provider, so by default Robolectric's
+ * [android.content.pm.PackageManager] behaves as if AnkiDroid were not installed.
+ *
+ * Robolectric only shadows `resolveContentProvider(String, int)`, so the Tiramisu+ overload throws
+ * `UnsupportedOperationException`. Still the case on Robolectric master and no upstream issue
+ * tracks it, so these pin to the pre-Tiramisu branch. Both branches share the same null handling.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [32])
+internal class AddContentApiTest {
+    private val api get() = AddContentApi(RuntimeEnvironment.getApplication())
+
+    @Test
+    fun apiHostSpecVersionIsMinusOneWhenAnkiDroidIsNotInstalled() {
+        assertEquals(-1, api.apiHostSpecVersion)
+    }
+
+    @Test
+    fun apiHostSpecVersionIsReadFromProviderMetaData() {
+        installAnkiDroid(Bundle().apply { putInt("com.ichi2.anki.provider.spec", 2) })
+        assertEquals(2, api.apiHostSpecVersion)
+    }
+
+    /** An installed AnkiDroid without the meta-data key predates it, so it's spec 1 */
+    @Test
+    fun apiHostSpecVersionIsOneWhenProviderHasNoMetaData() {
+        installAnkiDroid(metaData = null)
+        assertEquals(1, api.apiHostSpecVersion)
+    }
+
+    private fun installAnkiDroid(metaData: Bundle?) {
+        val provider =
+            ProviderInfo().apply {
+                authority = FlashCardsContract.AUTHORITY
+                packageName = "com.ichi2.anki"
+                name = "com.ichi2.anki.provider.CardContentProvider"
+                this.metaData = metaData
+            }
+        shadowOf(RuntimeEnvironment.getApplication().packageManager).addOrUpdateProvider(provider)
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

<!---
Uncomment this section if AI tools were used. New contributors may not use AI tools. See:
https://github.com/ankidroid/Anki-Android/blob/main/AI_POLICY.md
> [!NOTE]
> Assisted-by: ___
--->

## Purpose / Description
addContentApi.apiHostSpecVersion is documented to return -1 when AnkiDroid is not installed, but returns 1. Third party apps use it as their "is AnkiDroid installed?" check, so a device with no AnkiDroid looks identical to one running AnkiDroid 2.5 (spec version 1).

The null check was dropped in 2eeed65 ("build: bump compileSdkVersion to 33") when the two SDK branches merged into one info variable.

Also fixes a related doc mismatch in the same file: getNoteCount claims -1 on failure but has always returned 0.
## Fixes
* Fixes #21418

## Approach
See commits

## How Has This Been Tested?
New Robolectric unit test

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->