### PR TITLE
Fix missing TalkBack labels on Card Browser filter checkboxes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/search/CardStateBottomSheetFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/search/CardStateBottomSheetFragment.kt
@@ -105,6 +105,7 @@ class CardStateBottomSheetFragment : BottomSheetDialogFragment(R.layout.fragment
         ) {
             val state = this.states[position]
             holder.binding.text.text = state.label
+            holder.binding.checkbox.contentDescription = state.label
             holder.binding.icon.setImageResource(state.iconRes)
             holder.binding.root.setOnClickListener { onItemClickedListener(state) }
             holder.binding.checkbox.apply {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/search/FlagsBottomSheetFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/search/FlagsBottomSheetFragment.kt
@@ -127,6 +127,7 @@ class FlagsBottomSheetFragment : BottomSheetDialogFragment(R.layout.fragment_bot
         ) {
             val model = this.states[position]
             holder.binding.text.text = model.label
+            holder.binding.checkbox.contentDescription = model.label
             holder.binding.icon.setImageResource(model.flag.drawableRes)
             // TODO: Long press to rename
             holder.binding.root.setOnClickListener { onItemClickedListener(model.flag) }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/search/CardStateBottomSheetFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/search/CardStateBottomSheetFragmentTest.kt
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Alok Srivastava <alok020505@gmail.com>
+
+package com.ichi2.anki.browser.search
+
+import android.os.Looper
+import android.widget.CheckBox
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.R
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.browser.withCardBrowserFragment
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+
+/** Test of [CardStateBottomSheetFragment] */
+@RunWith(AndroidJUnit4::class)
+class CardStateBottomSheetFragmentTest : RobolectricTest() {
+    // TalkBack users must hear which card state a checkbox toggles, not just "checked"/"not checked"
+    @Test
+    fun `card state checkbox exposes its label to TalkBack`() =
+        withCardBrowserFragment {
+            CardStateBottomSheetFragment().show(childFragmentManager, CardStateBottomSheetFragment.TAG)
+            shadowOf(Looper.getMainLooper()).idle()
+
+            onView(withId(R.id.list)).inRoot(isDialog()).check { view, _ ->
+                val recyclerView = view as RecyclerView
+                val holder = requireNotNull(recyclerView.findViewHolderForAdapterPosition(0))
+                val checkbox = holder.itemView.findViewById<CheckBox>(R.id.checkbox)
+                // position 0 is CardState.New
+                assertThat(checkbox.contentDescription, equalTo("New" as CharSequence))
+            }
+        }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/search/FlagsBottomSheetFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/search/FlagsBottomSheetFragmentTest.kt
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Alok Srivastava <alok020505@gmail.com>
+
+package com.ichi2.anki.browser.search
+
+import android.os.Looper
+import android.widget.CheckBox
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.R
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.browser.withCardBrowserFragment
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+
+/** Test of [FlagsBottomSheetFragment] */
+@RunWith(AndroidJUnit4::class)
+class FlagsBottomSheetFragmentTest : RobolectricTest() {
+    // TalkBack users must hear which flag a checkbox toggles, not just "checked"/"not checked"
+    @Test
+    fun `flag checkbox exposes its label to TalkBack`() =
+        withCardBrowserFragment {
+            FlagsBottomSheetFragment.createInstance().show(childFragmentManager, FlagsBottomSheetFragment.TAG)
+            shadowOf(Looper.getMainLooper()).idle()
+
+            onView(withId(R.id.list)).inRoot(isDialog()).check { view, _ ->
+                val recyclerView = view as RecyclerView
+                val holder = requireNotNull(recyclerView.findViewHolderForAdapterPosition(0))
+                val checkbox = holder.itemView.findViewById<CheckBox>(R.id.checkbox)
+                // position 0 is Flag.NONE
+                assertThat(checkbox.contentDescription, equalTo("No Flag" as CharSequence))
+            }
+        }
+}


### PR DESCRIPTION
## Purpose / Description
The Flags and Card State filter bottom sheets in the Card Browser bind a per-row CheckBox
without a contentDescription. TalkBack users swiping through the list only hear "checked" /
"not checked" with no indication of which flag or card state the checkbox toggles.

## Approach
Set `contentDescription` to the row's label in `FlagsBottomSheetFragment.kt` and
`CardStateBottomSheetFragment.kt`'s `onBindViewHolder`, matching the existing pattern already
used in `BrowserColumnSelectionAdapter.kt` for its column-toggle buttons.

## How Has This Been Tested?
Added `FlagsBottomSheetFragmentTest` and `CardStateBottomSheetFragmentTest` (Robolectric), which
show the bottom sheet, bind the first row, and assert the checkbox's `contentDescription` matches
the visible label text. Both tests were confirmed failing before the fix (`contentDescription` was
`null`) and passing after. Also ran the full `com.ichi2.anki.browser.*` test package with no
regressions.

## Learning (optional, can help others)
Found by comparing the Flags/Card State filter sheets (new UI, ~2 weeks old) against the existing
accessibility pattern in `BrowserColumnSelectionAdapter`, which already sets `contentDescription`
on its equivalent per-row toggle for the same reason.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)


Fixes #21421