### PR TITLE
Add test for ReviewerControlPreference.getPreferenceAssignedTo (#13283)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ReviewerControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ReviewerControlPreference.kt
@@ -84,7 +84,6 @@ open class ReviewerControlPreference : ControlPreference {
                 it::class == ReviewerControlPreference::class
             } as List<ReviewerControlPreference>
 
-    @NeedsTest("Ensure correct preference is returned for side-specific binding")
     override fun getPreferenceAssignedTo(binding: Binding): ControlPreference? {
         val cardSide = side ?: return super.getPreferenceAssignedTo(binding)
         val reviewerBinding = ReviewerBinding(binding, cardSide)

--- a/AnkiDroid/src/test/java/com/ichi2/preferences/ReviewerControlPreferenceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/preferences/ReviewerControlPreferenceTest.kt
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Alok Srivastava <alok020505@gmail.com>
+
+package com.ichi2.preferences
+
+import androidx.preference.PreferenceManager
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.cardviewer.Gesture
+import com.ichi2.anki.reviewer.Binding
+import com.ichi2.anki.reviewer.CardSide
+import com.ichi2.anki.reviewer.MappableBinding.Companion.toPreferenceString
+import com.ichi2.anki.reviewer.ReviewerBinding
+import com.ichi2.testutils.getJavaMethodAsAccessible
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Test of [ReviewerControlPreference.getPreferenceAssignedTo]
+ *
+ * `getRelatedPreferences` matches preferences by exact class (`it::class == ReviewerControlPreference::class`),
+ * so instances here must be real [ReviewerControlPreference]s rather than a test subclass - `side` and
+ * `getPreferenceAssignedTo` are accessed via reflection as they're `protected`.
+ */
+@RunWith(AndroidJUnit4::class)
+class ReviewerControlPreferenceTest : RobolectricTest() {
+    private val bindingsToPersist = mutableMapOf<ReviewerControlPreference, Binding>()
+
+    @Test
+    fun `binding on the same side is found on a different preference`() {
+        val gesture = Binding.GestureInput(Gesture.SWIPE_UP)
+        val ownerPref = buildPreference(key = "owner", side = CardSide.QUESTION, binding = gesture)
+        val queryingPref = buildPreference(key = "querying", side = CardSide.QUESTION)
+        buildScreen(ownerPref, queryingPref)
+
+        // the conflict should be found on the *other* preference, not a self-conflict
+        assertEquals(ownerPref, queryingPref.callGetPreferenceAssignedTo(gesture))
+    }
+
+    @Test
+    fun `binding on a different side is not found`() {
+        val gesture = Binding.GestureInput(Gesture.SWIPE_UP)
+        val questionPref = buildPreference(key = "question", side = CardSide.QUESTION, binding = gesture)
+        val answerPref = buildPreference(key = "answer", side = CardSide.ANSWER)
+        buildScreen(questionPref, answerPref)
+
+        assertNull(answerPref.callGetPreferenceAssignedTo(gesture))
+    }
+
+    @Test
+    fun `binding on 'both' sides conflicts with a single-side binding`() {
+        val gesture = Binding.GestureInput(Gesture.SWIPE_UP)
+        val questionPref = buildPreference(key = "question", side = CardSide.QUESTION, binding = gesture)
+        val bothPref = buildPreference(key = "both", side = CardSide.BOTH)
+        buildScreen(questionPref, bothPref)
+
+        assertEquals(questionPref, bothPref.callGetPreferenceAssignedTo(gesture))
+    }
+
+    private fun buildPreference(
+        key: String,
+        side: CardSide,
+        binding: Binding? = null,
+    ): ReviewerControlPreference {
+        val pref = ReviewerControlPreference(targetContext)
+        pref.key = key
+        pref.setSideForTest(side)
+        if (binding != null) bindingsToPersist[pref] = binding
+        return pref
+    }
+
+    private fun buildScreen(vararg preferences: ReviewerControlPreference) {
+        val preferenceManager = PreferenceManager(targetContext)
+        val screen = preferenceManager.createPreferenceScreen(targetContext)
+        preferenceManager.setPreferences(screen)
+        preferences.forEach { screen.addPreference(it) }
+        preferences.forEach { pref ->
+            bindingsToPersist[pref]?.let { binding ->
+                val side = requireNotNull(pref.getSideForTest())
+                pref.value = listOf(ReviewerBinding(binding, side)).toPreferenceString()
+            }
+        }
+    }
+
+    private fun ReviewerControlPreference.sideField() =
+        ReviewerControlPreference::class.java.getDeclaredField("side").apply { isAccessible = true }
+
+    private fun ReviewerControlPreference.setSideForTest(side: CardSide?) = sideField().set(this, side)
+
+    private fun ReviewerControlPreference.getSideForTest() = sideField().get(this) as CardSide?
+
+    private fun ReviewerControlPreference.callGetPreferenceAssignedTo(binding: Binding): ControlPreference? =
+        getJavaMethodAsAccessible(
+            ReviewerControlPreference::class.java,
+            "getPreferenceAssignedTo",
+            Binding::class.java,
+        ).invoke(this, binding) as ControlPreference?
+}


### PR DESCRIPTION
Covers side-specific binding lookup: a binding on QUESTION/ANSWER only matches a preference on
the same side, while a binding on BOTH conflicts with any single-side binding. Verified via
mutation testing that re-introducing the bug (ignoring the card side) breaks the test.

Fixes part of #13283

## Purpose / Description
`ReviewerControlPreference.getPreferenceAssignedTo` had no test coverage (`@NeedsTest("Ensure
correct preference is returned for side-specific binding")`). This is one of many `@NeedsTest`
items tracked in #13283 — only this single method is covered here, per the maintainer's stated
preference elsewhere in that thread to keep PRs to one test at a time.

## Approach
Added `ReviewerControlPreferenceTest` covering three cases: a binding on the same side is found,
a binding on a different side is not found, and a binding on `CardSide.BOTH` conflicts with a
single-side binding. Since `getRelatedPreferences()` matches preferences by exact class
(`it::class == ReviewerControlPreference::class`), the test uses real `ReviewerControlPreference`
instances (not a subclass) and accesses the `protected` `side` field and `getPreferenceAssignedTo`
method via reflection, following the existing pattern in `NumberRangePreferenceCompatTest`.

## How Has This Been Tested?
Ran the new test in isolation and confirmed it fails when the side-overlap logic is broken
(temporarily changed `ReviewerBinding(binding, cardSide)` to always use `CardSide.BOTH`, confirmed
the "different side is not found" test failed, then reverted). Also ran the full
`com.ichi2.preferences.*` test package with no regressions.

## Learning (optional, can help others)
`ReviewerBinding.equals()` treats `CardSide.BOTH` as conflicting with any other side, and two
same-typed sides as conflicting with each other — that's the "side overlap" logic this method
relies on via `getPreferencesAssignedTo`.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
