### PR TITLE
test: add coverage for TagsArrayAdapter.TagTreeNode (covers #13283)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
@@ -80,7 +80,6 @@ class TagsArrayAdapter(
      * @param vh The reference to currently bound [ViewHolder]. A node bound with some [ViewHolder] must have [vh] nonnull.
      * @see onBindViewHolder for the binding
      */
-    @NeedsTest("Make sure that the data structure works properly.")
     data class TagTreeNode(
         val tag: String,
         val parent: TagTreeNode?,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapterTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapterTest.kt
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2026 capthunder19 <anirudhpatwal19@gmail.com>
+package com.ichi2.anki.dialogs.tags
+
+import com.ichi2.anki.dialogs.tags.TagsArrayAdapter.TagTreeNode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TagsArrayAdapterTest {
+    private fun leaf(
+        tag: String,
+        parent: TagTreeNode,
+    ): TagTreeNode =
+        TagTreeNode(
+            tag = tag,
+            parent = parent,
+            children = ArrayList(),
+            level = parent.level + 1,
+            subtreeSize = 1,
+            isExpanded = true,
+            subtreeCheckedCnt = 0,
+            vh = null,
+        )
+
+    private fun root(): TagTreeNode =
+        TagTreeNode(
+            tag = "",
+            parent = null,
+            children = ArrayList(),
+            level = -1,
+            subtreeSize = 0,
+            isExpanded = true,
+            subtreeCheckedCnt = 0,
+            vh = null,
+        )
+
+    @Test
+    fun `getContributeSize returns 1 when collapsed`() {
+        val node =
+            leaf("a", root()).apply {
+                subtreeSize = 5
+                isExpanded = false
+            }
+
+        assertEquals(1, node.getContributeSize())
+    }
+
+    @Test
+    fun `getContributeSize returns subtreeSize when expanded`() {
+        val node =
+            leaf("a", root()).apply {
+                subtreeSize = 5
+                isExpanded = true
+            }
+
+        assertEquals(5, node.getContributeSize())
+    }
+
+    @Test
+    fun `isNotLeaf is false for a node without children`() {
+        val node = leaf("a", root())
+
+        assertFalse(node.isNotLeaf())
+    }
+
+    @Test
+    fun `isNotLeaf is true for a node with children`() {
+        val node = leaf("a", root())
+        node.children.add(leaf("a::b", node))
+
+        assertTrue(node.isNotLeaf())
+    }
+
+    @Test
+    fun `iterateAncestorsOf walks from a node up to the root, excluding itself`() {
+        val root = root()
+        val a = leaf("a", root)
+        val b = leaf("a::b", a)
+
+        val ancestors = TagTreeNode.iterateAncestorsOf(b).asSequence().toList()
+
+        assertEquals(listOf(a, root), ancestors)
+    }
+
+    @Test
+    fun `toggleIsExpanded collapsing propagates the size delta to all expanded ancestors`() {
+        val root = root()
+        val a = leaf("a", root).apply { subtreeSize = 3 }
+        val b = leaf("a::b", a).apply { subtreeSize = 2 }
+        val c = leaf("a::b::c", b)
+        b.children.add(c)
+        a.children.add(b)
+        root.children.add(a)
+        root.subtreeSize = a.getContributeSize()
+
+        a.toggleIsExpanded()
+
+        assertFalse(a.isExpanded)
+        assertEquals(1, a.getContributeSize())
+        assertEquals(1, root.subtreeSize)
+    }
+
+    @Test
+    fun `toggleIsExpanded stops propagating once a collapsed ancestor is reached`() {
+        val root = root()
+        val a = leaf("a", root)
+        val b = leaf("a::b", a).apply { isExpanded = false }
+        val c = leaf("a::b::c", b).apply { subtreeSize = 2 }
+        val d = leaf("a::b::c::d", c)
+        c.children.add(d)
+        b.children.add(c)
+        a.children.add(b)
+        root.children.add(a)
+        b.subtreeSize = 1 + c.getContributeSize()
+        a.subtreeSize = 1 + b.getContributeSize()
+        root.subtreeSize = a.getContributeSize()
+
+        val aSizeBefore = a.subtreeSize
+        val rootSizeBefore = root.subtreeSize
+        val bSizeBefore = b.subtreeSize
+
+        c.toggleIsExpanded()
+
+        assertFalse(c.isExpanded)
+        assertEquals(bSizeBefore - 1, b.subtreeSize)
+        assertEquals(aSizeBefore, a.subtreeSize)
+        assertEquals(rootSizeBefore, root.subtreeSize)
+    }
+}


### PR DESCRIPTION
Adds unit tests for `TagTreeNode`, the tree structure `TagsArrayAdapter` uses to render nested tags, which was flagged with `@NeedsTest("Make sure that the data structure works properly.")` and had no coverage.

Covers:
- `getContributeSize()` returning 1 when collapsed vs. `subtreeSize` when expanded
- `isNotLeaf()` for leaf and non-leaf nodes
- `iterateAncestorsOf()` walking from a node up to the root
- `toggleIsExpanded()` propagating the size delta to expanded ancestors, and stopping once it hits an already-collapsed ancestor

All tests are plain JUnit against the node structure directly, no Robolectric needed since the class has no Android view dependency until it's bound to a ViewHolder.

* Part of #13283
