### PR TITLE
Add test for CardBrowserFragmentViewModel.openDeckSelectionDialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragmentViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragmentViewModel.kt
@@ -18,14 +18,12 @@ package com.ichi2.anki.browser
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.ichi2.anki.common.annotations.NeedsTest
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 
 class CardBrowserFragmentViewModel : ViewModel() {
     val flowOfSearchForDecks = MutableSharedFlow<Unit>()
 
-    @NeedsTest("default usage")
     fun openDeckSelectionDialog() =
         viewModelScope.launch {
             flowOfSearchForDecks.emit(Unit)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserFragmentViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserFragmentViewModelTest.kt
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Alok Srivastava <alok020505@gmail.com>
+
+package com.ichi2.anki.browser
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import com.ichi2.anki.RobolectricTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Test of [CardBrowserFragmentViewModel] */
+@RunWith(AndroidJUnit4::class)
+class CardBrowserFragmentViewModelTest : RobolectricTest() {
+    @Test
+    fun `openDeckSelectionDialog emits from flowOfSearchForDecks`() =
+        runTest {
+            val viewModel = CardBrowserFragmentViewModel()
+
+            viewModel.flowOfSearchForDecks.test {
+                viewModel.openDeckSelectionDialog()
+                awaitItem()
+            }
+        }
+}


### PR DESCRIPTION
Covers the default usage: calling openDeckSelectionDialog() emits from flowOfSearchForDecks.
Verified via mutation testing that removing the emit breaks the test.

Fixes part of #13283

## Purpose / Description
`CardBrowserFragmentViewModel.openDeckSelectionDialog` had no test coverage
(`@NeedsTest("default usage")`). This is another item from the #13283 tracker — only this single
method is covered here, per the maintainer's stated preference to keep PRs to one test at a time.

## Approach
Added `CardBrowserFragmentViewModelTest` using Turbine to verify that calling
`openDeckSelectionDialog()` causes `flowOfSearchForDecks` to emit a value.

## How Has This Been Tested?
Ran the new test in isolation and confirmed it fails when the emit is removed from
`openDeckSelectionDialog()` (mutation test: temporarily removed `flowOfSearchForDecks.emit(Unit)`,
confirmed the test failed with a Turbine timeout, then reverted). Also ran the full
`com.ichi2.anki.browser.*` test package with no regressions.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
