### PR TITLE
test: extract sdk-specific tests from InitialActivityTest

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.kt
@@ -19,7 +19,6 @@ package com.ichi2.anki
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
-import android.os.Build
 import androidx.core.content.edit
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -28,7 +27,6 @@ import com.ichi2.anki.servicelayer.PreferenceUpgradeService
 import com.ichi2.testutils.EmptyApplication
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.contains
 import org.junit.Before
 import org.junit.Test
 import org.junit.experimental.categories.Category
@@ -37,7 +35,6 @@ import org.mockito.Mockito.mockStatic
 import org.mockito.Mockito.times
 import org.mockito.kotlin.never
 import org.robolectric.annotation.Config
-import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)
@@ -116,96 +113,5 @@ class InitialActivityTest : RobolectricTest() {
             secondResult,
             equalTo(false),
         )
-    }
-
-    @Config(sdk = [BEFORE_Q])
-    @Test
-    fun startupBeforeQ() {
-        val expectedPermissions =
-            arrayOf(
-                android.Manifest.permission.READ_EXTERNAL_STORAGE,
-                android.Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                android.Manifest.permission.INTERNET,
-            )
-
-        // force a safe startup before Q
-        assertThat(
-            selectStoragePermissions(canManageExternalStorage = false).permissions.asIterable(),
-            contains(*expectedPermissions),
-        )
-        assertThat(
-            selectStoragePermissions(canManageExternalStorage = true).permissions.asIterable(),
-            contains(*expectedPermissions),
-        )
-    }
-
-    @Config(sdk = [Q])
-    @Test
-    fun startupQ() {
-        assertThat(selectStoragePermissions(canManageExternalStorage = false), equalTo(PermissionSet.LEGACY_ACCESS))
-        assertThat(selectStoragePermissions(canManageExternalStorage = true), equalTo(PermissionSet.LEGACY_ACCESS))
-    }
-
-    @SuppressLint("InlinedApi")
-    @Config(sdk = [R_OR_AFTER])
-    @Test
-    fun `Android 11 - After upgrade from AnkiDroid 2 15 (with MANAGE_EXTERNAL_STORAGE)`() {
-        // after an upgrade, all we need is READ/WRITE. Once we reinstall, we need MANAGE_EXTERNAL_STORAGE
-        val expectedPermissions =
-            arrayOf(
-                android.Manifest.permission.READ_EXTERNAL_STORAGE,
-                android.Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                android.Manifest.permission.INTERNET,
-            )
-
-        selectStoragePermissions(
-            canManageExternalStorage = true,
-            currentFolderIsAccessibleAndLegacy = true,
-        ).let {
-            assertThat(
-                it.permissions.asIterable(),
-                contains(*expectedPermissions),
-            )
-        }
-    }
-
-    @SuppressLint("InlinedApi")
-    @Config(sdk = [R_OR_AFTER])
-    @Test
-    fun `Android 11 - After reinstall (with MANAGE_EXTERNAL_STORAGE)`() {
-        val permissions =
-            selectStoragePermissions(
-                canManageExternalStorage = true,
-                currentFolderIsAccessibleAndLegacy = false,
-            )
-
-        assertTrue(android.Manifest.permission.MANAGE_EXTERNAL_STORAGE in permissions.permissions)
-    }
-
-    @Config(sdk = [R_OR_AFTER])
-    @Test
-    fun startupAfterQWithoutManageExternalStorage() {
-        assertThat(
-            selectStoragePermissions(canManageExternalStorage = false),
-            equalTo(PermissionSet.APP_PRIVATE),
-        )
-    }
-
-    /**
-     * Helper for [com.ichi2.anki.selectStoragePermissions], making `currentFolderIsAccessibleAndLegacy` optional
-     */
-    private fun selectStoragePermissions(
-        canManageExternalStorage: Boolean,
-        currentFolderIsAccessibleAndLegacy: Boolean = false,
-    ): PermissionSet =
-        com.ichi2.anki.selectStoragePermissions(
-            canManageExternalStorage = canManageExternalStorage,
-            currentFolderIsAccessibleAndLegacy = currentFolderIsAccessibleAndLegacy,
-        )
-
-    companion object {
-        const val BEFORE_Q = Build.VERSION_CODES.Q - 1
-        const val Q = Build.VERSION_CODES.Q
-        const val R_OR_AFTER = Build.VERSION_CODES.R
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/SelectStoragePermissionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/SelectStoragePermissionsTest.kt
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki
+
+import android.annotation.SuppressLint
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.testutils.EmptyApplication
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.contains
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [selectStoragePermissions]
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class) // no point in Application init if we don't use it
+class SelectStoragePermissionsTest {
+    @Config(sdk = [BEFORE_Q])
+    @Test
+    fun startupBeforeQ() {
+        val expectedPermissions =
+            arrayOf(
+                android.Manifest.permission.READ_EXTERNAL_STORAGE,
+                android.Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                android.Manifest.permission.INTERNET,
+            )
+
+        // force a safe startup before Q
+        assertThat(
+            selectStoragePermissions(canManageExternalStorage = false).permissions.asIterable(),
+            contains(*expectedPermissions),
+        )
+        assertThat(
+            selectStoragePermissions(canManageExternalStorage = true).permissions.asIterable(),
+            contains(*expectedPermissions),
+        )
+    }
+
+    @Config(sdk = [Q])
+    @Test
+    fun startupQ() {
+        assertThat(selectStoragePermissions(canManageExternalStorage = false), equalTo(PermissionSet.LEGACY_ACCESS))
+        assertThat(selectStoragePermissions(canManageExternalStorage = true), equalTo(PermissionSet.LEGACY_ACCESS))
+    }
+
+    @SuppressLint("InlinedApi")
+    @Config(sdk = [R_OR_AFTER])
+    @Test
+    fun `Android 11 - After upgrade from AnkiDroid 2 15 (with MANAGE_EXTERNAL_STORAGE)`() {
+        // after an upgrade, all we need is READ/WRITE. Once we reinstall, we need MANAGE_EXTERNAL_STORAGE
+        val expectedPermissions =
+            arrayOf(
+                android.Manifest.permission.READ_EXTERNAL_STORAGE,
+                android.Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                android.Manifest.permission.INTERNET,
+            )
+
+        selectStoragePermissions(
+            canManageExternalStorage = true,
+            currentFolderIsAccessibleAndLegacy = true,
+        ).let {
+            assertThat(
+                it.permissions.asIterable(),
+                contains(*expectedPermissions),
+            )
+        }
+    }
+
+    @SuppressLint("InlinedApi")
+    @Config(sdk = [R_OR_AFTER])
+    @Test
+    fun `Android 11 - After reinstall (with MANAGE_EXTERNAL_STORAGE)`() {
+        val permissions =
+            selectStoragePermissions(
+                canManageExternalStorage = true,
+                currentFolderIsAccessibleAndLegacy = false,
+            )
+
+        assertTrue(android.Manifest.permission.MANAGE_EXTERNAL_STORAGE in permissions.permissions)
+    }
+
+    @Config(sdk = [R_OR_AFTER])
+    @Test
+    fun startupAfterQWithoutManageExternalStorage() {
+        assertThat(
+            selectStoragePermissions(canManageExternalStorage = false),
+            equalTo(PermissionSet.APP_PRIVATE),
+        )
+    }
+
+    /**
+     * Helper for [com.ichi2.anki.selectStoragePermissions], making `currentFolderIsAccessibleAndLegacy` optional
+     */
+    private fun selectStoragePermissions(
+        canManageExternalStorage: Boolean,
+        currentFolderIsAccessibleAndLegacy: Boolean = false,
+    ): PermissionSet =
+        com.ichi2.anki.selectStoragePermissions(
+            canManageExternalStorage = canManageExternalStorage,
+            currentFolderIsAccessibleAndLegacy = currentFolderIsAccessibleAndLegacy,
+        )
+
+    companion object {
+        const val BEFORE_Q = Build.VERSION_CODES.Q - 1
+        const val Q = Build.VERSION_CODES.Q
+        const val R_OR_AFTER = Build.VERSION_CODES.R
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 5 - implementation, except comments

## Purpose / Description
This test could trigger an `UnsatisfiedLinkError` on `openBackend`, dependent on test ordering.

The `@Config` annotation meant that tests were run in a different Robolectric sandbox.

When mixed with `RobolectricTest`, the backend library was loaded into the current sandbox. 
The backend may only be loaded in one `ClassLoader`, and it went into one where backend methods were unused.

## Fixes
* Part of #14796

## Approach
Tests were moved to fix this. They no longer require `RobolectricTest`.

## How Has This Been Tested?
Test-only

## Learning (optional, can help others)
* `@Config` and `RobolectricTest` couldn't be combined.

I plan to fix this upstream in `Anki-Android-Backend`, so I didn't add a regression test.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)