### PR TITLE
refactor: migrate StudyOptions to destination pattern 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -100,6 +100,7 @@ import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.destinations.PreferencesDestination
+import com.ichi2.anki.common.destinations.StudyOptionsDestination
 import com.ichi2.anki.common.destinations.navigate
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.storage.CollectionHelper
@@ -2037,9 +2038,7 @@ open class DeckPicker :
 
         // otherwise, we need to launch the activity
         Timber.i("Opening Study Options")
-        val intent = Intent()
-        intent.setClass(this, StudyOptionsActivity::class.java)
-        reviewLauncher.launch(intent)
+        reviewLauncher.navigate(StudyOptionsDestination)
     }
 
     @NeedsTest("Instrumented tests for review reminders")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
@@ -24,6 +24,8 @@ import androidx.fragment.app.FragmentContainerView
 import androidx.fragment.app.commit
 import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.ShortcutGroupProvider
+import com.ichi2.anki.common.destinations.StudyOptionsDestination
+import com.ichi2.anki.common.destinations.navigate
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
@@ -140,11 +142,7 @@ open class SingleFragmentActivity :
     // Begin - implementation of CustomStudyListener methods here for crash fix
     // TODO - refactor https://github.com/ankidroid/Anki-Android/pull/17508#pullrequestreview-2465561993
     private fun openStudyOptionsAndFinish() {
-        val intent =
-            Intent(this, StudyOptionsActivity::class.java).apply {
-                putExtra("withDeckOptions", false)
-            }
-        startActivity(intent, null)
+        navigate(StudyOptionsDestination)
         this.finish()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
@@ -99,8 +99,10 @@ open class SingleFragmentActivity :
             when (CustomStudyAction.fromBundle(bundle)) {
                 CustomStudyAction.CUSTOM_STUDY_SESSION,
                 CustomStudyAction.EXTEND_STUDY_LIMITS,
-                ->
-                    openStudyOptionsAndFinish()
+                -> {
+                    navigate(StudyOptionsDestination)
+                    finish()
+                }
             }
         }
     }
@@ -138,15 +140,6 @@ open class SingleFragmentActivity :
                 action = intentAction
             }
     }
-
-    // Begin - implementation of CustomStudyListener methods here for crash fix
-    // TODO - refactor https://github.com/ankidroid/Anki-Android/pull/17508#pullrequestreview-2465561993
-    private fun openStudyOptionsAndFinish() {
-        navigate(StudyOptionsDestination)
-        this.finish()
-    }
-
-    // END CustomStudyListener temporary implementation - should refactor out
 }
 
 interface DispatchKeyEventListener {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsDestination.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsDestination.kt
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki
+
+import android.content.Context
+import android.content.Intent
+import com.ichi2.anki.common.destinations.StudyOptionsDestination
+
+/** Builds the [Intent] that opens the study options screen. */
+fun StudyOptionsDestination.toIntent(context: Context): Intent = Intent(context, StudyOptionsActivity::class.java)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/navigation/AnkiDroidNavigator.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/navigation/AnkiDroidNavigator.kt
@@ -13,8 +13,10 @@ import com.ichi2.anki.common.destinations.Destination
 import com.ichi2.anki.common.destinations.Navigator
 import com.ichi2.anki.common.destinations.PreferencesDestination
 import com.ichi2.anki.common.destinations.StatisticsDestination
+import com.ichi2.anki.common.destinations.StudyOptionsDestination
 import com.ichi2.anki.pages.toIntent
 import com.ichi2.anki.preferences.toIntent
+import com.ichi2.anki.toIntent
 
 /** AnkiDroid's [Navigator] implementation. */
 object AnkiDroidNavigator : Navigator {
@@ -32,6 +34,7 @@ object AnkiDroidNavigator : Navigator {
             is DeckOptionsDestination -> destination.toIntent(navContext)
             is PreferencesDestination -> destination.toIntent(navContext)
             is StatisticsDestination -> destination.toIntent(navContext)
+            is StudyOptionsDestination -> destination.toIntent(navContext)
         }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
@@ -23,8 +23,8 @@ import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.OnErrorListener
 import com.ichi2.anki.R
 import com.ichi2.anki.SingleFragmentActivity
-import com.ichi2.anki.StudyOptionsActivity
 import com.ichi2.anki.common.destinations.DeckOptionsDestination
+import com.ichi2.anki.common.destinations.StudyOptionsDestination
 import com.ichi2.anki.common.destinations.navigate
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.time.SECONDS_PER_DAY
@@ -150,8 +150,7 @@ class CongratsPage :
         )
 
     private fun openStudyOptionsAndFinish() {
-        val intent = Intent(requireContext(), StudyOptionsActivity::class.java)
-        startActivity(intent, null)
+        navigate(StudyOptionsDestination)
         requireActivity().finish()
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersScreenshotTest.kt
@@ -3,7 +3,6 @@
 
 package com.ichi2.anki.reviewreminders
 
-import android.content.Intent
 import androidx.annotation.IdRes
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
@@ -12,6 +11,8 @@ import com.google.android.material.appbar.AppBarLayout
 import com.ichi2.anki.R
 import com.ichi2.anki.ScreenshotTest
 import com.ichi2.anki.StudyOptionsActivity
+import com.ichi2.anki.common.destinations.StudyOptionsDestination
+import com.ichi2.anki.common.destinations.launchActivity
 import com.ichi2.anki.preferences.PreferencesActivity
 import com.ichi2.anki.preferences.PreferencesFragment
 import com.ichi2.anki.reviewreminders.ScheduleRemindersFragment.FragmentHost
@@ -94,26 +95,23 @@ class ReviewRemindersScreenshotTest : ScreenshotTest() {
     @Test
     fun `study options frame host`() {
         val deckId = addDeck("Test Deck")
-        ActivityScenario
-            .launch<StudyOptionsActivity>(
-                Intent(targetContext, StudyOptionsActivity::class.java),
-            ).use { scenario ->
-                scenario.onActivity { activity ->
-                    commitScheduleRemindersAndCapture(
-                        fragmentManager = activity.supportFragmentManager,
-                        containerId = R.id.studyoptions_frame,
-                        host = FragmentHost.STUDY_OPTIONS_FRAME,
-                        scope = ReviewReminderScope.DeckSpecific(deckId),
-                        prefix = "studyOptionsFrameHost",
-                    )
-                    commitTroubleshootingAndCapture(
-                        fragmentManager = activity.supportFragmentManager,
-                        containerId = R.id.studyoptions_frame,
-                        host = FragmentHost.STUDY_OPTIONS_FRAME,
-                        prefix = "studyOptionsFrameHost",
-                    )
-                }
+        launchActivity<StudyOptionsActivity>(StudyOptionsDestination).use { scenario ->
+            scenario.onActivity { activity ->
+                commitScheduleRemindersAndCapture(
+                    fragmentManager = activity.supportFragmentManager,
+                    containerId = R.id.studyoptions_frame,
+                    host = FragmentHost.STUDY_OPTIONS_FRAME,
+                    scope = ReviewReminderScope.DeckSpecific(deckId),
+                    prefix = "studyOptionsFrameHost",
+                )
+                commitTroubleshootingAndCapture(
+                    fragmentManager = activity.supportFragmentManager,
+                    containerId = R.id.studyoptions_frame,
+                    host = FragmentHost.STUDY_OPTIONS_FRAME,
+                    prefix = "studyOptionsFrameHost",
+                )
             }
+        }
     }
 
     @Test

--- a/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/Navigator.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/Navigator.kt
@@ -32,7 +32,7 @@ interface Navigator {
         /**
          * Use during app startup to set the global [Navigator] instance.
          *
-         * Placed on the companion object, so calers may use `Navigator.register` to avoid
+         * Placed on the companion object, so callers may use `Navigator.register` to avoid
          * collisions with other top-level `register` functions.
          */
         fun register(navigator: Navigator) {

--- a/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/StudyOptionsDestination.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/StudyOptionsDestination.kt
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.common.destinations
+
+/** Opens the study options screen. */
+data object StudyOptionsDestination : Destination()


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

## Purpose / Description
Mechanical refactoring - allows for a Destination to be referenced by a ViewModel, and by feature modules once we go multimodule.

## Fixes
* Related to #20558
* Part of #20737

## Approach
Continue the pattern started in:

* https://github.com/ankidroid/Anki-Android/pull/21023

## How Has This Been Tested?
* Untested

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)