### PR TITLE
Feat: Bottom Nav Bar Shortcuts

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/BottomNavController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BottomNavController.kt
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 package com.ichi2.anki
 
+import android.content.Context
 import android.view.View
 import androidx.activity.OnBackPressedCallback
 import androidx.annotation.IdRes
+import androidx.annotation.StringRes
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
@@ -52,14 +54,32 @@ class BottomNavController(
         @IdRes val id: Int,
         /** Fragment tag used to find and reuse this destination's fragment across tab switches. */
         val tag: String,
+        @StringRes val shortcutLabel: Int,
     ) {
-        HOME(R.id.nav_home, "home"),
-        BROWSER(R.id.nav_browser, "browser"),
-        STATS(R.id.nav_stats, "stats"),
-        MORE(R.id.nav_more, "more"),
+        HOME(R.id.nav_home, "home", R.string.deck_picker_group),
+        BROWSER(R.id.nav_browser, "browser", R.string.card_browser_context_menu),
+        STATS(R.id.nav_stats, "stats", R.string.open_statistics),
+        MORE(R.id.nav_more, "more", R.string.bottom_nav_more),
         ;
 
+        fun title(context: Context): String =
+            when (this) {
+                HOME -> TR.actionsDecks()
+                BROWSER -> context.getString(R.string.bottom_nav_browse)
+                STATS -> TR.statisticsTitle()
+                MORE -> context.getString(R.string.bottom_nav_more)
+            }
+
         companion object {
+            fun populateMenu(
+                bottomNavigationView: BottomNavigationView,
+                context: Context,
+            ) {
+                entries.forEach { item ->
+                    bottomNavigationView.menu.findItem(item.id)?.title = item.title(context)
+                }
+            }
+
             fun fromId(
                 @IdRes id: Int,
             ): NavigationItem? =
@@ -93,8 +113,7 @@ class BottomNavController(
      * Call once after the activity's content view is set up.
      */
     fun setup() {
-        bottomNavigationView.menu.findItem(R.id.nav_home)?.title = TR.actionsDecks()
-        bottomNavigationView.menu.findItem(R.id.nav_stats)?.title = TR.statisticsTitle()
+        NavigationItem.populateMenu(bottomNavigationView, activity)
         activity.onBackPressedDispatcher.addCallback(activity, backCallback)
         bottomNavigationView.setOnItemSelectedListener { item ->
             when (item.itemId) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -74,6 +74,7 @@ import anki.sync.SyncStatusResponse
 import com.google.android.material.progressindicator.LinearProgressIndicator
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
+import com.ichi2.anki.BottomNavController.NavigationItem
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.DeckPickerFloatingActionMenu.FloatingActionBarToggleListener
@@ -1562,6 +1563,24 @@ open class DeckPicker :
         return false
     }
 
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        if (!Prefs.devBottomNavEnabled || fragmented || event.action != KeyEvent.ACTION_DOWN || !event.isAltPressed) {
+            return super.dispatchKeyEvent(event)
+        }
+
+        val bottomNavigation = binding.bottomNavigation ?: return super.dispatchKeyEvent(event)
+        val destination =
+            when (event.keyCode) {
+                KeyEvent.KEYCODE_1 -> NavigationItem.HOME
+                KeyEvent.KEYCODE_2 -> NavigationItem.BROWSER
+                KeyEvent.KEYCODE_3 -> NavigationItem.STATS
+                KeyEvent.KEYCODE_4 -> NavigationItem.MORE
+                else -> return super.dispatchKeyEvent(event)
+            }
+        bottomNavigation.selectedItemId = destination.id
+        return true
+    }
+
     override fun onKeyUp(
         keyCode: Int,
         event: KeyEvent,
@@ -2300,10 +2319,19 @@ open class DeckPicker :
     }
 
     override val shortcuts
-        get() =
-            ShortcutGroup(
+        get(): ShortcutGroup {
+            fun bottomNavShortcut(
+                keys: String,
+                destination: NavigationItem,
+            ) = if (Prefs.devBottomNavEnabled && !fragmented) shortcut(keys, destination.shortcutLabel) else null
+
+            return ShortcutGroup(
                 listOfNotNull(
                     shortcut("A", R.string.menu_add_note),
+                    bottomNavShortcut("Alt+1", NavigationItem.HOME),
+                    bottomNavShortcut("Alt+2", NavigationItem.BROWSER),
+                    bottomNavShortcut("Alt+3", NavigationItem.STATS),
+                    bottomNavShortcut("Alt+4", NavigationItem.MORE),
                     shortcut("B", R.string.card_browser_context_menu),
                     shortcut("Y", R.string.pref_cat_sync),
                     shortcut("/", R.string.deck_conf_cram_search),
@@ -2323,6 +2351,7 @@ open class DeckPicker :
                 ),
                 R.string.deck_picker_group,
             )
+        }
 
     companion object {
         /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/HomeScreenNavigation.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/HomeScreenNavigation.kt
@@ -39,8 +39,7 @@ fun setupBottomNavigation() {
     val contentWrapper = deckPicker.findViewById<View>(R.id.deck_picker_content_wrapper)
     bottomNav.isVisible = true
 
-    bottomNav.menu.findItem(R.id.nav_home)?.title = CollectionManager.TR.actionsDecks()
-    bottomNav.menu.findItem(R.id.nav_stats)?.title = CollectionManager.TR.statisticsTitle()
+    NavigationItem.populateMenu(bottomNav, deckPicker)
 
     // Return to Home tab on back press when on a non-Home tab
     val bottomNavBackCallback =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/HomeScreenNavigation.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/HomeScreenNavigation.kt
@@ -39,6 +39,9 @@ fun setupBottomNavigation() {
     val contentWrapper = deckPicker.findViewById<View>(R.id.deck_picker_content_wrapper)
     bottomNav.isVisible = true
 
+    bottomNav.menu.findItem(R.id.nav_home)?.title = CollectionManager.TR.actionsDecks()
+    bottomNav.menu.findItem(R.id.nav_stats)?.title = CollectionManager.TR.statisticsTitle()
+
     // Return to Home tab on back press when on a non-Home tab
     val bottomNavBackCallback =
         object : OnBackPressedCallback(enabled = false) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -17,6 +17,7 @@ import androidx.core.content.edit
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.view.children
 import androidx.test.core.app.ActivityScenario
+import androidx.test.filters.SdkSuppress
 import anki.collection.opChanges
 import anki.scheduler.CardAnswer.Rating
 import app.cash.turbine.test
@@ -24,6 +25,7 @@ import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
+import com.ichi2.anki.databinding.ActivityHomescreenBinding
 import com.ichi2.anki.deckpicker.DeckPickerViewModel
 import com.ichi2.anki.dialogs.DatabaseErrorDialog
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType
@@ -438,6 +440,25 @@ class DeckPickerTest : RobolectricTest() {
         assertEquals(expectedTitle, actualTitle)
     }
 
+    private fun withBottomNavigationEnabled(action: () -> Unit) {
+        val preferences = Prefs.sharedPrefs
+        val key = Prefs.key(R.string.dev_bottom_nav_key)
+        val previousValue = if (preferences.contains(key)) preferences.getBoolean(key, false) else null
+        preferences.edit { putBoolean(key, true) }
+        try {
+            action()
+        } finally {
+            preferences.edit {
+                if (previousValue == null) remove(key) else putBoolean(key, previousValue)
+            }
+        }
+    }
+
+    private fun keyDownEvent(
+        keyCode: Int,
+        modifiers: Int,
+    ): KeyEvent = KeyEvent(0, 0, KeyEvent.ACTION_DOWN, keyCode, 0, modifiers)
+
     @Test
     fun `ContextMenu starts expected activities when specific options are selected`() =
         deckPicker {
@@ -776,18 +797,73 @@ class DeckPickerTest : RobolectricTest() {
 
     @Test
     fun `bottom navigation has correct labels`() =
-        runTest {
+        withBottomNavigationEnabled {
             assumeTrue("Not running on tablet", qualifiers != "xlarge")
-            Prefs.sharedPrefs.edit { putBoolean(Prefs.key(R.string.dev_bottom_nav_key), true) }
-            try {
-                deckPicker {
-                    val bottomNav = findViewById<com.google.android.material.bottomnavigation.BottomNavigationView>(R.id.bottom_navigation)
-                    val menu = bottomNav.menu
-                    assertThat(menu.findItem(R.id.nav_home)?.title.toString(), equalTo(CollectionManager.TR.actionsDecks()))
-                    assertThat(menu.findItem(R.id.nav_stats)?.title.toString(), equalTo(CollectionManager.TR.statisticsTitle()))
+            deckPicker {
+                val menu = ActivityHomescreenBinding.bind(findViewById(R.id.root_layout)).bottomNavigation!!.menu
+                assertThat(menu.findItem(R.id.nav_home)?.title.toString(), equalTo("Decks"))
+                assertThat(menu.findItem(R.id.nav_browser)?.title.toString(), equalTo("Browse"))
+                assertThat(menu.findItem(R.id.nav_stats)?.title.toString(), equalTo("Statistics"))
+                assertThat(menu.findItem(R.id.nav_more)?.title.toString(), equalTo("More"))
+            }
+        }
+
+    @Test
+    fun `Alt number shortcuts navigate between bottom navigation destinations`() =
+        withBottomNavigationEnabled {
+            assumeTrue("Not running on tablet", qualifiers != "xlarge")
+            deckPicker {
+                val bottomNav = ActivityHomescreenBinding.bind(findViewById(R.id.root_layout)).bottomNavigation!!
+                val shortcuts =
+                    listOf(
+                        KeyEvent.KEYCODE_1 to BottomNavController.NavigationItem.HOME,
+                        KeyEvent.KEYCODE_2 to BottomNavController.NavigationItem.BROWSER,
+                        KeyEvent.KEYCODE_3 to BottomNavController.NavigationItem.STATS,
+                        KeyEvent.KEYCODE_4 to BottomNavController.NavigationItem.MORE,
+                    )
+
+                shortcuts.forEach { (keyCode, destination) ->
+                    val handled = dispatchKeyEvent(keyDownEvent(keyCode, KeyEvent.META_ALT_ON))
+
+                    assertThat("Alt shortcut is handled", handled, equalTo(true))
+                    assertThat(bottomNav.selectedItemId, equalTo(destination.id))
                 }
-            } finally {
-                Prefs.sharedPrefs.edit { putBoolean(Prefs.key(R.string.dev_bottom_nav_key), false) }
+            }
+        }
+
+    @Test
+    @SdkSuppress(minSdkVersion = 26)
+    fun `bottom navigation exposes a long title as a tooltip`() =
+        withBottomNavigationEnabled {
+            assumeTrue("Not running on tablet", qualifiers != "xlarge")
+            deckPicker {
+                val bottomNav = ActivityHomescreenBinding.bind(findViewById(R.id.root_layout)).bottomNavigation!!
+                val longTitle = "Statistikenübersicht"
+
+                bottomNav.menu.findItem(R.id.nav_stats).title = longTitle
+
+                assertThat(bottomNav.findViewById<View>(R.id.nav_stats).tooltipText.toString(), equalTo(longTitle))
+            }
+        }
+
+    @Test
+    fun `bottom navigation shortcuts are registered in keyboard shortcut help`() =
+        withBottomNavigationEnabled {
+            assumeTrue("Not running on tablet", qualifiers != "xlarge")
+            deckPicker {
+                val bottomNavigationShortcuts = shortcuts.shortcuts.filter { it.shortcut.startsWith("Alt+") }
+
+                assertThat(
+                    bottomNavigationShortcuts.associate { it.shortcut to it.label },
+                    equalTo(
+                        mapOf(
+                            "Alt+1" to "Deck picker",
+                            "Alt+2" to "Card Browser",
+                            "Alt+3" to "Open statistics",
+                            "Alt+4" to "More",
+                        ),
+                    ),
+                )
             }
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -775,6 +775,23 @@ class DeckPickerTest : RobolectricTest() {
         }
 
     @Test
+    fun `bottom navigation has correct labels`() =
+        runTest {
+            assumeTrue("Not running on tablet", qualifiers != "xlarge")
+            Prefs.sharedPrefs.edit { putBoolean(Prefs.key(R.string.dev_bottom_nav_key), true) }
+            try {
+                deckPicker {
+                    val bottomNav = findViewById<com.google.android.material.bottomnavigation.BottomNavigationView>(R.id.bottom_navigation)
+                    val menu = bottomNav.menu
+                    assertThat(menu.findItem(R.id.nav_home)?.title.toString(), equalTo(CollectionManager.TR.actionsDecks()))
+                    assertThat(menu.findItem(R.id.nav_stats)?.title.toString(), equalTo(CollectionManager.TR.statisticsTitle()))
+                }
+            } finally {
+                Prefs.sharedPrefs.edit { putBoolean(Prefs.key(R.string.dev_bottom_nav_key), false) }
+            }
+        }
+
+    @Test
     fun `On a new startup, the App Intro is displayed`() =
         deckPicker(skipIntroduction = false) {
             val nextIntent = Shadows.shadowOf(this).nextStartedActivity


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

<!---
Uncomment this section if AI tools were used. New contributors may not use AI tools. See:
https://github.com/ankidroid/Anki-Android/blob/main/AI_POLICY.md
> [!NOTE]
> Assisted-by: ___
--->

## Purpose / Description
We add bottom nav bar shortcuts. Second commit populates the labels for the decks and statistics destination since they were overwritten.

## Fixes
* For GSoC 2026: Deck Picker Redesign

## Approach
Follows the same approach as detailed in my proposal, we use key events to handle the actions.

## How Has This Been Tested?
Tested via the emulator keyboard on Mac.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->