### PR TITLE
refactor: decouple WidgetStatus from AnkiDroidApp

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -66,6 +66,7 @@ import com.ichi2.utils.LanguageUtil
 import com.ichi2.utils.measureTime
 import com.ichi2.utils.setWebContentsDebuggingEnabled
 import com.ichi2.widget.DayRolloverAlarm
+import com.ichi2.widget.WidgetNotificationScheduler
 import com.ichi2.widget.cardanalysis.CardAnalysisWidget
 import com.ichi2.widget.deckpicker.DeckPickerWidget
 import com.ichi2.widget.restoreRecurringAlarms
@@ -132,6 +133,7 @@ open class AnkiDroidApp :
         initializeAcraCrashReporter()
         initializeNavigator()
         initializeWidgetRepository()
+        WidgetNotificationScheduler.register { scheduleNotification() }
         Animations.setPreferencesProvider { context -> PrefsRepository(context) }
         val logType = LogType.value
         when (logType) {

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetNotificationScheduler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetNotificationScheduler.kt
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.widget
+
+import com.ichi2.anki.common.annotations.LegacyNotifications
+
+/** The active [WidgetNotificationScheduler], set during app startup via [WidgetNotificationScheduler.register]. */
+@LegacyNotifications("delete with the rest of the widget's legacy notification code")
+lateinit var widgetNotificationScheduler: WidgetNotificationScheduler
+    private set
+
+/**
+ * Triggers the legacy 'due cards' notification check, keeping widget code decoupled from
+ * [com.ichi2.anki.AnkiDroidApp].
+ * This moves with the widgets once they become a separate module.
+ */
+@LegacyNotifications("Only used by the widget to trigger notifications, we plan to stop relying on the widget")
+fun interface WidgetNotificationScheduler {
+    fun scheduleNotification()
+
+    companion object {
+        /** Use during app startup to set the global [WidgetNotificationScheduler] instance. */
+        fun register(scheduler: WidgetNotificationScheduler) {
+            widgetNotificationScheduler = scheduler
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.kt
@@ -15,7 +15,6 @@
 package com.ichi2.widget
 
 import android.content.Context
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
 import com.ichi2.anki.common.preferences.sharedPrefs
@@ -99,7 +98,7 @@ object WidgetStatus {
             AnkiDroidWidgetSmall.UpdateService().doUpdate(context)
         }
         if (!Prefs.newReviewRemindersEnabled) {
-            (context.applicationContext as AnkiDroidApp).scheduleNotification()
+            widgetNotificationScheduler.scheduleNotification()
         }
     }
 


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

## Purpose / Description
Adds WidgetNotificationScheduler (similar to WidgetRepository).

Reduces a dependency from the widgets on `:AnkiDroid` to allow for extraction of the `:widgets` module.

## Fixes
* Part of #20737

## Approach
Standard extraction

## How Has This Been Tested?
⚠️ Unverified

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)