### PR TITLE
refactor(navigation): extract Reviewer/New Study Screen as a destination

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -86,7 +86,6 @@ import com.ichi2.anki.InitialActivity.StartupFailure.DiskFull
 import com.ichi2.anki.InitialActivity.StartupFailure.FutureAnkidroidVersion
 import com.ichi2.anki.InitialActivity.StartupFailure.SDCardNotMounted
 import com.ichi2.anki.InitialActivity.StartupFailure.StorageUndecided
-import com.ichi2.anki.IntentHandler.Companion.intentToReviewDeckFromShortcuts
 import com.ichi2.anki.StudyOptionsFragment.Companion.registerStudyOptionsAddEditReminderHandler
 import com.ichi2.anki.StudyOptionsFragment.Companion.registerStudyOptionsStudyHandler
 import com.ichi2.anki.account.AccountActivity
@@ -100,9 +99,13 @@ import com.ichi2.anki.common.android.animationDisabled
 import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.crashreporting.CrashReportService
+import com.ichi2.anki.common.destinations.DeferredNavigation
 import com.ichi2.anki.common.destinations.PreferencesDestination
+import com.ichi2.anki.common.destinations.ReviewDeckDestination
+import com.ichi2.anki.common.destinations.ReviewDeckDestination.NavigationType
 import com.ichi2.anki.common.destinations.StudyOptionsDestination
 import com.ichi2.anki.common.destinations.navigate
+import com.ichi2.anki.common.destinations.toIntent
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.common.time.TimeManager
@@ -2146,7 +2149,7 @@ open class DeckPicker :
             ShortcutInfoCompat
                 .Builder(this, shortcutData.deckId.toString())
                 .setIntent(
-                    intentToReviewDeckFromShortcuts(this, shortcutData.deckId),
+                    with(DeferredNavigation) { ReviewDeckDestination(shortcutData.deckId, NavigationType.CLEAR_TOP).toIntent() },
                 ).setIcon(IconCompat.createWithResource(this, R.mipmap.ic_launcher))
                 .setShortLabel(shortcutData.shortLabel)
                 .setLongLabel(shortcutData.longLabel)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -102,7 +102,6 @@ import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.destinations.DeferredNavigation
 import com.ichi2.anki.common.destinations.PreferencesDestination
 import com.ichi2.anki.common.destinations.ReviewDeckDestination
-import com.ichi2.anki.common.destinations.ReviewDeckDestination.NavigationType
 import com.ichi2.anki.common.destinations.StudyOptionsDestination
 import com.ichi2.anki.common.destinations.navigate
 import com.ichi2.anki.common.destinations.toIntent
@@ -2149,7 +2148,7 @@ open class DeckPicker :
             ShortcutInfoCompat
                 .Builder(this, shortcutData.deckId.toString())
                 .setIntent(
-                    with(DeferredNavigation) { ReviewDeckDestination(shortcutData.deckId, NavigationType.CLEAR_TOP).toIntent() },
+                    with(DeferredNavigation) { ReviewDeckDestination.ExternalLaunch(shortcutData.deckId).toIntent() },
                 ).setIcon(IconCompat.createWithResource(this, R.mipmap.ic_launcher))
                 .setShortLabel(shortcutData.shortLabel)
                 .setLongLabel(shortcutData.longLabel)
@@ -2275,8 +2274,7 @@ open class DeckPicker :
 
     private fun openReviewer() {
         Timber.i("Opening Reviewer")
-        val intent = Reviewer.getIntent(this)
-        reviewLauncher.launch(intent)
+        reviewLauncher.navigate(ReviewDeckDestination.CurrentDeck)
     }
 
     private fun createSubDeckDialog(did: DeckId) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -505,19 +505,5 @@ class IntentHandler : AbstractIntentHandler() {
             context: Context,
             deckId: DeckId,
         ): Intent = Intent(context, IntentHandler::class.java).putExtra(EXTRA_DECK_ID, deckId)
-
-        /**
-         * Returns an intent to review a specific deck.
-         * This does not states which reviewer to use, instead IntentHandler will choose whether to use the
-         * legacy or the new reviewer based on the "newReviewer" preference.
-         * It is expected to be used from widget, shortcut, reminders but not from ankidroid directly because of the CLEAR_TOP flag.
-         */
-        fun intentToReviewDeckFromShortcuts(
-            context: Context,
-            deckId: DeckId,
-        ) = Intent(context, IntentHandler::class.java).apply {
-            setAction(Intent.ACTION_VIEW)
-            putExtra(EXTRA_DECK_ID, deckId)
-        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReviewDeckDestination.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReviewDeckDestination.kt
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki
+
+import android.content.Context
+import android.content.Intent
+import com.ichi2.anki.IntentHandler.Companion.EXTRA_DECK_ID
+import com.ichi2.anki.common.destinations.ReviewDeckDestination
+import com.ichi2.anki.common.destinations.ReviewDeckDestination.NavigationType
+
+/** Builds the [Intent] that opens the reviewer for this destination. */
+fun ReviewDeckDestination.toIntent(context: Context): Intent =
+    when (navigationType) {
+        NavigationType.CLEAR_TOP ->
+            Intent(context, IntentHandler::class.java).apply {
+                // shortcuts require the intent to have an action
+                setAction(Intent.ACTION_VIEW)
+                putExtra(EXTRA_DECK_ID, deckId)
+            }
+    }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReviewDeckDestination.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReviewDeckDestination.kt
@@ -6,12 +6,12 @@ import android.content.Context
 import android.content.Intent
 import com.ichi2.anki.IntentHandler.Companion.EXTRA_DECK_ID
 import com.ichi2.anki.common.destinations.ReviewDeckDestination
-import com.ichi2.anki.common.destinations.ReviewDeckDestination.NavigationType
 
 /** Builds the [Intent] that opens the reviewer for this destination. */
 fun ReviewDeckDestination.toIntent(context: Context): Intent =
-    when (navigationType) {
-        NavigationType.CLEAR_TOP ->
+    when (this) {
+        is ReviewDeckDestination.CurrentDeck -> Reviewer.getIntent(context)
+        is ReviewDeckDestination.ExternalLaunch ->
             Intent(context, IntentHandler::class.java).apply {
                 // shortcuts require the intent to have an action
                 setAction(Intent.ACTION_VIEW)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
@@ -29,6 +29,9 @@ import anki.collection.OpChanges
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.StudyOptionsFragment.Companion.registerStudyOptionsAddEditReminderHandler
 import com.ichi2.anki.StudyOptionsFragment.Companion.registerStudyOptionsStudyHandler
+import com.ichi2.anki.common.destinations.DeferredNavigation
+import com.ichi2.anki.common.destinations.ReviewDeckDestination
+import com.ichi2.anki.common.destinations.toIntent
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction.Companion.REQUEST_KEY
 import com.ichi2.anki.libanki.DeckId
@@ -80,7 +83,7 @@ class StudyOptionsActivity :
         }
         registerStudyOptionsStudyHandler {
             Timber.i("Opening study screen from study options screen")
-            val reviewer = Reviewer.getIntent(this)
+            val reviewer = with(DeferredNavigation) { ReviewDeckDestination.CurrentDeck.toIntent() }
             // go back to DeckPicker after studying when not in tablet mode
             reviewer.flags = Intent.FLAG_ACTIVITY_FORWARD_RESULT
             startActivity(reviewer)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/navigation/AnkiDroidNavigator.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/navigation/AnkiDroidNavigator.kt
@@ -12,6 +12,7 @@ import com.ichi2.anki.common.destinations.DeckOptionsDestination
 import com.ichi2.anki.common.destinations.Destination
 import com.ichi2.anki.common.destinations.Navigator
 import com.ichi2.anki.common.destinations.PreferencesDestination
+import com.ichi2.anki.common.destinations.ReviewDeckDestination
 import com.ichi2.anki.common.destinations.StatisticsDestination
 import com.ichi2.anki.common.destinations.StudyOptionsDestination
 import com.ichi2.anki.pages.toIntent
@@ -33,6 +34,7 @@ object AnkiDroidNavigator : Navigator {
             is CsvImporterDestination -> destination.toIntent(navContext)
             is DeckOptionsDestination -> destination.toIntent(navContext)
             is PreferencesDestination -> destination.toIntent(navContext)
+            is ReviewDeckDestination -> destination.toIntent(navContext)
             is StatisticsDestination -> destination.toIntent(navContext)
             is StudyOptionsDestination -> destination.toIntent(navContext)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidget.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidget.kt
@@ -11,13 +11,14 @@ import android.content.Context
 import android.content.Intent
 import android.view.View
 import android.widget.RemoteViews
-import com.ichi2.anki.IntentHandler.Companion.intentToReviewDeckFromShortcuts
 import com.ichi2.anki.R
 import com.ichi2.anki.common.analytics.UsageAnalytics
 import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.destinations.DeckOptionsDestination
 import com.ichi2.anki.common.destinations.DeferredNavigation
+import com.ichi2.anki.common.destinations.ReviewDeckDestination
+import com.ichi2.anki.common.destinations.ReviewDeckDestination.NavigationType
 import com.ichi2.anki.common.destinations.toIntent
 import com.ichi2.anki.isCollectionEmpty
 import com.ichi2.anki.libanki.DeckId
@@ -184,7 +185,7 @@ class CardAnalysisWidget : AnalyticsWidgetProvider() {
 
             val intent =
                 if (!isEmptyDeck) {
-                    intentToReviewDeckFromShortcuts(context, deckData.deckId)
+                    with(DeferredNavigation) { ReviewDeckDestination(deckData.deckId, NavigationType.CLEAR_TOP).toIntent() }
                 } else {
                     with(DeferredNavigation) { DeckOptionsDestination.fromDeckId(deckData.deckId).toIntent() }
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidget.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidget.kt
@@ -18,7 +18,6 @@ import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.destinations.DeckOptionsDestination
 import com.ichi2.anki.common.destinations.DeferredNavigation
 import com.ichi2.anki.common.destinations.ReviewDeckDestination
-import com.ichi2.anki.common.destinations.ReviewDeckDestination.NavigationType
 import com.ichi2.anki.common.destinations.toIntent
 import com.ichi2.anki.isCollectionEmpty
 import com.ichi2.anki.libanki.DeckId
@@ -185,7 +184,7 @@ class CardAnalysisWidget : AnalyticsWidgetProvider() {
 
             val intent =
                 if (!isEmptyDeck) {
-                    with(DeferredNavigation) { ReviewDeckDestination(deckData.deckId, NavigationType.CLEAR_TOP).toIntent() }
+                    with(DeferredNavigation) { ReviewDeckDestination.ExternalLaunch(deckData.deckId).toIntent() }
                 } else {
                     with(DeferredNavigation) { DeckOptionsDestination.fromDeckId(deckData.deckId).toIntent() }
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidget.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidget.kt
@@ -12,13 +12,14 @@ import android.content.Intent
 import android.view.View
 import android.widget.RemoteViews
 import com.ichi2.anki.CollectionManager.withCol
-import com.ichi2.anki.IntentHandler.Companion.intentToReviewDeckFromShortcuts
 import com.ichi2.anki.R
 import com.ichi2.anki.common.analytics.UsageAnalytics
 import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.destinations.DeckOptionsDestination
 import com.ichi2.anki.common.destinations.DeferredNavigation
+import com.ichi2.anki.common.destinations.ReviewDeckDestination
+import com.ichi2.anki.common.destinations.ReviewDeckDestination.NavigationType
 import com.ichi2.anki.common.destinations.toIntent
 import com.ichi2.anki.isCollectionEmpty
 import com.ichi2.anki.libanki.DeckId
@@ -135,7 +136,7 @@ class DeckPickerWidget : AnalyticsWidgetProvider() {
 
                 val intent =
                     if (!isEmptyDeck) {
-                        intentToReviewDeckFromShortcuts(context, deck.deckId)
+                        with(DeferredNavigation) { ReviewDeckDestination(deck.deckId, NavigationType.CLEAR_TOP).toIntent() }
                     } else {
                         with(DeferredNavigation) { DeckOptionsDestination.fromDeckId(deck.deckId).toIntent() }
                     }

--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidget.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidget.kt
@@ -19,7 +19,6 @@ import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.destinations.DeckOptionsDestination
 import com.ichi2.anki.common.destinations.DeferredNavigation
 import com.ichi2.anki.common.destinations.ReviewDeckDestination
-import com.ichi2.anki.common.destinations.ReviewDeckDestination.NavigationType
 import com.ichi2.anki.common.destinations.toIntent
 import com.ichi2.anki.isCollectionEmpty
 import com.ichi2.anki.libanki.DeckId
@@ -136,7 +135,7 @@ class DeckPickerWidget : AnalyticsWidgetProvider() {
 
                 val intent =
                     if (!isEmptyDeck) {
-                        with(DeferredNavigation) { ReviewDeckDestination(deck.deckId, NavigationType.CLEAR_TOP).toIntent() }
+                        with(DeferredNavigation) { ReviewDeckDestination.ExternalLaunch(deck.deckId).toIntent() }
                     } else {
                         with(DeferredNavigation) { DeckOptionsDestination.fromDeckId(deck.deckId).toIntent() }
                     }

--- a/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/ReviewDeckDestination.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/ReviewDeckDestination.kt
@@ -6,16 +6,22 @@ import android.content.Intent
 import com.ichi2.anki.libanki.DeckId
 
 /**
- * Opens the reviewer for [deckId]: either the legacy or the new reviewer, based on
+ * Opens the reviewer: either the legacy or the new reviewer, based on
  * `Prefs.isNewStudyScreenEnabled`.
  */
-data class ReviewDeckDestination(
-    val deckId: DeckId,
-    val navigationType: NavigationType,
-) : Destination() {
-    /** The task-stack behavior when opening the reviewer. */
-    enum class NavigationType {
-        /** @see Intent.FLAG_ACTIVITY_CLEAR_TOP */
-        CLEAR_TOP,
-    }
+sealed class ReviewDeckDestination : Destination() {
+    /**
+     * Opens the reviewer for the currently selected deck.
+     */
+    data object CurrentDeck : ReviewDeckDestination()
+
+    /**
+     * Opens the reviewer for [deckId] via the app's entry point, for entry points outside the
+     * app: widgets, shortcuts and reminders.
+     *
+     * @see Intent.FLAG_ACTIVITY_CLEAR_TOP
+     */
+    data class ExternalLaunch(
+        val deckId: DeckId,
+    ) : ReviewDeckDestination()
 }

--- a/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/ReviewDeckDestination.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/ReviewDeckDestination.kt
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.common.destinations
+
+import android.content.Intent
+import com.ichi2.anki.libanki.DeckId
+
+/**
+ * Opens the reviewer for [deckId]: either the legacy or the new reviewer, based on
+ * `Prefs.isNewStudyScreenEnabled`.
+ */
+data class ReviewDeckDestination(
+    val deckId: DeckId,
+    val navigationType: NavigationType,
+) : Destination() {
+    /** The task-stack behavior when opening the reviewer. */
+    enum class NavigationType {
+        /** @see Intent.FLAG_ACTIVITY_CLEAR_TOP */
+        CLEAR_TOP,
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

## Purpose / Description
Part of the `:widgets` extraction.

## Fixes
* Related to https://github.com/ankidroid/Anki-Android/issues/20558
* Part of https://github.com/ankidroid/Anki-Android/issues/20737
 
## Approach

Continue the pattern started in:

* https://github.com/ankidroid/Anki-Android/pull/21023

## How Has This Been Tested?
⚠️ Untested

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)