### PR TITLE
build: enable parallel sync for Gradle 9.4+

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -38,3 +38,8 @@ android.experimental.enableTestFixturesKotlinSupport=true
 # attempting to use the github maven repo package publish from that comment did not work initially
 # perhaps can vendor a compiled lib / local maven repository for that plugin
 android.newDsl=false
+
+# Enable parallel sync for Gradle 9.4+ and Android Quail
+# https://docs.gradle.org/current/userguide/build_environment.html#gradle_properties_reference
+# https://developer.android.com/studio/releases/past-releases/as-quail-1-release-notes#android_studio_quail_1_parallel_gradle_sync_execution_change
+org.gradle.tooling.parallel=true


### PR DESCRIPTION
Recommended by Android Studio.

## How Has This Been Tested?

Gradle sync & CI

## Learning (optional, can help others)


> # Android Studio Quail 1 parallel Gradle Sync execution change

> Starting from Android Studio Quail 1, the `org.gradle.parallel=true` property in the `gradle.properties` file no longer enables parallel model fetching during Gradle Sync. This will result in a large sync time regression for large projects.
>
> To enable parallel sync in Android Studio Quail 1, set `org.gradle.tooling.parallel=true` in your project's `gradle.properties` file.

https://developer.android.com/studio/releases/past-releases/as-quail-1-release-notes#android_studio_quail_1_parallel_gradle_sync_execution_change

----

**Gradle Docs**

> When configured, Gradle will fork up to org.gradle.workers.max JVMs to execute projects in parallel.

https://docs.gradle.org/current/userguide/build_environment.html

----

On the Gradle side, this is a no-op as we set `org.gradle.parallel=true`

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)