### PR TITLE
fix(tests): use a fixed version for screenshots

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/ScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ScreenshotTest.kt
@@ -31,6 +31,7 @@ import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestParameterInjector
 import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.GraphicsMode
 import java.io.File
 
@@ -43,6 +44,14 @@ interface ScreenshotTestCategory
 @Category(ScreenshotTestCategory::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 abstract class ScreenshotTest : RobolectricTest() {
+    companion object {
+        /**
+         * Fixed `versionName` reported to screenshot tests, so screens which display
+         * the app version do not change on each release.
+         */
+        const val STABLE_VERSION_NAME = "X.Y.Z-screenshot"
+    }
+
     var fileNamePrefix = ""
 
     enum class ThemeConfig { LIGHT, PLAIN, DARK, BLACK }
@@ -57,8 +66,16 @@ abstract class ScreenshotTest : RobolectricTest() {
 
     @Before
     open fun applyGlobalConfig() {
+        stabilizeVersionName()
         applyDeviceConfig()
         applyThemeConfig()
+    }
+
+    /** Reports [STABLE_VERSION_NAME] as the `versionName` shown on-screen */
+    private fun stabilizeVersionName() {
+        shadowOf(targetContext.packageManager)
+            .getInternalMutablePackageInfo(targetContext.packageName)
+            .versionName = STABLE_VERSION_NAME
     }
 
     protected open fun applyDeviceConfig() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ScreenshotTestTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ScreenshotTestTest.kt
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki
+
+import com.ichi2.utils.VersionUtils
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+
+/** Meta tests for [ScreenshotTest] */
+class ScreenshotTestTest : ScreenshotTest() {
+    @Test
+    fun `version name does not change between releases - issue 21453`() {
+        // 'Info' displays the version in its toolbar, which shows as a break in screenshot diffs
+        assertThat(VersionUtils.pkgVersionName, equalTo(STABLE_VERSION_NAME))
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesScreenshotTest.kt
@@ -37,7 +37,6 @@ class PreferencesScreenshotTest : ScreenshotTest() {
                         }
                         (settingsFragment as? AboutFragment)?.apply {
                             binding.buildDate.text = "May 18, 2026"
-                            binding.version.text = "2.24.0-screenshot"
                         }
                         captureScreen(fragmentClass.simpleName!!)
                     }


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Assisted-by: Claude Fable 5 - all but comments and string constant


## Purpose / Description
A change in version number caused screenshot diffs to be displayed, which were noise rather tha genuine issues.

## Fixes
* Fixes #21453

## Approach
Instead, we use `X.Y.Z-screenshot`. This does not register as a diff on preferences or the 'Changelog' info screen.

## How Has This Been Tested?
Failing regression test was added

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)