### PR TITLE
fix(deck-picker): edge to edge - FAB position

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -55,7 +55,6 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat.Type.displayCutout
 import androidx.core.view.WindowInsetsCompat.Type.navigationBars
 import androidx.core.view.WindowInsetsCompat.Type.systemBars
-import androidx.core.view.doOnLayout
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
 import androidx.draganddrop.DropHelper
@@ -104,7 +103,6 @@ import com.ichi2.anki.common.destinations.navigate
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.common.time.TimeManager
-import com.ichi2.anki.common.utils.android.isRobolectric
 import com.ichi2.anki.common.utils.android.showThemedToast
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.compat.CompatHelper.Companion.getSerializableCompat
@@ -630,6 +628,16 @@ open class DeckPicker :
 
     override fun fitsSystemWindows(): Boolean = false
 
+    /** Raises the FAB by half the 'Studied X cards' line, so it clears the line's text */
+    private fun raiseFabAboveSummary(summaryHeight: Int) {
+        val fabBottomMargin = summaryHeight / 2
+        val layoutParams = floatingActionButtonBinding.fabLinearLayout.layoutParams as MarginLayoutParams
+        if (layoutParams.bottomMargin != fabBottomMargin) {
+            layoutParams.bottomMargin = fabBottomMargin
+            floatingActionButtonBinding.fabLinearLayout.layoutParams = layoutParams
+        }
+    }
+
     /** Applied edge-to-edge insets for the screen */
     private fun setupEdgeToEdge() {
         fun setRecyclerViewBottomPaddingAbove(target: View) {
@@ -664,17 +672,25 @@ open class DeckPicker :
             )
             deckPickerBinding.reviewSummaryTextView.updatePadding(bottom = bars.bottom)
 
-            // hack for Roborazzi screenshot tests
-            val fabBottomOffset = if (isRobolectric) 12.dp.toPx(this) else -12.dp.toPx(this)
             val bottomNavView = findViewById<View?>(R.id.bottom_navigation)
             val bottomNavOffset = if (bottomNavView?.isVisible == true) BOTTOM_NAV_HEIGHT_DP.dp.toPx(this) else 0
-            floatingActionButtonBinding.root.updatePadding(bottom = bars.bottom + fabBottomOffset + bottomNavOffset)
+            floatingActionButtonBinding.root.updatePadding(bottom = bars.bottom + bottomNavOffset)
 
             setRecyclerViewBottomPaddingAbove(floatingActionButtonBinding.fabMain)
             insets
         }
         floatingActionButtonBinding.fabMain.addOnLayoutChangeListener { v, _, _, _, _, _, _, _, _ ->
             setRecyclerViewBottomPaddingAbove(v)
+        }
+        deckPickerBinding.reviewSummaryTextView.addOnLayoutChangeListener { view, _, _, _, _, _, _, _, _ ->
+            // exclude paddingBottom: it holds the edge-to-edge inset, which is already applied
+            raiseFabAboveSummary(view.height - view.paddingBottom)
+        }
+        // The summary is hidden until the collection loads.
+        // Assume the summary takes up a single line, so it does not 'jump' up on load
+        deckPickerBinding.reviewSummaryTextView.apply {
+            measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)
+            raiseFabAboveSummary(measuredHeight - paddingBottom)
         }
         if (fragmented) {
             val studyoptionsView = binding.studyoptionsFragment ?: return
@@ -749,15 +765,18 @@ open class DeckPicker :
 
         fun onStudiedTodayChanged(studiedToday: String) {
             deckPickerBinding.reviewSummaryTextView.text = studiedToday
-            // Adjust bottom margin of fabLinearLayout based on reviewSummaryTextView height
-            deckPickerBinding.reviewSummaryTextView.doOnLayout { view ->
-                val layoutParams = floatingActionButtonBinding.fabLinearLayout.layoutParams as MarginLayoutParams
-                layoutParams.setMargins(0, 0, 0, view.height / 2)
-                floatingActionButtonBinding.fabLinearLayout.layoutParams = layoutParams
-            }
         }
 
         fun onCollectionStatusChanged(isInInitialState: Boolean) {
+            // no summary line in the initial state: the FAB rests unraised
+            val summary = deckPickerBinding.reviewSummaryTextView
+            if (isInInitialState) {
+                raiseFabAboveSummary(summaryHeight = 0)
+            } else if (summary.height > 0) {
+                // re-showing the summary with unchanged text does not lay it out again,
+                // so restore the FAB from the bounds the summary keeps while hidden
+                raiseFabAboveSummary(summary.height - summary.paddingBottom)
+            }
             // Hide the background when there are no cards to improve text readability.
             deckPickerBinding.background.isVisible = !isInInitialState
             if (animationDisabled()) {

--- a/AnkiDroid/src/main/res/layout/include_floating_add_button.xml
+++ b/AnkiDroid/src/main/res/layout/include_floating_add_button.xml
@@ -22,9 +22,7 @@
             android:id="@+id/fabLinearLayout"
             android:layout_width="wrap_content"
             android:orientation="vertical"
-            android:paddingStart="12dp"
-            android:paddingEnd="12dp"
-            android:paddingTop="12dp"
+            android:padding="12dp"
             android:layout_height="wrap_content"
         >
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerInsetsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerInsetsTest.kt
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki
+
+import android.content.Intent
+import android.view.View
+import android.view.View.MeasureSpec
+import android.view.ViewGroup.MarginLayoutParams
+import androidx.core.content.edit
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsCompat.Type.navigationBars
+import androidx.core.view.WindowInsetsCompat.Type.statusBars
+import androidx.core.view.isVisible
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.android.view.locationInWindow
+import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.testutils.BackupManagerTestUtilities
+import com.ichi2.testutils.insetsOf
+import com.ichi2.utils.Dp
+import com.ichi2.utils.dp
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.greaterThan
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+
+/**
+ * Edge-to-edge inset handling for the [DeckPicker] FAB.
+ *
+ * See issue 21241: the FAB shifted when returning from Settings.
+ */
+@RunWith(AndroidJUnit4::class)
+class DeckPickerInsetsTest : RobolectricTest() {
+    @Test
+    fun `FAB is above the navigation bar`() =
+        withDeckPicker(deckCount = 2) { deckPicker ->
+            val navBarBottom = 48.dp.toPx(targetContext)
+            deckPicker.dispatchInsets(navBarBottom = 48.dp)
+            deckPicker.layoutForTest()
+
+            // the studied-today line refreshes after the insets have been applied (as on resume)
+            deckPicker.viewModel.flowOfStudiedTodayStats.value = "Studied 3 cards in 3 minutes today"
+            deckPicker.layoutForTest()
+
+            val summary = deckPicker.deckPickerBinding.reviewSummaryTextView
+            val summaryTextHeight = summary.height - summary.paddingBottom
+            val fabColumnPadding = 12.dp.toPx(targetContext)
+            val fabMargin = 16.dp.toPx(targetContext)
+            assertThat(
+                "the FAB is unchanged compared to its pre-edge-to-edge position",
+                deckPicker.fabDistanceToWindowBottom,
+                equalTo(navBarBottom + fabColumnPadding + fabMargin + summaryTextHeight / 2),
+            )
+        }
+
+    @Test
+    fun `the FAB follows the summary line's layout passes`() =
+        withDeckPicker(deckCount = 2) { deckPicker ->
+            // note: the summary layout can be updated without the text event firing
+            // (e.g. screen width change)
+            val navBarBottom = 48.dp.toPx(targetContext)
+            deckPicker.dispatchInsets(navBarBottom = 48.dp)
+            deckPicker.viewModel.flowOfStudiedTodayStats.value = "Studied 3 cards in 3 minutes today"
+            deckPicker.layoutForTest()
+
+            val summary = deckPicker.deckPickerBinding.reviewSummaryTextView
+            summary.text = "Studied 3 cards in 3 minutes today\n(0.05s/card)"
+            deckPicker.layoutForTest()
+
+            val summaryTextHeight = summary.height - summary.paddingBottom
+            val fabColumnPadding = 12.dp.toPx(targetContext)
+            val fabMargin = 16.dp.toPx(targetContext)
+            assertThat(
+                "the FAB rests half the re-wrapped summary line above its padded position",
+                deckPicker.fabDistanceToWindowBottom,
+                equalTo(navBarBottom + fabColumnPadding + fabMargin + summaryTextHeight / 2),
+            )
+        }
+
+    @Test
+    fun `a same-height studied-today refresh does not move the FAB`() =
+        withDeckPicker(deckCount = 2) { deckPicker ->
+            deckPicker.viewModel.flowOfStudiedTodayStats.value = "Studied 10 cards in 5 minutes today"
+            deckPicker.layoutForTest()
+            deckPicker.dispatchInsets(navBarBottom = 48.dp)
+            deckPicker.layoutForTest()
+            val restingPosition = deckPicker.fabDistanceToWindowBottom
+
+            // same text length, so the line's height cannot change
+            deckPicker.viewModel.flowOfStudiedTodayStats.value = "Studied 11 cards in 5 minutes today"
+            deckPicker.layoutForTest()
+
+            assertThat(
+                "a same-height studied-today refresh must not move the FAB",
+                deckPicker.fabDistanceToWindowBottom,
+                equalTo(restingPosition),
+            )
+        }
+
+    @Test
+    fun `the FAB does not move when the deck list first appears`() {
+        // do not advance the looper: the FAB must be seen before the collection is loaded
+        ensureCollectionLoadIsSynchronous()
+        setIntroductionSlidesShown(true)
+        BackupManagerTestUtilities.setupSpaceForBackup(targetContext)
+        targetContext.sharedPrefs().edit { putBoolean("backupPromptDisabled", true) }
+        addDeck("Test Deck")
+
+        // Flows start collection on STARTED, so only call .create()
+        val controller = Robolectric.buildActivity(DeckPicker::class.java, Intent()).create()
+        saveControllerForCleanup(controller)
+        val deckPicker = controller.get()
+
+        check(!deckPicker.deckPickerBinding.deckPickerContent.isVisible) {
+            "the deck list/summary line should be hidden until the collection loads"
+        }
+        val marginBeforeLoad = deckPicker.fabBottomMargin
+
+        controller.start().resume().visible()
+        // advances the looper so the collection loads and the list appears
+        deckPicker.layoutForTest()
+        check(deckPicker.deckPickerBinding.deckPickerContent.isVisible) { "the deck list should be shown" }
+        // one line at the test's layout width, so the resting position is the seeded one
+        deckPicker.viewModel.flowOfStudiedTodayStats.value = "Studied 3 cards today"
+        deckPicker.layoutForTest()
+
+        assertThat(
+            "the FAB margin should be unchanged",
+            marginBeforeLoad,
+            equalTo(deckPicker.fabBottomMargin),
+        )
+        assertThat("the FAB should be above the summary line", deckPicker.fabBottomMargin, greaterThan(0))
+    }
+
+    @Test
+    fun `the FAB is raised again after leaving the initial state`() =
+        withDeckPicker(deckCount = 2) { deckPicker ->
+            deckPicker.layoutForTest()
+            val raisedMargin = deckPicker.fabBottomMargin
+            check(raisedMargin > 0) { "the FAB should start raised above the summary line" }
+
+            // delete every deck: the deck picker enters the initial state
+            col.decks.remove(listOf("Test Deck 0", "Test Deck 1").map { col.decks.id(it) })
+            deckPicker.updateDeckList()
+            deckPicker.layoutForTest()
+            check(deckPicker.fabBottomMargin == 0) { "the FAB should be unraised initially" }
+
+            // create a deck: the summary line reappears with unchanged studied-today text,
+            // so no layout pass fires on it
+            addDeck("A Deck")
+            deckPicker.updateDeckList()
+            deckPicker.layoutForTest()
+
+            assertThat(
+                "the FAB should be raised above the summary line again",
+                deckPicker.fabBottomMargin,
+                equalTo(raisedMargin),
+            )
+        }
+
+    /** The bottom margin raising the FAB above the 'Studied X cards' line. */
+    private val DeckPicker.fabBottomMargin: Int
+        get() = (floatingActionButtonBinding.fabLinearLayout.layoutParams as MarginLayoutParams).bottomMargin
+
+    /** The gap, in pixels, between the bottom of the FAB and the bottom of its container. */
+    private val DeckPicker.fabDistanceToWindowBottom: Int
+        get() {
+            val fab = floatingActionButtonBinding.fabMain
+            val container = floatingActionButtonBinding.root
+            val fabBottom = fab.locationInWindow().y + fab.height
+            val containerBottom = container.locationInWindow().y + container.height
+            return containerBottom - fabBottom
+        }
+
+    /** Dispatches realistic system-bar insets, which Robolectric otherwise reports as zero. */
+    private fun DeckPicker.dispatchInsets(navBarBottom: Dp) {
+        val insets =
+            with(targetContext) {
+                WindowInsetsCompat
+                    .Builder()
+                    .setInsets(statusBars(), insetsOf(top = 24.dp))
+                    .setInsets(navigationBars(), insetsOf(bottom = navBarBottom))
+                    .build()
+            }
+        ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
+    }
+
+    /**
+     * Forces measure/layout passes so view bounds can be asserted.
+     *
+     * Laid out at the window's current size so line wrapping is stable across passes.
+     */
+    private fun DeckPicker.layoutForTest() {
+        advanceRobolectricLooper()
+        performLayout()
+    }
+
+    /** [layoutForTest] without processing pending tasks: lays out the current state */
+    private fun DeckPicker.performLayout() {
+        val content = findViewById<View>(android.R.id.content)
+        val width = if (content.width > 0) content.width else 1080
+        val height = if (content.height > 0) content.height else 2400
+        // Two passes - the summary line's layout listener:
+        // 1. sets a margin
+        // 2. applies the margin
+        repeat(2) {
+            content.measure(
+                MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+                MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY),
+            )
+            content.layout(0, 0, width, height)
+        }
+    }
+}


### PR DESCRIPTION

> [!NOTE]
> Assisted-by: Claude Fable 5 - all non-comment code, guided and reviewed by myself
> This took a fair few sessions, and should be reviewed heavily

## Purpose / Description
* There was a race condition between when the 'Studied X cards today' text changed and the layout pass.
* A hack was applied (Robolectric-only insets) for the screenshot tests, but this was a genuine issue on the device.

## Fixes
* Fixes #21241

## Approach
Fixed by:
* moving the 12dp padding 'hack' back to the layout
* use a persistent listener, rather than waiting for 'onStudiedTodayChanged'
* Pre-defining the FAB's margin before the collection loads so the FAB doesn't jump when the deck list first appears.

## How Has This Been Tested?
Unit tested, existing screenshot tests, and tested on a API 33 emulator: entering and exiting the settings

<img width="363" height="761" alt="Screenshot 2026-08-10 at 23 54 46" src="https://github.com/user-attachments/assets/66522895-49f1-4529-8a12-d204961429d9" />

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)