### PR TITLE
fix(filtered-deck): restore state on recreation (#21463)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/filtered/FilteredDeckOptionsViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/filtered/FilteredDeckOptionsViewModel.kt
@@ -70,9 +70,14 @@ class FilteredDeckOptionsViewModel(
     init {
         viewModelScope.launch {
             Timber.i("Starting filtered deck options setup, deckId=$did")
+            // needed on both paths: name validation is done against this list
+            decksNames = withCol { safeGetDecksNames() }
             val previousState = savedStateHandle.get<FilteredDeckOptions>(ARG_DATA)
             if (previousState != null) {
+                initialState = savedStateHandle[ARG_INITIAL_DATA]
                 state.update { previousState }
+                // changes made before the view model was destroyed are still unsaved
+                hasUnsavedChanges.update { wasStateModified() }
                 return@launch
             }
             Timber.i("No previous stored state, querying the collection")
@@ -82,7 +87,6 @@ class FilteredDeckOptionsViewModel(
                     state.update { Initializing(throwable = throwable) }
                     return@launch
                 }
-            decksNames = withCol { safeGetDecksNames() }
             filteredDeckData
                 .asInitialState(
                     cardsOptions = cardsOptions,
@@ -90,6 +94,7 @@ class FilteredDeckOptionsViewModel(
                     defaultSearch2 = search2,
                 ).apply {
                     savedStateHandle[ARG_DATA] = this
+                    savedStateHandle[ARG_INITIAL_DATA] = this
                     initialState = this
                 }
             state.update { currentState() }
@@ -98,13 +103,16 @@ class FilteredDeckOptionsViewModel(
 
     fun onDeckNameChange(name: String) {
         Timber.i("Filtered deck name is changing")
+        val current = currentState()
         val error =
             when {
                 name.isBlank() -> FilteredNameInputError.Empty
+                // when editing a deck, its own name doesn't conflict with itself
+                current.id != null && name == current.title -> null
                 decksNames.contains(name) -> FilteredNameInputError.AlreadyExists
                 else -> null
             }
-        if (currentState().name == name) return
+        if (current.name == name) return
         updateCurrentState { copy(name = name, nameInputError = error) }
         hasUnsavedChanges.update { wasStateModified() }
     }
@@ -492,5 +500,11 @@ class FilteredDeckOptionsViewModel(
     companion object {
         /** Key used to store/retrieve our state in [SavedStateHandle]. */
         private const val ARG_DATA = "arg_data"
+
+        /**
+         * Key used to store/retrieve the state as it was first loaded in [SavedStateHandle]. Needed
+         * to detect unsaved changes after the view model is recreated.
+         */
+        private const val ARG_INITIAL_DATA = "arg_initial_data"
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/filtered/FilteredDeckOptionsViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/filtered/FilteredDeckOptionsViewModelTest.kt
@@ -391,9 +391,84 @@ class FilteredDeckOptionsViewModelTest : RobolectricTest() {
             }
         }
 
+    @Test
+    fun `name validation still works after the screen is restored`() =
+        runTest {
+            addDeck("A")
+            withRestoredViewModel {
+                onDeckNameChange("A")
+                assertThat(current.nameInputError, equalTo(FilteredNameInputError.AlreadyExists))
+                assertFalse(current.isBuildingAllowed)
+            }
+        }
+
+    @Test
+    fun `changed status still works after the screen is restored`() =
+        runTest {
+            addDeck("A")
+            withRestoredViewModel {
+                assertFalse(hasUnsavedChanges.value)
+                onSearchChange(FilterIndex.First, "flag:3")
+                assertTrue(hasUnsavedChanges.value)
+            }
+        }
+
+    @Test
+    fun `changes made before the screen is restored are still reported`() =
+        runTest {
+            addDeck("A")
+            withRestoredViewModel(
+                beforeDestroy = { onSearchChange(FilterIndex.First, "flag:3") },
+            ) {
+                assertTrue(hasUnsavedChanges.value)
+            }
+        }
+
+    @Test
+    fun `reverting to the deck's own name is not a duplicate`() =
+        runTest {
+            val testDid = createTestFilteredDeck()
+            withViewModel(did = testDid) {
+                onDeckNameChange("Not")
+                onDeckNameChange("Filtered")
+                assertNull(current.nameInputError)
+                assertTrue(current.isBuildingAllowed)
+            }
+        }
+
     /** Returns the current state as a [FilteredDeckOptions] or throw otherwise */
     private val FilteredDeckOptionsViewModel.current: FilteredDeckOptions
         get() = state.value as FilteredDeckOptions
+
+    /**
+     * Builds a view model and invokes [beforeDestroy] on it, then discards it and builds a second
+     * one over the same [SavedStateHandle], simulating the view model being destroyed while its
+     * saved state survives.
+     */
+    private fun TestScope.withRestoredViewModel(
+        did: DeckId = 0,
+        beforeDestroy: FilteredDeckOptionsViewModel.() -> Unit = {},
+        action: FilteredDeckOptionsViewModel.() -> Unit,
+    ) {
+        val handle =
+            SavedStateHandle().apply {
+                set(FilteredDeckOptionsFragment.ARG_DECK_ID, did)
+                set(FilteredDeckOptionsFragment.ARG_SEARCH, null as String?)
+                set(FilteredDeckOptionsFragment.ARG_SEARCH_2, null as String?)
+            }
+        FilteredDeckOptionsViewModel(handle).apply {
+            advanceUntilIdle()
+            advanceRobolectricLooper()
+            beforeDestroy()
+        }
+        advanceUntilIdle()
+        advanceRobolectricLooper()
+
+        val restoredViewModel = FilteredDeckOptionsViewModel(handle)
+        advanceUntilIdle()
+        advanceRobolectricLooper()
+        restoredViewModel.action()
+    }
 
     private fun TestScope.withViewModel(
         did: DeckId = 0,


### PR DESCRIPTION
this fixes the 3 things from the issue - after the screen gets recreated the duplicate name check
and the discard changes dialog both stop working, plus renaming a filtered deck back to its own
name was getting flagged as duplicate.

* Fixes #21463

## Purpose / Description
the init block in FilteredDeckOptionsViewModel was returning early whenever there was a previous
state saved:

    val previousState = savedStateHandle.get<FilteredDeckOptions>(ARG_DATA)
    if (previousState != null) {
        state.update { previousState }
        return@launch
    }

problem is two things below that return never ran. decksNames stayed as emptyList() so the
decksNames.contains(name) check inside onDeckNameChange could never be true, and initialState
stayed null so wasStateModified() hit `val initial = initialState ?: return false` and always
returned false. so after a restore you could type a name that already exist and get no error at
all (Build stays enabled, you just get a raw backend exception when you press it), and pressing
back would throw away all your edits without asking anything.

the third one is unrelated to restore - safeGetDecksNames() uses includeFiltered = true so the
list also has the deck you are editing right now in it. so if you rename an existing filtered deck
and then put the original name back it says "already exists" and disables Rebuild.

## Approach
moved `decksNames = withCol { safeGetDecksNames() }` above the early return since both paths need
it. for initialState i couldnt just read it back from ARG_DATA because that key holds the edited
state, not the original one, so its saved under its own key (ARG_INITIAL_DATA) and read back on
the restore path.

for the third one i used the existing `title` field - its already documented as the name from when
the deck was first loaded and it doesnt change for the lifetime of the screen, so its exactly what
was needed. only applied it when id != null so it doesnt affect creating new decks.

## How Has This Been Tested?
added 3 tests to FilteredDeckOptionsViewModelTest, all of them failed before the fix:

  name validation still works after the screen is restored -> expected <AlreadyExists> but was <null>
  changed status still works after the screen is restored  -> Expected value to be true
  reverting to the deck's own name is not a duplicate      -> expected <null> but was <AlreadyExists>

for simulating the restore theres a small withRestoredViewModel helper - it builds a view model,
throws it away and builds a second one over the same SavedStateHandle, which is basically what
happens when the VM dies but the handle survives.

also did mutation testing to make sure none of the 3 changes are redundant:
- removed just the initialState restore -> only test 2 failed
- removed the decksNames move + the own name check -> only tests 1 and 3 failed

whole com.ichi2.anki.filtered package is green after (17 tests), ktlint passes.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
