### PR TITLE
fix(study-screen): wait for custom scheduler before showing the answer

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerFragmentTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerFragmentTest.kt
@@ -21,8 +21,6 @@ import com.ichi2.anki.testutil.grantPermissions
 import com.ichi2.anki.testutil.notificationPermission
 import com.ichi2.anki.testutil.reviewDeckWithName
 import com.ichi2.anki.utils.ext.cardStateCustomizer
-import com.ichi2.testutils.common.Flaky
-import com.ichi2.testutils.common.OS
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Rule
@@ -49,11 +47,26 @@ class ReviewerFragmentTest : InstrumentedTest() {
     val retry = RetryRule(10)
 
     @Test
-    @Flaky(os = OS.ALL, "Fails on CI with timing issues frequently")
-    fun testCustomSchedulerWithCustomData() {
+    fun testCustomSchedulerWithCustomData() = testCustomSchedulerWithCustomData(schedulerDelayMs = 0)
+
+    /**
+     * Issue 17298: a card must not be answered until the custom scheduler has
+     * completed (statesMutated).
+     */
+    @Test
+    fun testCustomSchedulerWithCustomDataAndSlowScheduler() = testCustomSchedulerWithCustomData(schedulerDelayMs = 5000)
+
+    private fun testCustomSchedulerWithCustomData(schedulerDelayMs: Long) {
         setNewReviewer()
+        val delayJs =
+            if (schedulerDelayMs > 0) {
+                "await new Promise(resolve => setTimeout(resolve, $schedulerDelayMs));"
+            } else {
+                ""
+            }
         col.cardStateCustomizer =
             """
+            $delayJs
             states.good.normal.review.easeFactor = 3.0;
             states.good.normal.review.scheduledDays = 123;
             customData.good.c += 1;
@@ -91,7 +104,6 @@ class ReviewerFragmentTest : InstrumentedTest() {
     }
 
     @Test
-    @Flaky(os = OS.ALL, "Fails on CI with timing issues frequently")
     fun testCustomSchedulerWithRuntimeError() {
         setNewReviewer()
         // Issue 15035 - runtime errors weren't handled

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -181,8 +181,13 @@ class ReviewerFragment :
         }
 
         viewModel.statesMutationEvalFlow.collectIn(lifecycleScope) { eval ->
-            webViewLayout.evaluateJavascript(eval) {
-                viewModel.onStateMutationCallback()
+            // Completion is signaled by `statesMutated`
+            webViewLayout.evaluateJavascript(eval) { result ->
+                // eval failed, usually a syntax error
+                // Note: this is `"null"`, not null
+                if ("null" == result) {
+                    viewModel.onStateMutationCallback()
+                }
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -444,6 +444,10 @@ class ReviewerViewModel(
                 isInputFocused = false
                 return byteArrayOf()
             }
+            "statesMutated" -> {
+                onStateMutationCallback()
+                return byteArrayOf()
+            }
         }
         return when (uri.backendMethodName) {
             "getSchedulingStatesWithContext" -> getSchedulingStatesWithContext()
@@ -472,8 +476,12 @@ class ReviewerViewModel(
             return
         }
         mutationSignal = CompletableDeferred()
+        // https://github.com/ankitects/anki/commit/bd88c6d352dc7aeb4a674029eab7bdda2a821a78
         statesMutationEvalFlow.emit(
-            "anki.mutateNextCardStates('$stateMutationKey', async (states, customData, ctx) => { $js });",
+            """
+            anki.mutateNextCardStates('$stateMutationKey', async (states, customData, ctx) => { $js })
+                .finally(() => fetch("ankidroid/statesMutated", { method: "POST" }));
+            """,
         )
     }
 


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

## Purpose / Description
fix: `testCustomSchedulerWithCustomData`

The bug was that the mutation callback completed immediately. `setSchedulingStates` could be called after a review is persisted.

the page now notifies us of completion
## Fixes
* Fixes #17298

## Approach
To fix this: we mirror Anki Desktop's reviewer.py:

https://github.com/ankitects/anki/commit/bd88c6d352dc7aeb4a674029eab7bdda2a821a78

* https://github.com/ankitects/anki/pull/2421

## How Has This Been Tested?
Unit tested

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)