### PR TITLE
build(ci): allow 10 concurrent github-actions dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+  open-pull-requests-limit: 10
   target-branch: dependency-updates
   labels:
   - "dependencies"


### PR DESCRIPTION
Previously, the default was 5, and this blocked `CodeQL` from a necessary update.

* https://github.com/ankidroid/Anki-Android/pull/21403#issuecomment-5258005630

## How Has This Been Tested?
⚠️ Untested

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)