### PR TITLE
fix: Properly handle spacing for spinner checkmarks

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
@@ -180,7 +180,6 @@ class ChangeNoteTypeDialog : AnalyticsDialogFragment(R.layout.dialog_change_note
         }
     }
 
-    // TODO: Properly handle spacing for spinner checkmarks. Issue not created yet.
     private fun createNoteTypeAdapter(): ArrayAdapter<DisplayNoteType> {
         val noteTypes = viewModel.availableNoteTypes.map { DisplayNoteType(it.name, it.isCloze) }
 

--- a/AnkiDroid/src/main/res/drawable-ldrtl/spinner_dropdown_radio_indicator.xml
+++ b/AnkiDroid/src/main/res/drawable-ldrtl/spinner_dropdown_radio_indicator.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  RTL version of drawable/spinner_dropdown_radio_indicator: in RTL layouts the
+  check mark sits at the start (left), so the text-side inset goes on the right.
+-->
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:drawable="?android:attr/listChoiceIndicatorSingle"
+    android:insetRight="8dp" />

--- a/AnkiDroid/src/main/res/drawable/spinner_dropdown_radio_indicator.xml
+++ b/AnkiDroid/src/main/res/drawable/spinner_dropdown_radio_indicator.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  listChoiceIndicatorSingle with extra space on the text side.
+
+  A CheckedTextView pads its text by exactly the check mark's intrinsic width
+  (drawablePadding does not apply to the check mark), so insetting the
+  indicator is the way to add a gap between the text and the indicator.
+
+  InsetDrawable insets do not auto-mirror; drawable-ldrtl holds the RTL version.
+-->
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:drawable="?android:attr/listChoiceIndicatorSingle"
+    android:insetLeft="8dp" />

--- a/AnkiDroid/src/main/res/layout/item_spinner_dropdown_with_radio.xml
+++ b/AnkiDroid/src/main/res/layout/item_spinner_dropdown_with_radio.xml
@@ -11,7 +11,7 @@
 <CheckedTextView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@android:id/text1"
     style="?android:attr/spinnerDropDownItemStyle"
-    android:checkMark="?android:attr/listChoiceIndicatorSingle"
+    android:checkMark="@drawable/spinner_dropdown_radio_indicator"
     android:singleLine="true"
     android:layout_width="match_parent"
     android:layout_height="?dropdownListPreferredItemHeight"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/SpinnerDropdownWithRadioTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/SpinnerDropdownWithRadioTest.kt
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.ui
+
+import android.content.Context
+import android.graphics.Rect
+import android.view.LayoutInflater
+import android.widget.CheckedTextView
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.R
+import com.ichi2.testutils.createRtlContext
+import com.ichi2.themes.Themes
+import com.ichi2.utils.dp
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.greaterThanOrEqualTo
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Test of [R.layout.item_spinner_dropdown_with_radio]
+ *
+ * https://github.com/ankidroid/Anki-Android/issues/21030
+ */
+@RunWith(AndroidJUnit4::class)
+class SpinnerDropdownWithRadioTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    /**
+     * A [CheckedTextView] pads its text by exactly the check mark's intrinsic width,
+     * so a gap between the text and the visible indicator can only come from padding
+     * declared on the text side of the check mark drawable itself.
+     */
+    @Test
+    fun `text does not touch the radio indicator`() {
+        val view = inflateDropdownItem(context)
+        val padding = Rect().also { view.checkMarkDrawable!!.getPadding(it) }
+        assertThat(
+            "check mark drawable should reserve space on its left (text) side",
+            padding.left,
+            greaterThanOrEqualTo(8.dp.toPx(context)),
+        )
+    }
+
+    /** In RTL layouts, the check mark sits at the start, so the gap belongs on its right. */
+    @Test
+    fun `text does not touch the radio indicator in RTL`() {
+        val view = inflateDropdownItem(context.createRtlContext())
+        val padding = Rect().also { view.checkMarkDrawable!!.getPadding(it) }
+        assertThat(
+            "check mark drawable should reserve space on its right (text) side in RTL",
+            padding.right,
+            greaterThanOrEqualTo(8.dp.toPx(context)),
+        )
+    }
+
+    private fun inflateDropdownItem(context: Context): CheckedTextView {
+        Themes.setTheme(context)
+        return LayoutInflater
+            .from(context)
+            .inflate(R.layout.item_spinner_dropdown_with_radio, null) as CheckedTextView
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/ContextUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/ContextUtils.kt
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.testutils
+
+import android.content.Context
+import android.content.res.Configuration
+import java.util.Locale
+
+/** Returns a [Context] whose configuration uses a right-to-left layout direction */
+fun Context.createRtlContext(): Context {
+    val rtlConfiguration =
+        Configuration(resources.configuration).apply {
+            setLayoutDirection(Locale.forLanguageTag("ar"))
+        }
+    return createConfigurationContext(rtlConfiguration)
+}


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5 - all (comments modified)

## Purpose / Description
Fixes a TODO

<img width="566" height="414" alt="image" src="https://github.com/user-attachments/assets/5f14b6e4-d62d-4310-9faf-95806518bd6a" />


## Fixes
* Fixes #21030

## Approach
* use `InsetDrawable` (8dp) - using a `ldrtl` override for RTL handling

## How Has This Been Tested?

**Before**

<img width="931" height="1044" alt="image" src="https://github.com/user-attachments/assets/8a8cd0e4-bccc-4347-a3bd-319297f26a9f" />

**After**

<img width="960" height="1071" alt="image" src="https://github.com/user-attachments/assets/c4ba2597-42e2-48d5-ab4b-cd621ef7514e" />

**RTL**
<img width="960" height="1026" alt="image" src="https://github.com/user-attachments/assets/ca52df1b-ab9c-44bb-aafc-d341e0aae7ea" />


## Learning (optional, can help others)
`ldrtl` = layour direction; right to left

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)