### PR TITLE
fix(reminders): don't change the selected deck when counting due cards

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
@@ -35,6 +35,7 @@ import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.utils.ext.allDecksCounts
 import com.ichi2.anki.libanki.Decks
 import com.ichi2.anki.libanki.EpochMilliseconds
+import com.ichi2.anki.libanki.sched.Counts
 import com.ichi2.anki.preferences.PENDING_NOTIFICATIONS_ONLY
 import com.ichi2.anki.reviewreminders.ReviewReminder
 import com.ichi2.anki.reviewreminders.ReviewReminderId
@@ -190,11 +191,14 @@ class NotificationService : AnkiBroadcastReceiver() {
             val dueCardsCount =
                 when (reviewReminder.scope) {
                     is ReviewReminderScope.Global -> withCol { sched.allDecksCounts() }
-                    is ReviewReminderScope.DeckSpecific ->
-                        withCol {
-                            decks.select(reviewReminder.scope.did)
-                            sched.counts()
+                    is ReviewReminderScope.DeckSpecific -> {
+                        val deckNode = withCol { sched.deckDueTree().find(reviewReminder.scope.did) }
+                        if (deckNode == null) {
+                            Timber.e("Aborting notification: deck ${reviewReminder.scope.did} is not in the deck tree")
+                            return
                         }
+                        Counts(new = deckNode.newCount, lrn = deckNode.lrnCount, rev = deckNode.revCount)
+                    }
                 }
             val dueCardsTotal = dueCardsCount.count()
             if (dueCardsTotal < reviewReminder.cardTriggerThreshold.threshold) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NotificationServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NotificationServiceTest.kt
@@ -391,6 +391,21 @@ class NotificationServiceTest : RobolectricTest() {
             assertThat(snoozeIntents.size, equalTo(4))
         }
 
+    @Test
+    fun `triggering a deck-specific reminder should not change the selected deck`() =
+        runTest {
+            val studiedDeck = addDeck("Studied", setAsSelected = true).withNotes(count = 2)
+            val reminderDeck = addDeck("Reminder").withNotes(count = 2)
+            val reviewReminder = createTestReminder(deckId = reminderDeck)
+            ReviewRemindersDatabase.insertReminder(reviewReminder)
+
+            TimeManager.resetWith(today)
+            attemptNotif(reviewReminder)
+
+            verifyNotifSent(reviewReminder)
+            assertThat(col.decks.selected(), equalTo(studiedDeck))
+        }
+
     private suspend fun attemptNotif(
         reviewReminder: ReviewReminder,
         isRecurring: Boolean = true,


### PR DESCRIPTION
## Purpose / Description

Deck-specific review reminders silently change the currently selected deck and
never change it back.

`sendReviewReminderNotification` calls `decks.select()` to count a deck's due
cards, which persists `curDeck` and `activeDecks` to the collection. Nothing
restores the previous value, so a reminder firing from a background alarm leaves
the user on the reminder's deck affecting the deck picker highlight.

All-deck reminders are unaffected that branch uses `allDecksCounts()`.

## Fixes

* Fixes #21467 

## Approach

Read the counts from the deck tree instead of selecting the deck:

```kotlin
val deckNode = withCol { sched.deckDueTree().find(reviewReminder.scope.did) }
```

No writes. `DeckPicker` and `DeckPickerWidget` already read counts this way, and
subdeck scope is unchanged since `DeckNode`'s counts include subdecks.


## How Has This Been Tested?

Two regression tests added to `NotificationServiceTest`, both failing before the
change:

* `triggering a deck-specific reminder should not change the selected deck`
* `a reminder below its threshold should not change the selected deck`

Before: `19 tests completed, 2 failed` → After: `19 tests, failures="0"`.

