### PR TITLE
fix(card-browser): add fast path to reduce chance of ANRs

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -514,10 +514,18 @@ open class CardBrowser :
                 when (command) {
                     is NoteEditorCommand.LoadInPane -> {
                         binding.noteEditorFrame?.isVisible = true
-                        if (fragment?.hasUnsavedChanges() == true) {
-                            showSaveChangesDialog(command.launcher)
-                        } else {
-                            loadNoteEditorFragment(command.launcher)
+                        val editor = fragment
+                        when {
+                            // #19737: the pane already displays this selection. Refresh it in
+                            // place: recreating the fragment is expensive enough to ANR when
+                            // searches complete in quick succession. If there are unsaved
+                            // changes, keep them: this is a redundant refresh, not a navigation
+                            editor != null && editor.isEditingSameCards(command.launcher) ->
+                                if (!editor.hasUnsavedChanges()) {
+                                    editor.reloadNoteFromCollection()
+                                }
+                            editor?.hasUnsavedChanges() == true -> showSaveChangesDialog(command.launcher)
+                            else -> loadNoteEditorFragment(command.launcher)
                         }
                     }
                     is NoteEditorCommand.LaunchActivity -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -1188,6 +1188,30 @@ class NoteEditorFragment :
 
     private fun collectionHasLoaded(): Boolean = allNoteTypeIds != null
 
+    /**
+     * Whether this fragment is editing the cards which [launcher] targets.
+     */
+    fun isEditingSameCards(launcher: NoteEditorLauncher): Boolean {
+        if (launcher !is NoteEditorLauncher.EditSelection) return false
+        if (arguments?.getInt(EXTRA_CALLER) != NoteEditorCaller.EDIT.value) return false
+        return cardIdsFromArguments?.asList() == launcher.cardIds
+    }
+
+    /**
+     * Reloads the current note from the collection and rebuilds the fields, e.g. after the
+     * note was updated by another component (find & replace in the Card Browser).
+     *
+     * Unsaved edits are discarded: check [hasUnsavedChanges] before calling.
+     */
+    fun reloadNoteFromCollection() {
+        Timber.i("reloadNoteFromCollection()")
+        val cardId = currentEditedCard?.id ?: return
+        currentEditedCard = getColUnsafe.getCard(cardId)
+        // reset so setNote() reloads the tags of the note
+        selectedTags = null
+        setNote(currentEditedCard!!.note(getColUnsafe), FieldChangeType.refresh(shouldReplaceNewlines()))
+    }
+
     // ----------------------------------------------------------------------------
     // SAVE NOTE METHODS
     // ----------------------------------------------------------------------------

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -106,6 +106,7 @@ import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.instanceOf
 import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.CoreMatchers.sameInstance
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.greaterThan
@@ -1726,6 +1727,43 @@ class CardBrowserTest : RobolectricTest() {
                 )
 
             assertMenusEqual(expectedMenuItems, menu)
+        }
+
+    @Test // #19737 - recreating the editor is expensive enough to ANR when repeated
+    fun `pane editor is not recreated when a search returns the same row`() =
+        withBrowser(noteCount = 2, fragmented = true) {
+            val editorBeforeRefresh = assertNotNull(fragment, "note editor fragment")
+
+            // every `opExecuted` calls refreshBrowserUI() -> a new search
+            // the focused row is unchanged, so the pane editor does not need to be recreated
+            searchCards()
+            advanceRobolectricLooper()
+
+            assertThat("the pane editor is reused", fragment, sameInstance(editorBeforeRefresh))
+        }
+
+    @Test // #19737
+    fun `pane editor refreshes when the note changes outside the editor`() =
+        withBrowser(noteCount = 1, fragmented = true) {
+            val editor = assertNotNull(fragment, "note editor fragment")
+            assertThat(editor.getFieldForTest(0).fieldText, equalTo("0"))
+
+            // simulate 'find & replace' in the browser: the note changes,
+            // then opExecuted calls refreshBrowserUI() -> a new search
+            val cardId = assertNotNull(viewModel.focusedRow?.toCardId(viewModel.cardsOrNotes))
+            withCol {
+                val note = getCard(cardId).note(this)
+                note.setField(0, "replaced")
+                updateNote(note)
+            }
+            searchCards()
+            advanceRobolectricLooper()
+
+            assertThat(
+                "the pane editor shows the updated note",
+                fragment?.getFieldForTest(0)?.fieldText,
+                equalTo("replaced"),
+            )
         }
 
     @Test


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

## Purpose / Description
Rebuilding the fragment can cause an ANR

## Fixes
* Part of #19737

> [!CAUTION]
> I will mark the rest of this issue as WONTFIX - there are other paths which may cause ANRs on less powerful phones, but that needs a rewrite of `NoteEditorFragment` for async loading

## Approach
This adds a fast path when the fragment does not need to be rebuilt.

## How Has This Been Tested?
Unit tested

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)