### PR TITLE
fix(card-browser): replace `focusedRow` with `paneRow`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
@@ -265,7 +265,8 @@ class BrowserMultiColumnAdapter(
             }
             holder.setIsSelected(isSelected)
             val rowColor =
-                if (viewModel.isFragmented && viewModel.focusedRow == id) {
+                // This only highlights in fragmented mode
+                if (viewModel.paneRow == id) {
                     ThemeUtils.getThemeAttrColor(context, R.attr.focusedRowBackgroundColor)
                 } else {
                     backendColorToColor(row.color)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -207,8 +207,8 @@ class CardBrowserFragment :
             }
         }
 
-    /** The focused row, should only be used for efficient `notifyItemChanged` calls */
-    private var focusedRow: CardOrNoteId? = null
+    /** The pane row, should only be used for efficient `notifyItemChanged` calls */
+    private var paneRow: CardOrNoteId? = null
 
     // Dev option for Issue 18709
     // The old layout's MenuProvider is coupled to the activity's toolbar, which causes
@@ -970,10 +970,10 @@ class CardBrowserFragment :
 
         fun onSelectedRowsChanged(rows: Set<Any>) = cardsAdapter.notifyDataSetChanged()
 
-        fun onFocusedRowChanged(newFocused: CardOrNoteId?) {
-            val previous = focusedRow
-            focusedRow = newFocused
-            listOfNotNull(previous, newFocused)
+        fun onPaneRowChanged(newPaneRow: CardOrNoteId?) {
+            val previous = paneRow
+            paneRow = newPaneRow
+            listOfNotNull(previous, newPaneRow)
                 .distinct()
                 .mapNotNull { activityViewModel.getPositionOfId(it) }
                 .forEach { cardsAdapter.notifyItemChanged(it) }
@@ -1166,7 +1166,7 @@ class CardBrowserFragment :
         activityViewModel.flowOfReverseDirection.launchCollectionInLifecycleScope(::reverseDirectionChanged)
         activityViewModel.flowOfIsTruncated.launchCollectionInLifecycleScope(::onIsTruncatedChanged)
         activityViewModel.flowOfSelectedRows.launchCollectionInLifecycleScope(::onSelectedRowsChanged)
-        activityViewModel.flowOfFocusedRow.launchCollectionInLifecycleScope(::onFocusedRowChanged)
+        activityViewModel.flowOfPaneRow.launchCollectionInLifecycleScope(::onPaneRowChanged)
         activityViewModel.flowOfActiveColumns.launchCollectionInLifecycleScope(::onColumnsChanged)
         activityViewModel.flowOfCardsUpdated.launchCollectionInLifecycleScope(::cardsUpdatedChanged)
         activityViewModel.flowOfMultiSelectModeChanged.launchCollectionInLifecycleScope(::onMultiSelectModeChanged)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -190,15 +190,18 @@ class CardBrowserViewModel(
     val cardsOrNotes get() = flowOfCardsOrNotes.value
 
     /**
-     * Ensures [focusedRow] points to a row in the current [cards] list, falling back to the
-     * first row when [focusedRow] no longer visible.
+     * Ensures [paneRow] points to a row in the current [cards] list, falling back to the
+     * first row when [paneRow] no longer visible.
+     *
+     * No-op on phones.
      */
-    private fun ensureFocusedRowValid() {
-        focusedRow =
+    private fun ensurePaneRowValid() {
+        paneRow =
             when {
+                !isFragmented -> null
                 cards.isEmpty() -> null
-                focusedRow == null || focusedRow !in cards -> cards.first()
-                else -> focusedRow
+                paneRow == null || paneRow !in cards -> cards.first()
+                else -> paneRow
             }
     }
 
@@ -313,12 +316,21 @@ class CardBrowserViewModel(
      */
     val flowOfSaveSearchNamePrompt = MutableSharedFlow<String>()
 
-    val flowOfFocusedRow: StateFlow<CardOrNoteId?>
+    /**
+     * The row whose note is loaded in the trailing pane ([isFragmented] mode only).
+     *
+     * `null` when the pane displays no row:
+     * * on phones.
+     * * when there are no search results.
+     *
+     * @see NoteEditorCommand
+     */
+    val flowOfPaneRow: StateFlow<CardOrNoteId?>
         field = MutableStateFlow<CardOrNoteId?>(null)
-    var focusedRow: CardOrNoteId?
-        get() = flowOfFocusedRow.value
+    var paneRow: CardOrNoteId?
+        get() = flowOfPaneRow.value
         private set(value) {
-            flowOfFocusedRow.value = value
+            flowOfPaneRow.value = value
         }
 
     suspend fun queryAllSelectedCardIds() = selectedRows.queryCardIds(this.cardsOrNotes)
@@ -326,13 +338,14 @@ class CardBrowserViewModel(
     suspend fun queryAllSelectedNoteIds() = selectedRows.queryNoteIds(this.cardsOrNotes)
 
     /**
-     * Returns the list of Card IDs that should be updated.
+     * Returns the list of Card IDs that should be updated when editing [row].
      *
-     * In 'Notes' mode, this includes all cards of the current note (sibling cards).
+     * In 'Notes' mode, this includes all cards of the row's note (sibling cards).
      * In 'Cards' mode, this returns only the selected cards.
      */
-    suspend fun getCardIdsForNoteEditor(): List<CardId> {
-        val cardId = focusedRow?.toCardId(cardsOrNotes) ?: return emptyList()
+    suspend fun getCardIdsForNoteEditor(row: CardOrNoteId): List<CardId> {
+        // a note row maps to no cards in a corrupted collection: see toCardId
+        val cardId = row.toCardId(cardsOrNotes) ?: return emptyList()
 
         return if (cardsOrNotes == NOTES) {
             withCol {
@@ -347,9 +360,9 @@ class CardBrowserViewModel(
         }
     }
 
-    /** Builds a [NoteEditorLauncher] for the current selection, or `null` if there's nothing to edit. */
-    suspend fun editNoteLauncher(): NoteEditorLauncher? {
-        val cardIds = getCardIdsForNoteEditor()
+    /** Builds a [NoteEditorLauncher] to edit [row], or `null` if there's nothing to edit. */
+    suspend fun editNoteLauncher(row: CardOrNoteId): NoteEditorLauncher? {
+        val cardIds = getCardIdsForNoteEditor(row)
         if (cardIds.isEmpty()) {
             Timber.w("EditSelection skipped: card list is empty")
             return null
@@ -664,10 +677,10 @@ class CardBrowserViewModel(
             if (isInMultiSelectMode) {
                 val wasSelected = id in selectedRows
                 toggleRowSelection(rowSelection)
-                // when in mutliselect, only deselecting should cause a change in focus
+                // when in mutliselect, only deselecting should update the pane
                 if (wasSelected && isFragmented) {
-                    focusedRow = id
-                    editNoteLauncher()?.let { flowOfNoteEditorCommand.emit(NoteEditorCommand.LoadInPane(it)) }
+                    paneRow = id
+                    editNoteLauncher(id)?.let { flowOfNoteEditorCommand.emit(NoteEditorCommand.LoadInPane(it)) }
                 }
             } else {
                 setNoteEditorRow(id)
@@ -682,7 +695,6 @@ class CardBrowserViewModel(
             } else {
                 toggleRowSelection(rowSelection)
             }
-            focusedRow = id
         }
 
     /**
@@ -696,23 +708,23 @@ class CardBrowserViewModel(
             } else {
                 toggleRowSelection(rowSelection)
             }
-            focusedRow = id
         }
     }
 
     /**
      * Opens the note editor for the given row.
      *
-     * @param row The row to focus and open in the note editor.
-     * Passing `null` indicates that no row is selected and will close the note editor.
+     * When [fragmented][isFragmented], [row] is loaded in the trailing pane and becomes the
+     * [paneRow], otherwise the standalone NoteEditor activity is launched.
      */
-    private fun setNoteEditorRow(row: CardOrNoteId?) =
+    private fun setNoteEditorRow(row: CardOrNoteId) =
         viewModelScope.launch {
-            focusedRow = row
-            if (!isFragmented) {
+            if (isFragmented) {
+                paneRow = row
+            } else {
                 endMultiSelectMode(SingleSelectCause.OpenNoteEditorActivity)
             }
-            val launcher = editNoteLauncher() ?: return@launch
+            val launcher = editNoteLauncher(row) ?: return@launch
             flowOfNoteEditorCommand.emit(
                 if (isFragmented) NoteEditorCommand.LoadInPane(launcher) else NoteEditorCommand.LaunchActivity(launcher),
             )
@@ -767,9 +779,9 @@ class CardBrowserViewModel(
     @NeedsTest("Deleting the focused row is properly handled;#18639")
     suspend fun deleteSelectedNotes(): Int {
         val cardIds = queryAllSelectedCardIds()
-        // reset focused row if that row is about to be deleted
-        if (focusedRow?.cardOrNoteId in cardIds) {
-            focusedRow = null
+        // reset the pane row if that row is about to be deleted
+        if (paneRow?.cardOrNoteId in cardIds) {
+            paneRow = null
         }
         return undoableOp(this@CardBrowserViewModel) { removeNotes(cardIds = cardIds) }
             .count
@@ -1398,7 +1410,7 @@ class CardBrowserViewModel(
 
                     ensureActive()
                     this@CardBrowserViewModel.cards.replaceWith(cardsOrNotes, cards)
-                    ensureFocusedRowValid()
+                    ensurePaneRowValid()
                     if (isFragmented) flowOfNoteEditorCommand.emit(NoteEditorCommand.fromCurrentSearchState())
                     flowOfSearchState.emit(SearchState.Completed.fromCurrentState(fromUserSearch))
                     selectUnvalidatedRowIds(cardOrNoteIdsToSelect)
@@ -1528,7 +1540,8 @@ class CardBrowserViewModel(
 
     /** Builds the post-search trailing-pane command from current ViewModel state (tablet only). */
     private suspend fun NoteEditorCommand.Companion.fromCurrentSearchState(): NoteEditorCommand =
-        editNoteLauncher()?.let { NoteEditorCommand.LoadInPane(it) } ?: NoteEditorCommand.HidePane
+        paneRow?.let { row -> editNoteLauncher(row) }?.let { NoteEditorCommand.LoadInPane(it) }
+            ?: NoteEditorCommand.HidePane
 
     companion object {
         /** Intent extra carrying the [DeckId] the browser should open scoped to. */

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -1386,7 +1386,7 @@ class CardBrowserViewModelTest : JvmTest() {
                     awaitItem(),
                     "phone tap launches a standalone NoteEditor activity",
                 )
-                assertThat("focusedRow set to tapped row", focusedRow, equalTo(getRowAtPosition(1)))
+                assertThat("phone: no pane -> no pane row", paneRow, nullValue())
                 assertThat("not in multi-select after tap", isInMultiSelectMode, equalTo(false))
             }
         }
@@ -1424,7 +1424,7 @@ class CardBrowserViewModelTest : JvmTest() {
         }
 
     @Test
-    fun `onTap deselect on tablet emits selection event with focused id`() =
+    fun `onTap deselect on tablet reloads the pane with the deselected row`() =
         runViewModelTest(notes = 2, isFragmented = true) {
             selectRowAtPosition(0)
             selectRowAtPosition(1)
@@ -1435,29 +1435,30 @@ class CardBrowserViewModelTest : JvmTest() {
                     awaitItem(),
                     "tablet deselect loads the editor in the trailing pane",
                 )
-                assertThat("focusedRow points at deselected row", focusedRow, equalTo(deselectedId))
+                assertThat("paneRow points at deselected row", paneRow, equalTo(deselectedId))
             }
         }
 
     @Test
-    fun `onTap add-to-multi-select on tablet does not move focus`() =
+    fun `onTap add-to-multi-select on tablet does not move the pane row`() =
         runViewModelTest(notes = 3, isFragmented = true) {
-            // long-press row 1 to enter multi-select; focus and selection both land on row 1
+            // open row 1 in the pane, then long-press it to enter multi-select
+            onTap(getRowAtPosition(1).toRowSelection()).join()
             handleRowLongPress(getRowAtPosition(1).toRowSelection()).join()
-            assertThat("initial focus on row 1", focusedRow, equalTo(getRowAtPosition(1)))
+            assertThat("pane shows row 1", paneRow, equalTo(getRowAtPosition(1)))
 
-            // tap row 2 to ADD it to the selection — focus must stay on row 1
+            // tap row 2 to ADD it to the selection - the pane must not change
             flowOfNoteEditorCommand.test {
                 onTap(getRowAtPosition(2).toRowSelection()).join()
                 expectNoEvents() // no editor reload
-                assertThat("focus unchanged after add-to-multi-select", focusedRow, equalTo(getRowAtPosition(1)))
+                assertThat("pane unchanged after add-to-multi-select", paneRow, equalTo(getRowAtPosition(1)))
                 assertThat("row 2 was added to selection", getRowAtPosition(2) in selectedRows, equalTo(true))
             }
         }
 
     @Test
-    fun `stale focusedRow falls back to first card after search`() =
-        runViewModelTest {
+    fun `stale paneRow falls back to first card after search`() =
+        runViewModelTest(isFragmented = true) {
             val deckOne = addDeck("One")
             val deckTwo = addDeck("Two")
             addNoteToDeck(deckOne)
@@ -1466,13 +1467,49 @@ class CardBrowserViewModelTest : JvmTest() {
             setSelectedDeck(deckTwo)
             searchJob?.join()
             val deckTwoRow = cards.first()
-            handleRowLongPress(deckTwoRow.toRowSelection()).join()
-            assertThat("initial focus is on the deckTwo row", focusedRow, equalTo(deckTwoRow))
+            onTap(deckTwoRow.toRowSelection()).join()
+            assertThat("pane shows the deckTwo row", paneRow, equalTo(deckTwoRow))
 
             setSelectedDeck(deckOne)
             searchJob?.join()
-            assertThat("focusedRow no longer points to filtered-out row", focusedRow, not(equalTo(deckTwoRow)))
-            assertThat("focusedRow falls back to first row of new search", focusedRow, equalTo(cards.first()))
+            assertThat("paneRow no longer points to filtered-out row", paneRow, not(equalTo(deckTwoRow)))
+            assertThat("paneRow falls back to first row of new search", paneRow, equalTo(cards.first()))
+        }
+
+    @Test
+    fun `pane row is unused on phones`() =
+        runViewModelTest(notes = 2, isFragmented = false) {
+            searchJob?.join()
+            assertThat("phone: no pane -> no pane row after search", paneRow, nullValue())
+
+            onTap(getRowAtPosition(1).toRowSelection()).join()
+            assertThat("phone: no pane -> no pane row after tap", paneRow, nullValue())
+        }
+
+    @Test
+    fun `long press does not change the pane row`() =
+        runViewModelTest(notes = 2, isFragmented = true) {
+            onTap(getRowAtPosition(0).toRowSelection()).join()
+            assertThat("pane shows the tapped row", paneRow, equalTo(getRowAtPosition(0)))
+
+            handleRowLongPress(getRowAtPosition(1).toRowSelection()).join()
+            assertThat("row 1 is selected", getRowAtPosition(1) in selectedRows, equalTo(true))
+            assertThat("pane still shows the opened row", paneRow, equalTo(getRowAtPosition(0)))
+        }
+
+    @Test
+    fun `deleting the pane row falls back to the first remaining row`() =
+        runViewModelTest(notes = 2, isFragmented = true) {
+            searchJob?.join()
+            val toDelete = getRowAtPosition(1)
+            // open row 1 in the pane, then long-press it to select it
+            onTap(toDelete.toRowSelection()).join()
+            handleRowLongPress(toDelete.toRowSelection()).join()
+
+            deleteSelectedNotes()
+            searchJob?.join()
+            assertThat("deleted row is no longer displayed", toDelete !in cards, equalTo(true))
+            assertThat("pane falls back to the first remaining row", paneRow, equalTo(cards.first()))
         }
 
     @Test


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

## Purpose / Description
I found `focusedRow` to be complex, and have been working to simplify it.

## Fixes
* Fixes #19805

## Approach

Somewhat considered a follow on from:
* https://github.com/ankidroid/Anki-Android/pull/20876
  * 7681feb1a29db061f7240634f6a05bf09757ff29

This conceptually splits the active row in the pane from focus and selection, simplifying how the screen is modelled.

* `paneRow` is always null on mobile
* a long press no longer moves the highlight away from the pane selection

## How Has This Been Tested?
Unit tests

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)