### PR TITLE
build: allow specifying an ABI to build: `-PabiFilter`

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -246,12 +246,26 @@ android {
      */
     def enableSeparateBuildPerCPUArchitecture = true
 
+    /**
+     * Restricts the build to a single CPU architecture, e.g. `-PabiFilter=arm64-v8a`.
+     * Allows F-Droid to build one APK per architecture without patching this file (#21399).
+     */
+    def abiFilter = providers.gradleProperty("abiFilter").getOrNull()
+    def supportedAbis = ["armeabi-v7a", "x86", "arm64-v8a", "x86_64"]
+    if (abiFilter != null && !supportedAbis.contains(abiFilter)) {
+        throw new GradleException("Unsupported -PabiFilter value '$abiFilter'. Expected one of: $supportedAbis")
+    }
+
     splits {
         abi {
             reset()
             enable = enableSeparateBuildPerCPUArchitecture
             //universalApk enableUniversalApk  // set in debug + release config blocks above
-            include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
+            if (abiFilter != null) {
+                include abiFilter
+            } else {
+                include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
+            }
         }
     }
     // applicationVariants are e.g. debug, release


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

## Rationale
A user requested this, I looked into the F-Droid implementation, and this flag would reduce complexity on their side.

Note that I defer the decision on the ABI to ship to the F-Droid maintainers. I'm surprised they would only want an `arm64-v8a` apk.

## Fixes

* Fixes #21399

## Approach

Specify a flag which F-Droid can use:

e.g. `-PabiFilter=arm64-v8a`

```yaml
  gradle:
    - full
  gradleprops:
    - abiFilter=arm64-v8a
```

## Testing

⚠️ None

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
