### PR TITLE
refactor(navigation): migrate import search to `BrowserDestination`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackendImporting.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackendImporting.kt
@@ -3,14 +3,14 @@
 
 package com.ichi2.anki
 
-import android.content.Intent
 import android.net.Uri
 import androidx.fragment.app.FragmentActivity
 import anki.collection.OpChangesOnly
 import anki.import_export.ImportAnkiPackageRequest
 import anki.search.SearchNode
 import com.ichi2.anki.CollectionManager.withCol
-import com.ichi2.anki.browser.CardBrowserViewModel
+import com.ichi2.anki.common.destinations.BrowserDestination
+import com.ichi2.anki.common.destinations.navigate
 import com.ichi2.anki.libanki.importCsvRaw
 import com.ichi2.anki.observability.undoableOp
 import kotlinx.coroutines.Dispatchers
@@ -60,11 +60,6 @@ val hideShowButtonCss =
  */
 suspend fun FragmentActivity.searchInBrowser(input: ByteArray): ByteArray {
     val searchString = withCol { buildSearchString(listOf(SearchNode.parseFrom(input))) }
-    val starterIntent =
-        Intent(this, CardBrowser::class.java).apply {
-            putExtra(CardBrowserViewModel.EXTRA_SEARCH_QUERY, searchString)
-            putExtra(CardBrowserViewModel.EXTRA_ALL_DECKS, true)
-        }
-    startActivity(starterIntent)
+    navigate(BrowserDestination.Search(query = searchString, allDecks = true))
     return input
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserDestination.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserDestination.kt
@@ -19,4 +19,9 @@ fun BrowserDestination.toIntent(context: Context): Intent =
                 putExtra(CardBrowserViewModel.EXTRA_DECK_ID, deckId)
                 putExtra(CardBrowserViewModel.EXTRA_CARD_ID_KEY, cardId)
             }
+        is BrowserDestination.Search ->
+            Intent(context, CardBrowser::class.java).apply {
+                putExtra(CardBrowserViewModel.EXTRA_SEARCH_QUERY, query)
+                putExtra(CardBrowserViewModel.EXTRA_ALL_DECKS, allDecks)
+            }
     }

--- a/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/BrowserDestination.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/BrowserDestination.kt
@@ -21,4 +21,14 @@ sealed class BrowserDestination : Destination() {
         val deckId: DeckId,
         val cardId: CardId,
     ) : BrowserDestination()
+
+    /**
+     * Opens the Card Browser, searching for [query].
+     *
+     * @param allDecks if `true`, search all decks instead of the selected deck
+     */
+    data class Search(
+        val query: String,
+        val allDecks: Boolean,
+    ) : BrowserDestination()
 }


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

## Fixes
* Part of #20558

## Approach
Adds a 'BrowserDestination.Search' variant and migrates 'searchInBrowser' from a raw CardBrowser intent to 'navigate()'.

## How Has This Been Tested?
Untested - obvious

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)