### PR TITLE
test(baseline): ensure `DeckPicker.onResume` exists

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/BaselineProfileEntry.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/BaselineProfileEntry.kt
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package com.ichi2.anki
+
+/**
+ * A single rule in a human-readable baseline profile (`baseline-prof.txt`):
+ * either a [ClassRule] or a [MethodRule].
+ *
+ * ```
+ * Lcom/ichi2/anki/DeckPicker;                 (class rule: no flags)
+ * SPLcom/ichi2/anki/DeckPicker;->onResume()V  (method rule: flags S and P)
+ * ```
+ *
+ * A class rule preloads the class; a method rule marks the method for
+ * ahead-of-time compilation, with flags recording when it was observed
+ * executing while the profile was generated.
+ *
+ * See https://developer.android.com/topic/performance/baselineprofiles/manually-create-measure#manually-define-rules
+ */
+sealed interface BaselineProfileEntry {
+    /** JVM class descriptor, e.g. `Lcom/ichi2/anki/DeckPicker;`. */
+    val classDescriptor: String
+
+    /** [classDescriptor] as a source-style name: `com.ichi2.anki.DeckPicker`. */
+    val className: String
+        get() = classDescriptor.removePrefix("L").removeSuffix(";").replace('/', '.')
+
+    /** Preloads the class at install time. */
+    data class ClassRule(
+        override val classDescriptor: String,
+    ) : BaselineProfileEntry {
+        override fun toString() = classDescriptor
+    }
+
+    /**
+     * Marks the method for ahead-of-time compilation.
+     *
+     * @param flags when the method was observed executing; never empty
+     * @param methodSignature method name and JVM type signature, e.g. `onResume()V`
+     */
+    data class MethodRule(
+        val flags: Set<Flag>,
+        override val classDescriptor: String,
+        val methodSignature: String,
+    ) : BaselineProfileEntry {
+        init {
+            require(flags.isNotEmpty()) { "method rule requires at least one flag: '$this'" }
+        }
+
+        /** Method name without its type signature: `onResume`. */
+        val methodName: String get() = methodSignature.substringBefore('(')
+
+        override fun toString(): String {
+            // Flag.entries, not flags: emit in the format's canonical H, S, P order.
+            val flagString = Flag.entries.filter { it in flags }.joinToString("") { it.char.toString() }
+            return "$flagString$classDescriptor$METHOD_SEPARATOR$methodSignature"
+        }
+    }
+
+    /** When a method was observed executing during profile generation. */
+    enum class Flag(
+        val char: Char,
+    ) {
+        /** Executed enough times to be considered 'hot'. */
+        HOT('H'),
+
+        /** Executed during app startup; AOT-compiled for it. */
+        STARTUP('S'),
+
+        /** Executed after startup (e.g. scrolling, animation). */
+        POST_STARTUP('P'),
+        ;
+
+        companion object {
+            fun fromChar(char: Char): Flag? = entries.firstOrNull { it.char == char }
+        }
+    }
+
+    companion object {
+        private const val METHOD_SEPARATOR = "->"
+
+        fun parseProfile(lines: List<String>): List<BaselineProfileEntry> =
+            lines
+                .filter { it.isNotBlank() && !it.startsWith('#') }
+                .map { parse(it) }
+
+        fun parse(line: String): BaselineProfileEntry {
+            val descriptorStart = line.indexOfFirst { Flag.fromChar(it) == null }
+            require(descriptorStart >= 0 && line[descriptorStart] == 'L') { "malformed rule: '$line'" }
+            val flags = line.take(descriptorStart).mapTo(mutableSetOf()) { Flag.fromChar(it)!! }
+            val descriptor = line.substring(descriptorStart)
+
+            if (METHOD_SEPARATOR in descriptor) {
+                return MethodRule(
+                    flags = flags,
+                    classDescriptor = descriptor.substringBefore(METHOD_SEPARATOR),
+                    methodSignature = descriptor.substringAfter(METHOD_SEPARATOR),
+                )
+            }
+            // Flags record when a *method* executed; a flagged class rule is malformed.
+            require(flags.isEmpty()) { "malformed rule: '$line'" }
+            return ClassRule(descriptor)
+        }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/BaselineProfileEntryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/BaselineProfileEntryTest.kt
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki
+
+import com.ichi2.anki.BaselineProfileEntry.ClassRule
+import com.ichi2.anki.BaselineProfileEntry.Flag
+import com.ichi2.anki.BaselineProfileEntry.MethodRule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+class BaselineProfileEntryTest {
+    @Test
+    fun `parses a method rule`() {
+        val rule = BaselineProfileEntry.parse("SPLcom/ichi2/anki/DeckPicker;->onResume()V")
+
+        assertIs<MethodRule>(rule)
+        assertEquals(setOf(Flag.STARTUP, Flag.POST_STARTUP), rule.flags)
+        assertEquals("Lcom/ichi2/anki/DeckPicker;", rule.classDescriptor)
+        assertEquals("onResume()V", rule.methodSignature)
+        assertEquals("com.ichi2.anki.DeckPicker", rule.className)
+        assertEquals("onResume", rule.methodName)
+        assertEquals("SPLcom/ichi2/anki/DeckPicker;->onResume()V", rule.toString())
+    }
+
+    @Test
+    fun `parses a class rule`() {
+        val rule = BaselineProfileEntry.parse("Lcom/ichi2/anki/DeckPicker;")
+
+        assertIs<ClassRule>(rule)
+        assertEquals("Lcom/ichi2/anki/DeckPicker;", rule.classDescriptor)
+        assertEquals("com.ichi2.anki.DeckPicker", rule.className)
+        assertEquals("Lcom/ichi2/anki/DeckPicker;", rule.toString())
+    }
+
+    @Test
+    fun `parses an inner class`() {
+        val rule = BaselineProfileEntry.parse("HLcom/ichi2/anki/DeckPicker\$Companion;->foo(I)Z")
+
+        assertIs<MethodRule>(rule)
+        assertEquals(setOf(Flag.HOT), rule.flags)
+        assertEquals("com.ichi2.anki.DeckPicker\$Companion", rule.className)
+        assertEquals("foo", rule.methodName)
+    }
+
+    @Test
+    fun `parseProfile skips blank lines and comments`() {
+        val lines =
+            listOf(
+                "# Baseline profile rules for AnkiDroid",
+                "",
+                "Lcom/ichi2/anki/DeckPicker;",
+                "  ",
+                "SPLcom/ichi2/anki/DeckPicker;->onResume()V",
+            )
+
+        val rules = BaselineProfileEntry.parseProfile(lines)
+
+        assertEquals(
+            listOf("Lcom/ichi2/anki/DeckPicker;", "SPLcom/ichi2/anki/DeckPicker;->onResume()V"),
+            rules.map { it.toString() },
+        )
+    }
+
+    @Test
+    fun `parseProfile still rejects malformed rules`() {
+        assertFailsWith<IllegalArgumentException> {
+            BaselineProfileEntry.parseProfile(listOf("Lcom/ichi2/anki/DeckPicker;", "XLcom/ichi2/anki/DeckPicker;"))
+        }
+    }
+
+    @Test
+    fun `rejects malformed rules`() {
+        val malformed =
+            listOf(
+                // empty
+                "",
+                // flags without a descriptor
+                "SP",
+                // descriptor not starting with L
+                "com/ichi2/anki/DeckPicker;",
+                // unknown flag
+                "XLcom/ichi2/anki/DeckPicker;",
+                // class rule with flags
+                "SLcom/ichi2/anki/DeckPicker;",
+                // method rule without flags
+                "Lcom/ichi2/anki/DeckPicker;->onResume()V",
+            )
+        for (line in malformed) {
+            assertFailsWith<IllegalArgumentException>("expected '$line' to be rejected") {
+                BaselineProfileEntry.parse(line)
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/BaselineProfileTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/BaselineProfileTest.kt
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki
+
+import com.ichi2.anki.BaselineProfileEntry.Flag
+import com.ichi2.anki.BaselineProfileEntry.MethodRule
+import org.junit.Test
+import java.io.File
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Ensures a manual run of the baseline profile won't drop rules.
+ */
+class BaselineProfileTest {
+    /**
+     * [DeckPicker.onResume] runs on every launch before the deck list is
+     * usable, so it must stay ahead-of-time compiled.
+     *
+     * See https://github.com/ankidroid/Anki-Android/issues/20734
+     */
+    @Test
+    fun `profile contains a startup rule for DeckPicker onResume`() {
+        val profile = File("src/main/generated/baselineProfiles/baseline-prof.txt")
+        assertTrue(profile.exists(), "baseline profile not found at ${profile.absolutePath}")
+
+        val rules = BaselineProfileEntry.parseProfile(profile.readLines())
+        val rule =
+            rules.filterIsInstance<MethodRule>().firstOrNull {
+                it.className == "com.ichi2.anki.DeckPicker" && it.methodSignature == "onResume()V"
+            }
+
+        assertNotNull(
+            rule,
+            "No rule for DeckPicker.onResume() in ${profile.name}: the method is " +
+                "no longer ahead-of-time compiled. Ensure the BaselineProfileGenerator " +
+                "journey reaches DeckPicker, then regenerate (baselineprofile/README.md).",
+        )
+        assertTrue(
+            Flag.STARTUP in rule.flags,
+            "'$rule' lost the S (startup) flag: DeckPicker.onResume() no longer runs " +
+                "inside the profiled startup window. Check the BaselineProfileGenerator " +
+                "journey, then regenerate (baselineprofile/README.md).",
+        )
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5 - I directed Claude to heavily engineer the parser

## Purpose / Description
Baseline profiles are generated manually, we need to be sure they're not broken.

## Fixes
* Fixes #20734

## Approach
Add a parser for the file format, to explain the domain

Then write a test

## How Has This Been Tested?
Test-only 

## Learning (optional, can help others)
https://developer.android.com/topic/performance/baselineprofiles/manually-create-measure#manually-define-rules

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)