### PR TITLE
feat(sync): Media failure notifications are expandable and copyable (fixup of #20976)

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -530,6 +530,11 @@
                 />
         </receiver>
 
+        <!-- Copy Sync Error Message to Clipboard -->
+        <receiver
+            android:name="com.ichi2.anki.receiver.CopyToClipboardReceiver"
+            android:exported="false" />
+
         <!-- "Add Note" widget -->
         <receiver
             android:name="com.ichi2.widget.AddNoteWidget"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/receiver/CopyToClipboardReceiver.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/receiver/CopyToClipboardReceiver.kt
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2026 LUwUcifer <luwucifwer@proton.me>
+package com.ichi2.anki.receiver
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationManagerCompat
+import com.ichi2.anki.R
+import com.ichi2.anki.common.utils.android.showThemedToast
+import com.ichi2.anki.notifications.NotificationId
+import com.ichi2.utils.copyToClipboard
+import timber.log.Timber
+
+/**
+ * Copies [EXTRA_SYNC_ERROR_LOG] to the clipboard and dismisses the media sync notification.
+ *
+ * @see com.ichi2.anki.worker.SyncMediaWorker
+ */
+class CopyToClipboardReceiver : BroadcastReceiver() {
+    override fun onReceive(
+        context: Context,
+        intent: Intent,
+    ) {
+        val text =
+            intent.getStringExtra(EXTRA_SYNC_ERROR_LOG) ?: run {
+                Timber.w("CopyToClipboardReceiver: no error log found")
+                showThemedToast(context, R.string.something_wrong, shortLength = true)
+                return
+            }
+        // only dismiss the notification once the text is safely on the clipboard
+        if (context.copyToClipboard(text)) {
+            NotificationManagerCompat.from(context).cancel(NotificationId.SYNC_MEDIA)
+        }
+    }
+
+    companion object {
+        const val EXTRA_SYNC_ERROR_LOG = "syncErrorLog"
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
@@ -129,6 +129,9 @@ object SentenceCase {
     context(_: Fragment)
     val toggleSuspend get() = TR.browsingToggleSuspend().toSentenceCase(R.string.sentence_toggle_suspend)
 
+    context(_: Context)
+    val copyToClipboard get() = TR.qtMiscCopyToClipboard().toSentenceCase(R.string.sentence_copy_to_clipboard)
+
     context(_: Fragment)
     val findAndReplace get() = TR.browsingFindAndReplace().toSentenceCase(R.string.sentence_find_and_replace)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
@@ -94,6 +94,11 @@ class SyncMediaWorker(
                 setContentTitle(CollectionManager.TR.syncMediaFailed())
                 throwable.localizedMessage?.let { message ->
                     setContentText(message)
+                    setStyle(
+                        NotificationCompat
+                            .BigTextStyle()
+                            .bigText(message),
+                    )
                 }
             }
             Timber.d("SyncMediaWorker: showing failure notification")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
@@ -16,9 +16,12 @@
 package com.ichi2.anki.worker
 
 import android.app.Notification
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.Build
+import androidx.annotation.VisibleForTesting
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.work.Constraints
@@ -36,10 +39,13 @@ import anki.sync.MediaSyncProgress
 import anki.sync.SyncAuth
 import anki.sync.syncAuth
 import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.NotificationChannel
 import com.ichi2.anki.R
 import com.ichi2.anki.cancelMediaSync
 import com.ichi2.anki.notifications.NotificationId
+import com.ichi2.anki.receiver.CopyToClipboardReceiver
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.ext.trySetForeground
 import com.ichi2.utils.Permissions
 import kotlinx.coroutines.CancellationException
@@ -91,13 +97,20 @@ class SyncMediaWorker(
         } catch (throwable: Throwable) {
             Timber.w(throwable, "SyncMediaWorker failed")
             notify {
-                setContentTitle(CollectionManager.TR.syncMediaFailed())
+                // TODO: add a contentIntent, so tapping the notification opens the app
+                //  (ideally showing the media sync log: an AlertDialog in DeckPicker)
+                setContentTitle(TR.syncMediaFailed())
                 throwable.localizedMessage?.let { message ->
                     setContentText(message)
                     setStyle(
                         NotificationCompat
                             .BigTextStyle()
                             .bigText(message),
+                    )
+                    addAction(
+                        R.drawable.baseline_content_copy_24,
+                        with(applicationContext) { TR.sentenceCase.copyToClipboard },
+                        getCopyToClipboardIntent(message),
                     )
                 }
             }
@@ -134,7 +147,7 @@ class SyncMediaWorker(
 
     override suspend fun getForegroundInfo(): ForegroundInfo {
         val title = applicationContext.getString(R.string.syncing_media)
-        val cancelTitle = CollectionManager.TR.syncAbortButton()
+        val cancelTitle = TR.syncAbortButton()
         val notification =
             buildNotification {
                 setContentTitle(title)
@@ -148,6 +161,20 @@ class SyncMediaWorker(
         } else {
             ForegroundInfo(NotificationId.SYNC_MEDIA, notification)
         }
+    }
+
+    @VisibleForTesting
+    internal fun getCopyToClipboardIntent(text: String): PendingIntent {
+        val intent =
+            Intent(applicationContext, CopyToClipboardReceiver::class.java).apply {
+                putExtra(CopyToClipboardReceiver.EXTRA_SYNC_ERROR_LOG, text.take(MAX_ERROR_TEXT_LENGTH))
+            }
+        return PendingIntent.getBroadcast(
+            applicationContext,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
     }
 
     private fun notify(notification: Notification) = notificationManager?.notify(NotificationId.SYNC_MEDIA, notification)
@@ -169,7 +196,7 @@ class SyncMediaWorker(
 
     private fun getProgressNotification(progress: CharSequence): Notification {
         val title = applicationContext.getString(R.string.syncing_media)
-        val cancelTitle = CollectionManager.TR.syncAbortButton()
+        val cancelTitle = TR.syncAbortButton()
 
         return buildNotification {
             setContentTitle(title)
@@ -183,6 +210,15 @@ class SyncMediaWorker(
         private const val HKEY_KEY = "hkey"
         private const val ENDPOINT_KEY = "endpoint"
         const val NOTIFICATION_UPDATE_RATE_MS = 500L
+
+        /**
+         * Maximum length of the error text placed in [getCopyToClipboardIntent].
+         *
+         * The notification and its intents must fit in the Binder transaction buffer (~1MB),
+         * which an unusually large message (e.g. from a [StackOverflowError]) may exceed
+         */
+        @VisibleForTesting
+        const val MAX_ERROR_TEXT_LENGTH = 100_000
 
         fun getWorkRequest(auth: SyncAuth): OneTimeWorkRequest {
             val constraints =

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ClipboardUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ClipboardUtil.kt
@@ -92,12 +92,13 @@ object ClipboardUtil {
  * @param text the text that needs to be copied
  * @param successMessageId message that needs to be shown after successfully copying the text
  * @param failureMessageId message that needs to be shown in case failed to copy the text
+ * @return whether the text was copied to the clipboard
  */
 fun Context.copyToClipboard(
     text: String,
     @StringRes successMessageId: Int = R.string.about_ankidroid_successfully_copied_debug_info,
     @StringRes failureMessageId: Int = R.string.failed_to_copy,
-) {
+): Boolean {
     val copied = copyTextToClipboard(text)
     // in Android S_V2 and above, the system is guaranteed to show a message on a successful copy
     // so we don't need to do anything
@@ -105,7 +106,7 @@ fun Context.copyToClipboard(
 
     if (doesNotNeedToShowMessage) {
         Timber.v("successfully copied to clipboard & system informed user of copy")
-        return
+        return true
     }
 
     val confirmationMessage = if (copied) successMessageId else failureMessageId
@@ -115,6 +116,8 @@ fun Context.copyToClipboard(
     } else {
         showThemedToast(this, confirmationMessage, shortLength = true)
     }
+
+    return copied
 }
 
 /**

--- a/AnkiDroid/src/main/res/values/sentence-case.xml
+++ b/AnkiDroid/src/main/res/values/sentence-case.xml
@@ -91,4 +91,5 @@ undoActionUndone()
     <string name="sentence_answer_again" maxLength="41">Answer again</string>
     <string name="sentence_answer_hard" maxLength="41">Answer hard</string>
     <string name="sentence_answer_good" maxLength="41">Answer good</string>
+    <string name="sentence_copy_to_clipboard">Copy to clipboard</string>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/receiver/CopyToClipboardReceiverTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/receiver/CopyToClipboardReceiverTest.kt
@@ -11,6 +11,7 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.R
+import com.ichi2.anki.common.utils.ext.requireSystemService
 import com.ichi2.anki.notifications.NotificationId
 import com.ichi2.testutils.EmptyApplication
 import org.hamcrest.MatcherAssert.assertThat
@@ -27,9 +28,9 @@ import org.robolectric.shadows.ShadowContextImpl
 class CopyToClipboardReceiverTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val clipboardManager
-        get() = context.getSystemService(ClipboardManager::class.java)!!
+        get() = context.requireSystemService<ClipboardManager>()
     private val notificationManager
-        get() = context.getSystemService(NotificationManager::class.java)!!
+        get() = context.requireSystemService<NotificationManager>()
 
     @Test
     fun `copies the error log to the clipboard and dismisses the notification`() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/receiver/CopyToClipboardReceiverTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/receiver/CopyToClipboardReceiverTest.kt
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+package com.ichi2.anki.receiver
+
+import android.app.Application
+import android.app.NotificationManager
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.R
+import com.ichi2.anki.notifications.NotificationId
+import com.ichi2.testutils.EmptyApplication
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadow.api.Shadow
+import org.robolectric.shadows.ShadowContextImpl
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = EmptyApplication::class)
+class CopyToClipboardReceiverTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val clipboardManager
+        get() = context.getSystemService(ClipboardManager::class.java)!!
+    private val notificationManager
+        get() = context.getSystemService(NotificationManager::class.java)!!
+
+    @Test
+    fun `copies the error log to the clipboard and dismisses the notification`() {
+        NotificationManagerCompat.from(context).notify(
+            NotificationId.SYNC_MEDIA,
+            NotificationCompat
+                .Builder(context, "channel")
+                .setSmallIcon(R.drawable.ic_star_notify)
+                .build(),
+        )
+        val intent =
+            Intent(context, CopyToClipboardReceiver::class.java).apply {
+                putExtra(CopyToClipboardReceiver.EXTRA_SYNC_ERROR_LOG, "sync error log")
+            }
+
+        CopyToClipboardReceiver().onReceive(context, intent)
+
+        val copiedText =
+            clipboardManager.primaryClip
+                ?.getItemAt(0)
+                ?.text
+        assertThat(copiedText, equalTo("sync error log"))
+        assertThat("notification is dismissed", shadowOf(notificationManager).size(), equalTo(0))
+    }
+
+    @Test
+    fun `does not copy when the error log extra is missing`() {
+        val intent = Intent(context, CopyToClipboardReceiver::class.java)
+
+        CopyToClipboardReceiver().onReceive(context, intent)
+
+        assertThat(clipboardManager.hasPrimaryClip(), equalTo(false))
+    }
+
+    @Test
+    fun `keeps the notification if the copy fails`() {
+        NotificationManagerCompat.from(context).notify(
+            NotificationId.SYNC_MEDIA,
+            NotificationCompat
+                .Builder(context, "channel")
+                .setSmallIcon(R.drawable.ic_star_notify)
+                .build(),
+        )
+        val shadowNotificationManager = shadowOf(notificationManager)
+        // simulate a copy failure: the clipboard service is unavailable
+        Shadow
+            .extract<ShadowContextImpl>((context as Application).baseContext)
+            .removeSystemService(Context.CLIPBOARD_SERVICE)
+        val intent =
+            Intent(context, CopyToClipboardReceiver::class.java).apply {
+                putExtra(CopyToClipboardReceiver.EXTRA_SYNC_ERROR_LOG, "sync error log")
+            }
+
+        CopyToClipboardReceiver().onReceive(context, intent)
+
+        assertThat("the error log must remain accessible", shadowNotificationManager.size(), equalTo(1))
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
@@ -79,6 +79,7 @@ class SentenceCaseTest : RobolectricTest() {
                     assertThat(TR.sentenceCase.checkMediaAction, equalTo("Check media"))
                     assertThat(TR.sentenceCase.emptyCards, equalTo("Empty cards"))
                     assertThat(TR.sentenceCase.flagCard, equalTo("Flag card"))
+                    assertThat(TR.sentenceCase.copyToClipboard, equalTo("Copy to clipboard"))
                     assertThat(TR.sentenceCase.frontTemplate, equalTo("Front template"))
                     assertThat(TR.sentenceCase.backTemplate, equalTo("Back template"))
                     assertThat(TR.sentenceCase.renameDeck, equalTo("Rename deck"))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/worker/SyncMediaWorkerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/worker/SyncMediaWorkerTest.kt
@@ -15,13 +15,65 @@
  */
 package com.ichi2.anki.worker
 
+import android.app.PendingIntent
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.work.testing.TestListenableWorkerBuilder
+import androidx.work.testing.WorkManagerTestInitHelper
 import com.ichi2.anki.NOTIFICATION_MIN_DELAY_MS
+import com.ichi2.anki.receiver.CopyToClipboardReceiver
+import com.ichi2.testutils.EmptyApplication
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.not
+import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
 
+@RunWith(AndroidJUnit4::class)
+@Config(application = EmptyApplication::class)
 class SyncMediaWorkerTest {
+    private lateinit var worker: SyncMediaWorker
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        WorkManagerTestInitHelper.initializeTestWorkManager(context)
+        worker = TestListenableWorkerBuilder<SyncMediaWorker>(context).build()
+    }
+
     @Test
     @Suppress("SimplifyBooleanWithConstants")
     fun `notification update delay is not lower than min delay`() {
         assert(SyncMediaWorker.NOTIFICATION_UPDATE_RATE_MS >= NOTIFICATION_MIN_DELAY_MS)
+    }
+
+    // https://github.com/ankidroid/Anki-Android/issues/20826
+    @Test
+    fun `copy to clipboard intent is immutable`() {
+        val pendingIntent = worker.getCopyToClipboardIntent("error text")
+
+        assertThat(
+            "an intent attached to a notification must not be modifiable by other apps",
+            shadowOf(pendingIntent).flags and PendingIntent.FLAG_IMMUTABLE,
+            not(equalTo(0)),
+        )
+    }
+
+    // https://github.com/ankidroid/Anki-Android/issues/20826
+    @Test
+    fun `error text is trimmed to fit in the binder transaction buffer`() {
+        val hugeText = "e".repeat(SyncMediaWorker.MAX_ERROR_TEXT_LENGTH + 1)
+
+        val pendingIntent = worker.getCopyToClipboardIntent(hugeText)
+
+        val errorText =
+            shadowOf(pendingIntent)
+                .savedIntent
+                .getStringExtra(CopyToClipboardReceiver.EXTRA_SYNC_ERROR_LOG)
+        assertThat(errorText?.length, equalTo(SyncMediaWorker.MAX_ERROR_TEXT_LENGTH))
     }
 }

--- a/common/android/src/main/java/com/ichi2/anki/common/utils/ext/Context.kt
+++ b/common/android/src/main/java/com/ichi2/anki/common/utils/ext/Context.kt
@@ -5,6 +5,7 @@ package com.ichi2.anki.common.utils.ext
 
 import android.content.BroadcastReceiver
 import android.content.Context
+import androidx.core.content.ContextCompat
 import timber.log.Timber
 
 /**
@@ -21,3 +22,18 @@ fun Context.unregisterReceiverSilently(receiver: BroadcastReceiver) {
         Timber.d(e, "BroadcastReceiver was not previously registered")
     }
 }
+
+/**
+ * Returns the system service of type [T], for services which are always available
+ *
+ * ```
+ * val clipboardManager = context.requireSystemService<ClipboardManager>()
+ * ```
+ *
+ * @throws IllegalArgumentException if the service is unavailable
+ * @see ContextCompat.getSystemService
+ */
+inline fun <reified T : Any> Context.requireSystemService(): T =
+    requireNotNull(ContextCompat.getSystemService(this, T::class.java)) {
+        "system service unavailable: ${T::class.java.simpleName}"
+    }


### PR DESCRIPTION
> [!NOTE]
> This is a fixup of
> * https://github.com/ankidroid/Anki-Android/pull/20976

> [!NOTE]
> Assisted-by: Claude Fable 5

## Purpose / Description
SyncMediaWorker fail throwable notification could not be expanded or opened

## Fixes
* Fixes #20826

## Approach
1. Adds attribute .bigText to make text expandable
2. Adds addAction for a button that copies error message and instantly closes the message upon the action
3. Uses a custom receiver for serving pendingIntent required for addAction

## How Has This Been Tested?
The OP of this PR had tested it, this is just fixups; unit tests are added

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)