### PR TITLE
Fix ExportDialogFragment deleting ids file on configuration change

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
@@ -68,6 +68,9 @@ class ExportDialogFragment : DialogFragment() {
 
     override fun onDismiss(dialog: DialogInterface) {
         super.onDismiss(dialog)
+        // onDismiss is also called on a configuration change (from onDestroyView), in which case
+        // the dialog is recreated with the same arguments and still needs the ids file
+        if (activity?.isChangingConfigurations == true) return
         if (arguments?.containsKey(ARG_IDS_FILE) == true) {
             removeIdsFile()
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/export/ExportDialogFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/export/ExportDialogFragmentTest.kt
@@ -27,10 +27,13 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.browser.IdsFile
+import com.ichi2.anki.utils.ext.requireParcelable
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.not
 import org.junit.Test
 import org.junit.runner.RunWith
+import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
 class ExportDialogFragmentTest : RobolectricTest() {
@@ -153,9 +156,33 @@ class ExportDialogFragmentTest : RobolectricTest() {
         }
     }
 
+    @Test
+    fun `ids file is not removed on a configuration change`() {
+        val fragment =
+            ExportDialogFragment.newInstance(
+                cacheDir = targetContext.cacheDir,
+                type = ExportDialogFragment.ExportType.Notes,
+                ids = listOf(1L, 2L, 3L),
+            )
+        val idsFile = fragment.requireArguments().requireParcelable<IdsFile>(ARG_IDS_FILE)
+        assertTrue(idsFile.exists())
+
+        launchFragment<ExportDialogFragment>(
+            fragmentArgs = fragment.arguments,
+            themeResId = R.style.Theme_Light,
+        ).use { scenario ->
+            scenario.recreate()
+            assertTrue(idsFile.exists(), "ids file must survive a configuration change")
+        }
+    }
+
     /** Launches [ExportDialogFragment] and executes [action] on the fragment. */
     private fun onExportDialog(action: ExportDialogFragment.() -> Unit) =
         launchFragment<ExportDialogFragment>(
             themeResId = R.style.Theme_Light,
         ).use { scenario -> scenario.onFragment { action(it) } }
+
+    companion object {
+        private const val ARG_IDS_FILE = "arg_ids_file"
+    }
 }


### PR DESCRIPTION
## Purpose / Description
So turns out onDismiss() on the export dialog fires not just when the dialog is actually dismissed, but also on a config change (it comes from onDestroyView). Because of that, rotating the screen was deleting the ids file even though the dialog just gonna get recreated with the same args right after. Next time it try to read that file, its not there anymore and crashes.

## Fixes
* Fixes #21477

## Approach
Added a check in onDismiss() — if activity?.isChangingConfigurations is true we just return early and dont touch the file. So now it only gets deleted when the dialog is actually being dismissed for real, not on rotation. Also went and checked FindAndReplaceDialogFragment since it use the same ids file mechanism, but that one deletes the file on explicit cancel/submit clicks instead of inside onDismiss, so it was never hitting this bug in the first place.

## How Has This Been Tested?
Added a Robolectric test which open the export dialog with an ids file, then calls scenario.recreate() to simulate a rotation, and checks the file still exist after. Ran it before the fix and it fails like expected, then passes after. Also removed my fix again just to double check only this one test breaks and nothing else (mutation check basically).

## Checklist
Please, go through these checks before submitting the PR.

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
