### PR TITLE
Fix: change notetype templates disabled

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
@@ -597,6 +597,8 @@ class ChangeNoteTypeDialog : AnalyticsDialogFragment(R.layout.dialog_change_note
         private fun createTemplateSpinner() {
             binding.templatesContainer.removeAllViews()
 
+            if (!viewModel.canChangeTemplates) return
+
             val inputTemplateNames = viewModel.inputNoteType.templatesNames
             val outputTemplateNames = viewModel.outputNoteType.templatesNames
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeViewModel.kt
@@ -187,6 +187,8 @@ class ChangeNoteTypeViewModel(
      * Whether template mapping applies to the current conversion
      *
      * Templates may only be updated if the input and output note type are non-cloze
+     *
+     * @see canChangeTemplates
      */
     val canChangeTemplatesFlow by lazy {
         conversionTypeFlow
@@ -278,6 +280,15 @@ class ChangeNoteTypeViewModel(
      */
     val outputNoteType
         get() = outputNoteTypeFlow.value
+
+    /**
+     * Whether template mapping applies to the current conversion: both note types must be regular
+     *
+     * Unlike [canChangeTemplatesFlow], this never lags behind [outputNoteType]
+     */
+    val canChangeTemplates: Boolean
+        get() =
+            ConversionType.fromNoteTypeChange(current = inputNoteType, new = outputNoteType) == ConversionType.REGULAR_TO_REGULAR
 
     init {
         delayedInit {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeViewModel.kt
@@ -184,7 +184,7 @@ class ChangeNoteTypeViewModel(
     }
 
     /**
-     * Whether [updateTemplateMapping] can be called
+     * Whether template mapping applies to the current conversion
      *
      * Templates may only be updated if the input and output note type are non-cloze
      */
@@ -447,7 +447,11 @@ class ChangeNoteTypeViewModel(
         outputTemplateIndex: Int,
         mappedFrom: SelectedIndex,
     ) = viewModelScope.launch {
-        require(canChangeTemplatesFlow.value) { "changing templates was disabled" }
+        // a Spinner may deliver a selection the user didn't make
+        if (!canChangeTemplatesFlow.value) {
+            Timber.w("ignoring template mapping: changing templates is disabled")
+            return@launch
+        }
 
         Timber.d("Updating card mapping: %d -> %s", outputTemplateIndex, mappedFrom)
         val updatedValue = mappedFrom.toNullableInt()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialogTest.kt
@@ -6,14 +6,19 @@ package com.ichi2.anki.dialogs
 import android.content.Context
 import android.os.Bundle
 import android.os.Looper.getMainLooper
+import android.view.View
+import android.view.ViewGroup
 import android.view.accessibility.AccessibilityManager
+import android.widget.Spinner
 import androidx.fragment.app.testing.launchFragment
+import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.viewpager2.widget.ViewPager2
 import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.dialogs.ChangeNoteTypeDialog.Companion.ARG_NOTE_IDS
 import com.ichi2.anki.libanki.NoteId
+import org.hamcrest.Matchers.equalTo
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
@@ -34,10 +39,55 @@ class ChangeNoteTypeDialogTest : RobolectricTest() {
         // a crash is reported by FailOnUnhandledExceptionRule
     }
 
+    /** #20944: spinners which can't be used still deliver selections, which used to be fatal */
+    @Test
+    fun `no template spinners are built for a cloze note type`() =
+        withChangeNoteTypeDialog(addClozeNote("{{c1::Hi}}").id) {
+            assertThat("templates are locked", templatesContainer().childCount, equalTo(0))
+        }
+
+    @Test
+    fun `template spinners are built for a regular note type`() =
+        withChangeNoteTypeDialog(addBasicNote().id) {
+            assertThat("a spinner per output template", templatesContainer().childCount, equalTo(1))
+        }
+
+    @Test
+    fun `template spinners are rebuilt after visiting cloze`() =
+        withChangeNoteTypeDialog(addBasicNote().id) {
+            val container = templatesContainer()
+
+            selectNoteType("Cloze")
+            selectNoteType("Basic (and reversed card)")
+
+            assertThat("shown for regular -> regular", container.visibility, equalTo(View.VISIBLE))
+            assertThat("one spinner per output template", container.childCount, equalTo(2))
+        }
+
+    /** The template mapping rows, which only apply to a regular -> regular conversion */
+    private fun ChangeNoteTypeDialog.templatesContainer(): ViewGroup {
+        // the templates tab is the second page of the pager
+        val pager = requireView().findViewById<View>(R.id.change_note_type_pager)
+        assertThat("the dialog has loaded", pager.visibility, equalTo(View.VISIBLE))
+        selectTemplatesTab()
+        return requireNotNull(requireView().findViewById(R.id.templates_container)) {
+            "templates_container was not created"
+        }
+    }
+
     private fun ChangeNoteTypeDialog.selectTemplatesTab() {
         requireView()
             .findViewById<ViewPager2>(R.id.change_note_type_pager)
             .setCurrentItem(ChangeNoteTypeViewModel.Tab.Templates.position, false)
+        shadowOf(getMainLooper()).idle()
+    }
+
+    /** Picks a note type in the 'new note type' spinner, as a user would */
+    private fun ChangeNoteTypeDialog.selectNoteType(name: String) {
+        val spinner = requireView().findViewById<Spinner>(R.id.dest_note_type_spinner)
+        val id = requireNotNull(col.notetypes.byName(name)) { "note type '$name' not found" }.id
+        val position = (0 until spinner.count).first { spinner.adapter.getItemId(it) == id }
+        spinner.setSelection(position)
         shadowOf(getMainLooper()).idle()
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialogTest.kt
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 Ashish Yadav <mailtoashish693@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.dialogs
+
+import android.content.Context
+import android.os.Bundle
+import android.os.Looper.getMainLooper
+import android.view.accessibility.AccessibilityManager
+import androidx.fragment.app.testing.launchFragment
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.viewpager2.widget.ViewPager2
+import com.ichi2.anki.R
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.dialogs.ChangeNoteTypeDialog.Companion.ARG_NOTE_IDS
+import com.ichi2.anki.libanki.NoteId
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(AndroidJUnit4::class)
+class ChangeNoteTypeDialogTest : RobolectricTest() {
+    /**
+     * #20944: with an accessibility service enabled, a Spinner reports its initial selection.
+     * A template selection is meaningless for cloze, and used to be fatal
+     */
+    @Test
+    fun `templates tab for a cloze note does not crash with an accessibility service`() {
+        enableAccessibilityService()
+
+        withChangeNoteTypeDialog(addClozeNote("{{c1::Hi}}").id) {
+            selectTemplatesTab()
+        }
+        // a crash is reported by FailOnUnhandledExceptionRule
+    }
+
+    private fun ChangeNoteTypeDialog.selectTemplatesTab() {
+        requireView()
+            .findViewById<ViewPager2>(R.id.change_note_type_pager)
+            .setCurrentItem(ChangeNoteTypeViewModel.Tab.Templates.position, false)
+        shadowOf(getMainLooper()).idle()
+    }
+
+    /** Makes [AccessibilityManager.isEnabled] return true, as it would with TalkBack running */
+    private fun enableAccessibilityService() {
+        val manager = targetContext.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
+        shadowOf(manager).setEnabled(true)
+    }
+
+    private fun withChangeNoteTypeDialog(
+        noteId: NoteId,
+        action: ChangeNoteTypeDialog.() -> Unit,
+    ) {
+        launchFragment<ChangeNoteTypeDialog>(
+            fragmentArgs = Bundle().apply { putLongArray(ARG_NOTE_IDS, longArrayOf(noteId)) },
+            themeResId = R.style.Theme_Light,
+        ).use { scenario -> scenario.onFragment { action(it) } }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/ChangeNoteTypeViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/ChangeNoteTypeViewModelTest.kt
@@ -570,7 +570,9 @@ private suspend fun ChangeNoteTypeViewModel.setOutputNoteType(noteType: Notetype
 private fun ChangeNoteTypeViewModel.templateNameToIndex(name: String) =
     SelectedIndex.Index(this.outputNoteType.templatesNames.indexOf(name))
 
-private fun ChangeNoteTypeViewModel.canMapTemplates(): Boolean = canChangeTemplatesFlow.value
+/** [ChangeNoteTypeViewModel.canChangeTemplates], checking that [ChangeNoteTypeViewModel.canChangeTemplatesFlow] agrees */
+private fun ChangeNoteTypeViewModel.canMapTemplates(): Boolean =
+    canChangeTemplates.also { assertThat("canChangeTemplatesFlow agrees", canChangeTemplatesFlow.value, equalTo(it)) }
 
 /** Waits for the job, returning what it failed with, or `null` if it succeeded */
 private suspend fun Job.failureOrNull(): Throwable? {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/ChangeNoteTypeViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/ChangeNoteTypeViewModelTest.kt
@@ -28,11 +28,13 @@ import com.ichi2.anki.dialogs.ChangeNoteTypeViewModelTest.Launch.Regular
 import com.ichi2.anki.dialogs.SelectedIndex.NOTHING
 import com.ichi2.anki.libanki.NoteId
 import com.ichi2.anki.libanki.NotetypeJson
+import kotlinx.coroutines.Job
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.not
 import org.junit.Test
 import org.junit.runner.RunWith
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 
 @RunWith(AndroidJUnit4::class)
 class ChangeNoteTypeViewModelTest : RobolectricTest() {
@@ -410,6 +412,20 @@ class ChangeNoteTypeViewModelTest : RobolectricTest() {
     }
 
     @Test
+    fun `a template selection is ignored after switching to cloze`() =
+        viewModelTest(Regular(templateCount = 2)) {
+            setOutputNoteType(col.notetypes.byName("Cloze")!!)
+
+            assertTemplateSelectionIsIgnored()
+        }
+
+    @Test
+    fun `a template selection is ignored for a cloze note type`() =
+        viewModelTest(Cloze()) {
+            assertTemplateSelectionIsIgnored()
+        }
+
+    @Test
     fun `init fails if no notes`() {
         val ex = assertFailsWith<IllegalArgumentException> { buildViewModel(noteIds = emptyList()) }
         assertThat(ex.message, equalTo("ARG_NOTE_IDS was empty"))
@@ -555,3 +571,22 @@ private fun ChangeNoteTypeViewModel.templateNameToIndex(name: String) =
     SelectedIndex.Index(this.outputNoteType.templatesNames.indexOf(name))
 
 private fun ChangeNoteTypeViewModel.canMapTemplates(): Boolean = canChangeTemplatesFlow.value
+
+/** Waits for the job, returning what it failed with, or `null` if it succeeded */
+private suspend fun Job.failureOrNull(): Throwable? {
+    join()
+    var cause: Throwable? = null
+    invokeOnCompletion { cause = it }
+    return cause
+}
+
+/** Asserts that a template selection is dropped, rather than being fatal or changing the map */
+private suspend fun ChangeNoteTypeViewModel.assertTemplateSelectionIsIgnored() {
+    assertThat("precondition: templates are locked", canMapTemplates(), equalTo(false))
+    val mappingBefore = templateChangeMap
+
+    val failure = updateTemplateMapping(outputTemplateIndex = 0, mappedFrom = NOTHING).failureOrNull()
+
+    assertNull(failure, "the selection must not crash")
+    assertThat("the mapping is left alone", templateChangeMap, equalTo(mappingBefore))
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

> [!NOTE]
> Assisted-by: Claude Opus 5

## Purpose / Description

Changing Note Type could crash with `IllegalArgumentException: changing templates was disabled`. The crash comes from an ACRA report, and it needs no user interaction to happen: the template spinners report their initial selection back to the ViewModel, and if the conversion involves a cloze note type then template mapping does not apply, so the ViewModel refused the update by throwing.

## Fixes

* Fixes #20944

## Approach
See commits


## How Has This Been Tested?
Unit test

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->