### PR TITLE
fix(analytics): don't report exceptions holding PII

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AcraCrashReporter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AcraCrashReporter.kt
@@ -267,7 +267,11 @@ private object AcraCrashReporter : CrashReporter {
         onlyIfSilent: Boolean,
         context: Context,
     ) {
-        Analytics.sendAnalyticsException(e, false)
+        // the same filter ACRA uses below: it exists to keep sync server messages and
+        // other PII out of reporting, and analytics is reporting too
+        if (!ThrowableFilterService.shouldDiscardThrowable(e)) {
+            Analytics.sendAnalyticsException(e, false)
+        }
         AnkiDroidApp.sentExceptionReportHack = true
         val reportMode =
             context

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AcraCrashReporterAnalyticsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AcraCrashReporterAnalyticsTest.kt
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2026 Ashish Yadav <mailtoashish693@gmail.com>
+
+package com.ichi2.anki
+
+import androidx.core.content.edit
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import anki.backend.backendError
+import com.ichi2.anki.common.analytics.Analytics
+import com.ichi2.anki.common.crashreporting.CrashReportService
+import com.ichi2.anki.common.crashreporting.CrashReporter.Companion.FEEDBACK_REPORT_KEY
+import com.ichi2.anki.common.crashreporting.CrashReporter.Companion.FEEDBACK_REPORT_NEVER
+import com.ichi2.anki.common.preferences.sharedPrefs
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import net.ankiweb.rsdroid.exceptions.BackendSyncException.BackendSyncServerMessageException
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AcraCrashReporterAnalyticsTest : RobolectricTest() {
+    @Before
+    override fun setUp() {
+        super.setUp()
+        targetContext.sharedPrefs().edit { putString(FEEDBACK_REPORT_KEY, FEEDBACK_REPORT_NEVER) }
+        mockkObject(Analytics)
+        every { Analytics.sendAnalyticsException(any(), any()) } returns Unit
+    }
+
+    @After
+    override fun tearDown() {
+        super.tearDown()
+        unmockkObject(Analytics)
+    }
+
+    @Test
+    fun `an exception carrying a sync server message is not reported`() {
+        val withPii = Exception("outer", BackendSyncServerMessageException(backendError {}))
+
+        CrashReportService.sendExceptionReport(withPii, "test", null, false, targetContext)
+
+        verify(exactly = 0) { Analytics.sendAnalyticsException(any(), any()) }
+    }
+
+    @Test
+    fun `an ordinary exception is still reported`() {
+        CrashReportService.sendExceptionReport(IllegalStateException("safe"), "test", null, false, targetContext)
+
+        verify(exactly = 1) { Analytics.sendAnalyticsException(any(), any()) }
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

## Purpose / Description
sendExceptionReport reported to analytics on its first line, but the PII filter (ThrowableFilterService.shouldDiscardThrowable) guarded only the ACRA path below it. So I am fixinf that here

## Fixes
- Partially addresses #19577
- Related: #17392

## Approach
See commit

## How Has This Been Tested?
Unit tests

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->