### PR TITLE
Fix: analytics screen names

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -199,9 +199,13 @@ open class AnkiActivity(
         broadcastReceiver?.let { unregisterReceiver(it) }
     }
 
+    /** Name this screen is reported under. Override where the class doesn't identify the screen. */
+    protected open val analyticsScreenName: String
+        get() = javaClass.simpleName
+
     override fun onResume() {
         super.onResume()
-        Analytics.sendAnalyticsScreenView(this)
+        Analytics.sendAnalyticsScreenView(analyticsScreenName)
         (getSystemService(NOTIFICATION_SERVICE) as NotificationManager).cancel(
             SIMPLE_NOTIFICATION_ID,
         )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
@@ -55,6 +55,10 @@ open class SingleFragmentActivity :
     override val baseSnackbarBuilder: SnackbarBuilder
         get() = (fragment as? BaseSnackbarBuilderProvider)?.baseSnackbarBuilder ?: { }
 
+    // the same host class serves every screen it shows, so report what it's showing
+    override val analyticsScreenName: String
+        get() = intent.getStringExtra(EXTRA_FRAGMENT_NAME)?.substringAfterLast('.') ?: super.analyticsScreenName
+
     override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {
             return

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EmptyCardsDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EmptyCardsDialogFragment.kt
@@ -26,7 +26,6 @@ import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.core.text.HtmlCompat
 import androidx.core.view.isVisible
-import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -36,6 +35,7 @@ import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
+import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.browser.CardBrowserViewModel
 import com.ichi2.anki.databinding.DialogEmptyCardsBinding
 import com.ichi2.anki.dialogs.EmptyCardsUiState.EmptyCardsSearchFailure
@@ -58,7 +58,7 @@ import timber.log.Timber
  * A dialog that searches for empty cards and presents the user with the option to delete them.
  * A user may 'keep notes', which retains the first card of each note, even if the note is empty.
  */
-class EmptyCardsDialogFragment : DialogFragment() {
+class EmptyCardsDialogFragment : AnalyticsDialogFragment() {
     private val viewModel by viewModels<EmptyCardsViewModel>()
 
     private lateinit var binding: DialogEmptyCardsBinding

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/help/HelpDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/help/HelpDialog.kt
@@ -29,6 +29,7 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsConstants.Actions
 import com.ichi2.anki.analytics.AnalyticsConstants.Category
+import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.ankiActivity
 import com.ichi2.anki.common.analytics.Analytics
 import com.ichi2.anki.databinding.DialogHelpBinding
@@ -48,7 +49,7 @@ import dev.androidbroadcast.vbpd.viewBinding
 /**
  * [DialogFragment] responsible for showing the help/support menus.
  */
-class HelpDialog : DialogFragment() {
+class HelpDialog : AnalyticsDialogFragment() {
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     lateinit var actionsDispatcher: HelpItemActionsDispatcher
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
@@ -26,7 +26,6 @@ import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AlertDialog
 import androidx.core.text.HtmlCompat
 import androidx.core.view.isVisible
-import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.lifecycleScope
 import anki.cards.cardIds
 import anki.generic.Empty
@@ -37,6 +36,7 @@ import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
+import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.browser.IdsFile
 import com.ichi2.anki.browser.removeSafely
 import com.ichi2.anki.common.ALL_DECKS_ID
@@ -63,7 +63,7 @@ import java.io.File
  * Shows the possible options for exporting(collection, decks or notes/card selection).
  * Intended to replicate the desktop UI.
  */
-class ExportDialogFragment : DialogFragment() {
+class ExportDialogFragment : AnalyticsDialogFragment() {
     private lateinit var binding: DialogExportOptionsBinding
 
     override fun onDismiss(dialog: DialogInterface) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaActivity.kt
@@ -65,6 +65,9 @@ class MultimediaActivity :
     BaseSnackbarBuilderProvider {
     private val binding by viewBinding(ActivityMultimediaBinding::bind)
 
+    override val analyticsScreenName: String
+        get() = intent.getStringExtra(EXTRA_FRAGMENT_NAME)?.substringAfterLast('.') ?: super.analyticsScreenName
+
     private val Intent.multimediaArgsExtra: MultimediaActivityExtra?
         get() = extras?.getSerializableCompat(EXTRA_FRAGMENT_ARGS)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/ForgetCardsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/ForgetCardsDialog.kt
@@ -5,7 +5,6 @@ package com.ichi2.anki.scheduling
 import android.app.Dialog
 import android.os.Bundle
 import androidx.core.content.edit
-import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.setFragmentResultListener
@@ -13,6 +12,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
+import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.databinding.DialogForgetCardsBinding
@@ -43,7 +43,7 @@ import timber.log.Timber
  * * https://docs.ankiweb.net/browsing.html#cards
  */
 @NeedsTest("all")
-class ForgetCardsDialog : DialogFragment() {
+class ForgetCardsDialog : AnalyticsDialogFragment() {
     /**
      * Resets cards back to their original positions in the new queue
      *

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
@@ -32,7 +32,6 @@ import androidx.annotation.CheckResult
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.core.widget.doOnTextChanged
-import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
@@ -45,6 +44,7 @@ import com.google.android.material.tabs.TabLayoutMediator
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
+import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.asyncCatching
 import com.ichi2.anki.browser.IdsFile
 import com.ichi2.anki.browser.removeSafely
@@ -87,7 +87,7 @@ import kotlin.math.min
  *
  * @see SetDueDateViewModel
  */
-class SetDueDateDialog : DialogFragment() {
+class SetDueDateDialog : AnalyticsDialogFragment() {
     // We explicitly do not use calendar controls in this class
     // User feedback:
     // (1) Don't have to think about what today is in order to use it,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/SingleFragmentActivityAnalyticsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/SingleFragmentActivityAnalyticsTest.kt
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2026 Ashish Yadav <mailtoashish693@gmail.com>
+
+package com.ichi2.anki
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.common.analytics.Analytics
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * [SingleFragmentActivity] hosts a dozen unrelated screens, so reporting the host
+ * would file them all under one name.
+ */
+@RunWith(AndroidJUnit4::class)
+class SingleFragmentActivityAnalyticsTest : RobolectricTest() {
+    @Before
+    override fun setUp() {
+        super.setUp()
+        mockkObject(Analytics)
+        every { Analytics.sendAnalyticsScreenView(any<String>()) } returns Unit
+    }
+
+    @After
+    override fun tearDown() {
+        super.tearDown()
+        unmockkObject(Analytics)
+    }
+
+    @Test
+    fun `the hosted fragment is reported, not the host`() {
+        startRegularActivity<SingleFragmentActivity>(DrawingFragment.getIntent(targetContext))
+
+        verify { Analytics.sendAnalyticsScreenView("DrawingFragment") }
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

> [!NOTE]
> Assisted-by: Claude Opus 5

## Purpose / Description
Few screens report the wrong name and some dialogs didn't at all, fixing that here in this PR

## Fixes
NA

## Approach
See commits

## How Has This Been Tested?
Unit tests that are added and build

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->