### PR TITLE
fix js-api: return parsed object from nextTime/deckName

### DIFF
--- a/AnkiDroid/src/main/assets/scripts/js-api.js
+++ b/AnkiDroid/src/main/assets/scripts/js-api.js
@@ -76,6 +76,12 @@ const jsApiList = {
     ankiGetNoteTags: "getNoteTags",
 };
 
+/**
+ * Endpoints which returned the unparsed response body in API 0.0.3,
+ * the oldest version still accepted (see MINIMUM_JS_API_VERSION).
+ */
+const rawResponseEndpoints = ["nextTime1", "nextTime2", "nextTime3", "nextTime4", "deckName"];
+
 class AnkiDroidJS {
     constructor({ developer, version }) {
         this.developer = developer;
@@ -107,6 +113,9 @@ class AnkiDroidJS {
             }
 
             const responseData = await response.text();
+            if (this.version === "0.0.3" && rawResponseEndpoints.includes(endpoint)) {
+                return responseData;
+            }
             return JSON.parse(responseData);
         } catch (error) {
             console.error("Request error:", error);

--- a/AnkiDroid/src/main/assets/scripts/js-api.js
+++ b/AnkiDroid/src/main/assets/scripts/js-api.js
@@ -1,6 +1,6 @@
 /*
  * AnkiDroid JavaScript API
- * Version: 0.0.3
+ * Version: 0.0.4
  */
 
 /**
@@ -107,9 +107,6 @@ class AnkiDroidJS {
             }
 
             const responseData = await response.text();
-            if (endpoint.includes("nextTime") || endpoint.includes("deckName")) {
-                return responseData;
-            }
             return JSON.parse(responseData);
         } catch (error) {
             console.error("Request error:", error);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
@@ -18,6 +18,7 @@
 package com.ichi2.anki
 
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.lifecycleScope
 import anki.scheduler.CardAnswer.Rating
 import com.github.zafarkhaja.semver.Version
@@ -147,6 +148,7 @@ open class AnkiDroidJsAPI(
         errorCode: Int,
         apiDevContact: String,
     ) {
+        if (!reportedApiMessages.add("error$errorCode/$apiDevContact")) return
         val errorMsg: String = context.getString(R.string.anki_js_error_code, errorCode)
         val snackbarMsg: String = context.getString(R.string.api_version_developer_contact, apiDevContact, errorMsg)
 
@@ -158,6 +160,18 @@ open class AnkiDroidJsAPI(
         }
     }
 
+    /** Keys of messages already shown: a card sends a request for each API call it makes */
+    @VisibleForTesting
+    val reportedApiMessages = mutableSetOf<String>()
+
+    private fun showSnackbarOnce(
+        key: String,
+        message: String,
+    ) {
+        if (!reportedApiMessages.add(key)) return
+        activity.runOnUiThread { activity.showSnackbar(message) }
+    }
+
     /**
      * Supplied api version must be equal to current api version to call mark card, toggle flag functions etc.
      */
@@ -167,9 +181,7 @@ open class AnkiDroidJsAPI(
     ): Boolean {
         try {
             if (apiDevContact.isEmpty() || apiVer.isEmpty()) {
-                activity.runOnUiThread {
-                    activity.showSnackbar(context.getString(R.string.invalid_json_data, ""))
-                }
+                showSnackbarOnce("$apiVer/$apiDevContact", context.getString(R.string.invalid_json_data, ""))
                 return false
             }
             val versionCurrent = Version.parse(AnkiDroidJsAPIConstants.CURRENT_JS_API_VERSION)
@@ -185,15 +197,11 @@ open class AnkiDroidJsAPI(
                     true
                 }
                 versionSupplied.isLowerThan(versionCurrent) -> {
-                    activity.runOnUiThread {
-                        activity.showSnackbar(context.getString(R.string.update_js_api_version, apiDevContact))
-                    }
+                    showSnackbarOnce("$apiVer/$apiDevContact", context.getString(R.string.update_js_api_version, apiDevContact))
                     versionSupplied.isHigherThanOrEquivalentTo(Version.parse(AnkiDroidJsAPIConstants.MINIMUM_JS_API_VERSION))
                 }
                 else -> {
-                    activity.runOnUiThread {
-                        activity.showSnackbar(context.getString(R.string.valid_js_api_version, apiDevContact))
-                    }
+                    showSnackbarOnce("$apiVer/$apiDevContact", context.getString(R.string.valid_js_api_version, apiDevContact))
                     false
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
@@ -173,37 +173,39 @@ open class AnkiDroidJsAPI(
     }
 
     /**
-     * Supplied api version must be equal to current api version to call mark card, toggle flag functions etc.
+     * Checks whether the API version a card declares is accepted, warning the user if not.
+     *
+     * Users are warned when a template:
+     * - Requires an AnkiDroid update: [R.string.valid_js_api_version]
+     * - Is no longer supported: [R.string.update_js_api_version]
+     * - Is invalid: [R.string.invalid_json_data]
      */
-    private fun requireApiVersion(
+    @VisibleForTesting
+    internal fun requireApiVersion(
         apiVer: String,
         apiDevContact: String,
+        versionCurrent: Version = Version.parse(AnkiDroidJsAPIConstants.CURRENT_JS_API_VERSION),
+        versionMinimum: Version = Version.parse(AnkiDroidJsAPIConstants.MINIMUM_JS_API_VERSION),
     ): Boolean {
         try {
             if (apiDevContact.isEmpty() || apiVer.isEmpty()) {
                 showSnackbarOnce("$apiVer/$apiDevContact", context.getString(R.string.invalid_json_data, ""))
                 return false
             }
-            val versionCurrent = Version.parse(AnkiDroidJsAPIConstants.CURRENT_JS_API_VERSION)
             val versionSupplied = Version.parse(apiVer)
 
-            /*
-             * if api major version equals to supplied major version then return true and also check for minor version and patch version
-             * show toast for update and contact developer if need updates
-             * otherwise return false
-             */
             return when {
-                versionSupplied == versionCurrent -> {
-                    true
-                }
-                versionSupplied.isLowerThan(versionCurrent) -> {
-                    showSnackbarOnce("$apiVer/$apiDevContact", context.getString(R.string.update_js_api_version, apiDevContact))
-                    versionSupplied.isHigherThanOrEquivalentTo(Version.parse(AnkiDroidJsAPIConstants.MINIMUM_JS_API_VERSION))
-                }
-                else -> {
+                // the card needs a newer AnkiDroid
+                versionSupplied.isHigherThan(versionCurrent) -> {
                     showSnackbarOnce("$apiVer/$apiDevContact", context.getString(R.string.valid_js_api_version, apiDevContact))
                     false
                 }
+                // support has ended
+                versionSupplied.isLowerThan(versionMinimum) -> {
+                    showSnackbarOnce("$apiVer/$apiDevContact", context.getString(R.string.update_js_api_version, apiDevContact))
+                    false
+                }
+                else -> true
             }
         } catch (e: Exception) {
             Timber.w(e, "requireApiVersion::exception")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPIConstants.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPIConstants.kt
@@ -33,8 +33,14 @@ object AnkiDroidJsAPIConstants {
     const val ANKI_JS_ERROR_CODE_SET_DUE: Int = 7
     const val ANKI_JS_ERROR_CODE_SEARCH_CARD: Int = 8
 
-    // js api developer contact
+    /** The API version cards are written against. Breaking changes bump the major version */
     const val CURRENT_JS_API_VERSION = "0.0.4"
+
+    /**
+     * The oldest API version still accepted.
+     * Raise this to end support for an old version, informing users of all templates using this
+     * API version that they should make changes, or contact the template developer.
+     */
     const val MINIMUM_JS_API_VERSION = "0.0.3"
 
     val flagCommands =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPIConstants.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPIConstants.kt
@@ -34,7 +34,7 @@ object AnkiDroidJsAPIConstants {
     const val ANKI_JS_ERROR_CODE_SEARCH_CARD: Int = 8
 
     // js api developer contact
-    const val CURRENT_JS_API_VERSION = "0.0.3"
+    const val CURRENT_JS_API_VERSION = "0.0.4"
     const val MINIMUM_JS_API_VERSION = "0.0.3"
 
     val flagCommands =

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
@@ -525,11 +525,31 @@ class AnkiDroidJsAPITest : RobolectricTest() {
             }
         }
 
+    @Test
+    fun `outdated api version is only reported once`() =
+        runTest {
+            addBasicNote("Front", "Back")
+
+            val reviewer: Reviewer = startReviewer()
+            advanceRobolectricLooper()
+
+            val jsapi = reviewer.jsApi
+            val outdated = jsApiContract(version = AnkiDroidJsAPIConstants.MINIMUM_JS_API_VERSION)
+
+            repeat(3) { jsapi.handleJsApiRequest("deckName", outdated, false) }
+
+            // a card issues many requests: the warning must not be repeated for each one
+            assertThat(jsapi.reportedApiMessages.size, equalTo(1))
+        }
+
     companion object {
-        fun jsApiContract(data: String = ""): ByteArray =
+        fun jsApiContract(
+            data: String = "",
+            version: String = AnkiDroidJsAPIConstants.CURRENT_JS_API_VERSION,
+        ): ByteArray =
             JSONObject()
                 .apply {
-                    put("version", "0.0.4")
+                    put("version", version)
                     put("developer", "test@example.com")
                     put("data", data)
                 }.toString()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
@@ -529,7 +529,7 @@ class AnkiDroidJsAPITest : RobolectricTest() {
         fun jsApiContract(data: String = ""): ByteArray =
             JSONObject()
                 .apply {
-                    put("version", "0.0.3")
+                    put("version", "0.0.4")
                     put("developer", "test@example.com")
                     put("data", data)
                 }.toString()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
@@ -18,6 +18,7 @@
 package com.ichi2.anki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.zafarkhaja.semver.Version
 import com.ichi2.anki.AnkiDroidJsAPI.Companion.SUCCESS_KEY
 import com.ichi2.anki.AnkiDroidJsAPI.Companion.VALUE_KEY
 import com.ichi2.anki.AnkiDroidJsAPITest.Companion.jsApiContract
@@ -526,7 +527,24 @@ class AnkiDroidJsAPITest : RobolectricTest() {
         }
 
     @Test
-    fun `outdated api version is only reported once`() =
+    fun `unsupported api version is only reported once`() =
+        runTest {
+            addBasicNote("Front", "Back")
+
+            val reviewer: Reviewer = startReviewer()
+            advanceRobolectricLooper()
+
+            val jsapi = reviewer.jsApi
+            val unsupported = jsApiContract(version = "0.0.2")
+
+            repeat(3) { jsapi.handleJsApiRequest("deckName", unsupported, false) }
+
+            // a card issues many requests: the warning must not be repeated for each one
+            assertThat(jsapi.reportedApiMessages.size, equalTo(1))
+        }
+
+    @Test
+    fun `outdated version within the current major works without warning the user`() =
         runTest {
             addBasicNote("Front", "Back")
 
@@ -536,10 +554,37 @@ class AnkiDroidJsAPITest : RobolectricTest() {
             val jsapi = reviewer.jsApi
             val outdated = jsApiContract(version = AnkiDroidJsAPIConstants.MINIMUM_JS_API_VERSION)
 
-            repeat(3) { jsapi.handleJsApiRequest("deckName", outdated, false) }
+            val response = jsapi.handleJsApiRequest("deckName", outdated, false).decodeToString()
 
-            // a card issues many requests: the warning must not be repeated for each one
-            assertThat(jsapi.reportedApiMessages.size, equalTo(1))
+            assertThat(response, equalTo(formatApiResult("Default")))
+            // versions only break across majors: most users can't act on
+            // 'contact the developer', so they must not be warned about a compatible update
+            assertThat(jsapi.reportedApiMessages, equalTo(emptySet<String>()))
+        }
+
+    @Test
+    fun `card from an older major works without warning during its deprecation window`() =
+        runTest {
+            addBasicNote("Front", "Back")
+
+            val reviewer: Reviewer = startReviewer()
+            advanceRobolectricLooper()
+
+            val jsapi = reviewer.jsApi
+
+            // the state after a breaking change ships as 1.0.0, before the minimum is raised
+            val accepted =
+                jsapi.requireApiVersion(
+                    apiVer = "0.0.4",
+                    apiDevContact = "test@example.com",
+                    versionCurrent = Version.parse("1.0.0"),
+                    versionMinimum = Version.parse("0.0.3"),
+                )
+
+            assertThat(accepted, equalTo(true))
+            // the window is aimed at template developers, via dev channels: users can't act
+            // on it, and their cards still work
+            assertThat(jsapi.reportedApiMessages, equalTo(emptySet<String>()))
         }
 
     companion object {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/AddonModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/AddonModelTest.kt
@@ -70,7 +70,7 @@ class AddonModelTest : RobolectricTest() {
         assertEquals(addon.name, "valid-ankidroid-js-addon-test")
         assertEquals(addon.addonTitle, "Valid AnkiDroid JS Addon")
         assertEquals(addon.version, "1.0.0")
-        assertEquals(addon.ankidroidJsApi, "0.0.3")
+        assertEquals(addon.ankidroidJsApi, "0.0.4")
         assertEquals(addon.addonType, "reviewer")
         assertEquals(addon.icon, "") // reviewer icon is empty
 

--- a/AnkiDroid/src/test/resources/test-js-addon.json
+++ b/AnkiDroid/src/test/resources/test-js-addon.json
@@ -5,11 +5,9 @@
         "version": "1.1.1",
         "description": "Show progress bar in AnkiDroid, this package may not be used in node_modules. For using this addon view. https://github.com/ankidroid/Anki-Android/pull/9232",
         "main": "index.js",
-        "ankidroidJsApi": "0.0.3",
+        "ankidroidJsApi": "0.0.4",
         "addonType": "reviewer",
-        "keywords": [
-            "ankidroid-js-addon"
-        ],
+        "keywords": ["ankidroid-js-addon"],
         "author": {
             "name": "krmanik",
             "email": "infinyte01@gmail.com",
@@ -31,11 +29,9 @@
         "version": "1.0.1",
         "description": "This addon will listed in Addon Browser. Also AddonInfo.isValidAnkiDroidAddon return true for this package. For more view. https://github.com/ankidroid/Anki-Android/pull/9232",
         "main": "index.js",
-        "ankidroidJsApi": "0.0.3",
+        "ankidroidJsApi": "0.0.4",
         "addonType": "reviewer",
-        "keywords": [
-            "ankidroid-js-addon"
-        ],
+        "keywords": ["ankidroid-js-addon"],
         "author": {
             "name": "krmanik",
             "email": "infinyte01@gmail.com",

--- a/AnkiDroid/src/test/resources/valid-ankidroid-js-addon-test.json
+++ b/AnkiDroid/src/test/resources/valid-ankidroid-js-addon-test.json
@@ -2,7 +2,7 @@
     "name": "valid-ankidroid-js-addon-test",
     "addonTitle": "Valid AnkiDroid JS Addon",
     "version": "1.0.0",
-    "ankidroidJsApi": "0.0.3",
+    "ankidroidJsApi": "0.0.4",
     "addonType": "reviewer",
     "description": "This addon will listed in Addon Browser. Also AddonInfo.isValidAnkiDroidAddon return true for this package. For more view. https://github.com/ankidroid/Anki-Android/pull/9232",
     "main": "index.js",
@@ -13,9 +13,7 @@
         "type": "git",
         "url": "git+https://github.com/krmanik/ankidroid-js-addon.git"
     },
-    "keywords": [
-        "ankidroid-js-addon"
-    ],
+    "keywords": ["ankidroid-js-addon"],
     "author": {
         "name": "krmanik",
         "email": "infinyte01@gmail.com",


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

<!---
Uncomment this section if AI tools were used. New contributors may not use AI tools. See:
https://github.com/ankidroid/Anki-Android/blob/main/AI_POLICY.md
> [!NOTE]
--->
> Assisted-by: Claude Sonnet 5

## Purpose / Description
_Describe the problem or feature and motivation_

`ankiGetNextTime1-4` and `ankiGetDeckName` returned the raw response text instead of a parsed object, unlike the other API methods. The backend already emits valid JSON for these endpoints via `ApiResult.String`.

BREAKING CHANGE: these five methods now resolve to an object rather than a JSON string. Cards calling `JSON.parse()` on the result must drop it. API version bumped to 0.0.4.


## Fixes
* Fixes #21452

## Approach
_How does this change address the problem?_

Removed the `endpoint.includes("nextTime") || endpoint.includes("deckName")` special case in `handleRequest` (`js-api.js`) so every endpoint goes through `JSON.parse`. Nothing else needed changing: `AnkiDroidJsAPI.convertToByteArray(apiContract, string)` already wraps these values in `ApiResult.String`, whose `toString()` builds a `JSONObject` — the same `{"success": …, "value": …}` envelope used by every other endpoint. The special case dates back to the sync-to-async conversion (#14564) and had no counterpart on the backend.

`CURRENT_JS_API_VERSION` bumped to `0.0.4` (`MINIMUM_JS_API_VERSION` left at `0.0.3`), and the version comment in `js-api.js` updated to match. Cards still supplying `0.0.3` keep working and get the "update your API version" snackbar.

## How Has This Been Tested?

Manually, in the reviewer WebView, using the reproduction from the issue:

```js
const jsApiContract = { version: "0.0.4", developer: "test@test.com" };
const api = new AnkiDroidJS(jsApiContract);
api.ankiGetDeckName().then(r => console.log(typeof r, r));
api.ankiGetNextTime1().then(r => console.log(typeof r, r));
```

Before: `string {"success" : true, "value": "…"}`. After: `object {success: true, value: "…"}`, matching `ankiIsDisplayingAnswer` and the rest.


## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->