### PR TITLE
feat: improve handling of "Anki already open, or media currently syncing"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -43,6 +43,7 @@ import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.compat.CompatHelper
 import com.ichi2.anki.contextmenu.AnkiCardContextMenu
 import com.ichi2.anki.contextmenu.CardBrowserContextMenu
+import com.ichi2.anki.exception.CollectionLockedException
 import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.exception.SystemStorageException
 import com.ichi2.anki.logging.FragmentLifecycleLogger
@@ -135,6 +136,7 @@ open class AnkiDroidApp :
         initializeWidgetRepository()
         WidgetNotificationScheduler.register { scheduleNotification() }
         Animations.setPreferencesProvider { context -> PrefsRepository(context) }
+        CollectionLockedException.messageProvider = { getString(R.string.database_locked_summary_new, getString(R.string.col_path)) }
         val logType = LogType.value
         when (logType) {
             LogType.DEBUG -> Timber.plant(DebugTree())

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -31,6 +31,7 @@ import com.ichi2.anki.common.annotations.UseContextParameter
 import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.destinations.DeckOptionsDestination
+import com.ichi2.anki.common.destinations.PreferencesDestination
 import com.ichi2.anki.dialogs.DatabaseErrorDialog
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType
 import com.ichi2.anki.exception.CollectionLockedException
@@ -39,6 +40,7 @@ import com.ichi2.anki.exception.StorageNotConfiguredException
 import com.ichi2.anki.libanki.exception.InvalidSearchException
 import com.ichi2.anki.pages.fromCurrentDeck
 import com.ichi2.anki.pages.toIntent
+import com.ichi2.anki.preferences.toIntent
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.startup.redirectToMainEntryPoint
 import com.ichi2.anki.ui.internationalization.sentenceCase
@@ -721,6 +723,20 @@ data class CrashReportData(
             }
         }
 
+        /**
+         * Opens settings at the Advanced screen, where changing the 'AnkiDroid directory'
+         * resolves a [CollectionLockedException] (#21051)
+         */
+        data object OpenAdvancedSettings : HelpAction() {
+            override fun buttonText(context: Context): CharSequence = context.getString(R.string.settings)
+
+            override suspend fun execute(context: Context): Boolean {
+                Timber.i("Opening 'Advanced settings'")
+                context.startActivity(PreferencesDestination.Advanced.toIntent(context))
+                return true
+            }
+        }
+
         /** Opens 'Check Database' */
         data object OpenCheckDatabase : HelpAction() {
             override fun buttonText(context: Context): CharSequence = with(context) { TR.sentenceCase.checkDatabase }
@@ -749,6 +765,7 @@ data class CrashReportData(
                     }
 
                 if (link != null) return AnkiBackendLink(link)
+                if (e is CollectionLockedException) return OpenAdvancedSettings
                 if (e.isInvalidFsrsParametersException()) return OpenDeckOptions
                 if (e.isDeckNotFoundInLimitsMapException()) return OpenCheckDatabase
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -33,6 +33,7 @@ import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.destinations.DeckOptionsDestination
 import com.ichi2.anki.dialogs.DatabaseErrorDialog
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType
+import com.ichi2.anki.exception.CollectionLockedException
 import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.exception.StorageNotConfiguredException
 import com.ichi2.anki.libanki.exception.InvalidSearchException
@@ -198,7 +199,9 @@ suspend fun <T> FragmentActivity.runCatching(
                 Timber.w(exc, errorMessage)
                 if (!isFinishing) redirectToMainEntryPoint()
             }
-            is BackendNetworkException, is BackendSyncException, is StorageAccessException, is BackendCardTypeException -> {
+            is BackendNetworkException, is BackendSyncException, is StorageAccessException, is BackendCardTypeException,
+            is CollectionLockedException,
+            -> {
                 // these exceptions do not generate worthwhile crash reports
                 Timber.i("Showing error dialog but not sending a crash report.")
                 showError(exc.localizedMessage!!, exc.toCrashReportData(this, reportException = false))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -36,6 +36,7 @@ import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.common.storage.StorageDecision
 import com.ichi2.anki.common.utils.android.SdCard
 import com.ichi2.anki.compat.CompatHelper.Companion.sdkVersion
+import com.ichi2.anki.exception.CollectionLockedException
 import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService.setPreferencesUpToDate
@@ -78,7 +79,7 @@ object InitialActivity {
             try {
                 CollectionManager.getColUnsafe()
                 return null
-            } catch (e: BackendException.BackendDbException.BackendDbLockedException) {
+            } catch (e: CollectionLockedException) {
                 Timber.w(e)
                 StartupFailure.DatabaseLocked
             } catch (e: BackendException.BackendDbException.BackendDbFileTooNewException) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/account/LoginFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/account/LoginFragment.kt
@@ -40,11 +40,14 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import com.ichi2.anki.CollectionManager.TR
+import com.ichi2.anki.CrashReportData.Companion.toCrashReportData
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
 import com.ichi2.anki.account.AccountActivity.Companion.START_FROM_DECKPICKER
 import com.ichi2.anki.dialogs.help.HelpDialog
+import com.ichi2.anki.exception.CollectionLockedException
 import com.ichi2.anki.getEndpoint
+import com.ichi2.anki.showError
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.ext.isCompactWidth
@@ -227,7 +230,15 @@ class LoginFragment : Fragment(R.layout.fragment_my_account) {
                         showLoginSuccessDialog()
                     }
                     is LoginState.Error -> {
-                        showSnackbar(text = state.exception.message.toString())
+                        when (val exception = state.exception) {
+                            // the locked-collection guidance is too long for a snackbar
+                            is CollectionLockedException ->
+                                requireContext().showError(
+                                    exception.localizedMessage!!,
+                                    exception.toCrashReportData(requireContext(), reportException = false),
+                                )
+                            else -> showSnackbar(text = exception.message.toString())
+                        }
                     }
                     is LoginState.Idle -> { /* Not needed */ }
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -598,7 +598,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                 DIALOG_CONFIRM_DATABASE_CHECK -> res().getString(R.string.check_db_warning)
                 DIALOG_CONFIRM_RESTORE_BACKUP -> res().getString(R.string.restore_backup)
                 DIALOG_ONE_WAY_SYNC_FROM_SERVER -> res().getString(R.string.backup_full_sync_from_server_question)
-                DIALOG_DB_LOCKED -> res().getString(R.string.database_locked_summary)
+                DIALOG_DB_LOCKED -> res().getString(R.string.database_locked_summary_new, res().getString(R.string.col_path))
                 INCOMPATIBLE_DB_VERSION -> {
                     var databaseVersion = -1
                     try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -29,6 +29,8 @@ import com.ichi2.anki.R
 import com.ichi2.anki.ankiActivity
 import com.ichi2.anki.backend.DatabaseCorruption
 import com.ichi2.anki.backend.getDatabaseVersion
+import com.ichi2.anki.common.destinations.PreferencesDestination
+import com.ichi2.anki.common.destinations.navigate
 import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType.DIALOG_CONFIRM_DATABASE_CHECK
@@ -352,12 +354,15 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                 }
             }
             DIALOG_DB_LOCKED -> {
-                // If the database is locked, all we can do is ask the user to exit.
                 alertDialog.show {
                     title(R.string.database_locked_title)
                     message(text = message)
                     positiveButton(R.string.close) {
                         closeCollectionAndFinish()
+                    }
+                    // the user can change the 'AnkiDroid directory' to resolve the conflict
+                    neutralButton(R.string.settings) {
+                        navigate(PreferencesDestination.Advanced)
                     }
                     cancelable(false)
                 }

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -117,7 +117,7 @@
 
     <!-- Database Errors-->
     <string name="database_locked_title">Database Locked</string>
-    <string name="database_locked_summary">The AnkiDroid database is in use by another application. Please close the other application then reopen AnkiDroid.</string>
+    <string name="database_locked_summary_new" comment="%s is the name of the 'AnkiDroid directory' setting">Another AnkiDroid app is using this collection. It may conflict even when it is not visibly running.\n\nTo keep using both apps, change the ‘%s’ in one app\'s Advanced settings.\n\nTo use this app now, force-stop the conflicting app.</string>
 
 
     <string name="incompatible_database_version_title">Incompatible Database Version</string>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CoroutineHelpersRobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CoroutineHelpersRobolectricTest.kt
@@ -4,7 +4,13 @@ package com.ichi2.anki
 
 import androidx.fragment.app.FragmentActivity
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.exception.CollectionLockedException
 import com.ichi2.anki.exception.StorageNotConfiguredException
+import com.ichi2.testutils.BackendEmulatingOpenConflict
+import kotlinx.coroutines.test.runTest
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
@@ -31,5 +37,47 @@ class CoroutineHelpersRobolectricTest : RobolectricTest() {
         val redirect = shadowOf(activity).nextStartedActivity
         assertNotNull(redirect, "the main entry point should be opened")
         assertEquals(IntentHandler::class.qualifiedName, redirect.component?.className)
+    }
+
+    /**
+     * #21051: the collection lock is normally held by a second AnkiDroid install sharing the
+     * AnkiDroid folder. The backend's 'Anki already open' text doesn't explain this on Android,
+     * where the other app is invisible: [CollectionLockedException] carries guidance naming the
+     * likely cause instead.
+     */
+    @Test
+    fun `launchCatchingTask explains a locked collection`() =
+        withLockedCollection {
+            throwOnShowError = false
+            val activity = Robolectric.buildActivity(FragmentActivity::class.java).create().get()
+            activity.setTheme(R.style.Theme_Light)
+
+            activity.launchCatchingTask { withCol { } }
+            advanceRobolectricLooper()
+
+            assertThat(getAlertDialogText(true), containsString("Advanced settings"))
+        }
+
+    /** See `launchCatchingTask explains a locked collection`: the ViewModel error funnel */
+    @Test
+    fun `launchCatching explains a locked collection`() =
+        withLockedCollection {
+            runTest {
+                var message: String? = null
+
+                launchCatching(errorMessageHandler = { message = it }) { withCol { } }.join()
+
+                assertThat(message, containsString("Advanced settings"))
+            }
+        }
+
+    /** Emulates #21051: another AnkiDroid install holds the collection lock */
+    private fun withLockedCollection(block: () -> Unit) {
+        BackendEmulatingOpenConflict.enable()
+        try {
+            block()
+        } finally {
+            BackendEmulatingOpenConflict.disable()
+        }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CoroutineHelpersRobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CoroutineHelpersRobolectricTest.kt
@@ -2,11 +2,14 @@
 
 package com.ichi2.anki
 
+import android.content.DialogInterface
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.FragmentActivity
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.exception.CollectionLockedException
 import com.ichi2.anki.exception.StorageNotConfiguredException
+import com.ichi2.anki.preferences.PreferencesActivity
 import com.ichi2.testutils.BackendEmulatingOpenConflict
 import kotlinx.coroutines.test.runTest
 import org.hamcrest.CoreMatchers.containsString
@@ -15,6 +18,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.Shadows.shadowOf
+import org.robolectric.shadows.ShadowDialog
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -69,6 +73,31 @@ class CoroutineHelpersRobolectricTest : RobolectricTest() {
 
                 assertThat(message, containsString("Advanced settings"))
             }
+        }
+
+    /**
+     * The locked-collection dialog offers Settings, opened at the Advanced screen, where
+     * changing the 'AnkiDroid directory' resolves the conflict
+     */
+    @Test
+    fun `a locked collection error links to Advanced settings`() =
+        withLockedCollection {
+            throwOnShowError = false
+            val activity = Robolectric.buildActivity(FragmentActivity::class.java).create().get()
+            activity.setTheme(R.style.Theme_Light)
+
+            activity.launchCatchingTask { withCol { } }
+            advanceRobolectricLooper()
+
+            val helpButton = (ShadowDialog.getLatestDialog() as AlertDialog).getButton(DialogInterface.BUTTON_NEUTRAL)
+            assertEquals("Settings", helpButton.text.toString())
+
+            helpButton.performClick()
+            advanceRobolectricLooper()
+
+            val settings = shadowOf(activity).nextStartedActivity
+            assertNotNull(settings, "Advanced settings should be opened")
+            assertEquals(PreferencesActivity::class.qualifiedName, settings.component?.className)
         }
 
     /** Emulates #21051: another AnkiDroid install holds the collection lock */

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -3,6 +3,7 @@ package com.ichi2.anki
 
 import android.Manifest.permission.INTERNET
 import android.annotation.SuppressLint
+import android.content.DialogInterface
 import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
@@ -38,6 +39,7 @@ import com.ichi2.anki.dialogs.utils.title
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.navigation.AnkiDroidNavigator
 import com.ichi2.anki.observability.ChangeManager
+import com.ichi2.anki.preferences.PreferencesActivity
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.internationalization.sentenceCase
@@ -256,6 +258,30 @@ class DeckPickerTest : RobolectricTest() {
             deckPicker.databaseErrorDialog,
             equalTo(DatabaseErrorDialogType.DIALOG_DB_LOCKED),
         )
+    }
+
+    /**
+     * The 'Database Locked' dialog offers Settings, opened at the Advanced screen, where
+     * changing the 'AnkiDroid directory' resolves the conflict (#21051). Without it, the
+     * dialog's only button quits the app, contradicting the guidance in its own message.
+     */
+    @Test
+    fun `database locked dialog links to Advanced settings`() {
+        val deckPicker = startRegularActivity<DeckPicker>()
+        deckPicker.showDatabaseErrorDialog(DatabaseErrorDialogType.DIALOG_DB_LOCKED)
+        deckPicker.supportFragmentManager.executePendingTransactions()
+        advanceRobolectricLooper()
+
+        val settingsButton = (ShadowDialog.getLatestDialog() as AlertDialog).getButton(DialogInterface.BUTTON_NEUTRAL)
+        assertEquals("Settings", settingsButton.text.toString())
+
+        shadowOf(deckPicker).clearNextStartedActivities()
+        settingsButton.performClick()
+        advanceRobolectricLooper()
+
+        val settings = shadowOf(deckPicker).nextStartedActivity
+        assertNotNull(settings, "Advanced settings should be opened")
+        assertEquals(PreferencesActivity::class.qualifiedName, settings.component?.className)
     }
 
     /** Until the storage setup flow exists (#19552), the user gets recovery options, not a crash */

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -346,7 +346,7 @@ open class RobolectricTest :
     }
 
     /**
-     * Emulates a null collection and a `BackendDbLockedException` while [block] runs,
+     * Emulates a null collection and a `CollectionLockedException` while [block] runs,
      * restoring normal collection behavior afterwards.
      *
      * @see enableNullCollection

--- a/AnkiDroid/src/test/java/com/ichi2/anki/account/LoginFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/account/LoginFragmentTest.kt
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.account
+
+import android.widget.Button
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.android.material.textfield.TextInputEditText
+import com.ichi2.anki.R
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.throwOnShowError
+import com.ichi2.testutils.BackendEmulatingOpenConflict
+import com.ichi2.ui.TextInputEditField
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LoginFragmentTest : RobolectricTest() {
+    @Before
+    override fun setUp() {
+        super.setUp()
+        BackendEmulatingOpenConflict.enable()
+    }
+
+    @After
+    override fun tearDown() {
+        super.tearDown()
+        BackendEmulatingOpenConflict.disable()
+    }
+
+    /**
+     * #21051: the locked-collection guidance is multi-sentence, so it is shown in a dialog
+     * rather than truncated in the login screen's snackbar
+     */
+    @Test
+    fun `login with a locked collection shows guidance`() {
+        throwOnShowError = false
+        val activity = startRegularActivity<AccountActivity>(AccountActivity.getIntent(targetContext))
+        activity.findViewById<TextInputEditText>(R.id.username).setText("user@example.com")
+        activity.findViewById<TextInputEditField>(R.id.password).setText("hunter2")
+
+        activity.findViewById<Button>(R.id.login_button).performClick()
+        advanceRobolectricLooper()
+
+        assertThat(getAlertDialogText(true), containsString("Advanced settings"))
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/BackendEmulatingOpenConflictTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/BackendEmulatingOpenConflictTest.kt
@@ -18,7 +18,7 @@ package com.ichi2.testutils
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.RobolectricTest
-import net.ankiweb.rsdroid.BackendException.BackendDbException.BackendDbLockedException
+import com.ichi2.anki.exception.CollectionLockedException
 import org.junit.After
 import org.junit.Assert.assertThrows
 import org.junit.Before
@@ -42,7 +42,7 @@ class BackendEmulatingOpenConflictTest : RobolectricTest() {
     @Test
     fun assumeMocksAreValid() {
         assertThrows(
-            BackendDbLockedException::class.java,
+            CollectionLockedException::class.java,
         ) { CollectionManager.getColUnsafe() }
     }
 }

--- a/anki-common/src/main/kotlin/com/ichi2/anki/CollectionManager.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/CollectionManager.kt
@@ -26,6 +26,7 @@ import com.ichi2.anki.common.storage.StorageDecision
 import com.ichi2.anki.common.utils.android.Threads
 import com.ichi2.anki.common.utils.android.isRobolectric
 import com.ichi2.anki.common.utils.isRunningAsUnitTest
+import com.ichi2.anki.exception.CollectionLockedException
 import com.ichi2.anki.exception.StorageNotConfiguredException
 import com.ichi2.anki.exception.SystemStorageException
 import com.ichi2.anki.libanki.Collection
@@ -299,15 +300,20 @@ object CollectionManager {
             throw CollectionHelper.systemStorageFailure ?: StorageNotConfiguredException()
         }
         ensureBackendInner()
-        emulatedOpenFailure?.triggerFailure()
-        if (collection == null || collection!!.dbClosed) {
-            val collectionPath = collectionPathInValidFolder()
-            collection =
-                collection(
-                    collectionFiles = collectionPath,
-                    databaseBuilder = { backend -> createDatabaseUsingRustBackend(backend) },
-                    backend = backend,
-                )
+        try {
+            emulatedOpenFailure?.triggerFailure()
+            if (collection == null || collection!!.dbClosed) {
+                val collectionPath = collectionPathInValidFolder()
+                collection =
+                    collection(
+                        collectionFiles = collectionPath,
+                        databaseBuilder = { backend -> createDatabaseUsingRustBackend(backend) },
+                        backend = backend,
+                    )
+            }
+        } catch (e: BackendException.BackendDbException.BackendDbLockedException) {
+            // All consumers should better explain the issue
+            throw CollectionLockedException(e)
         }
     }
 
@@ -475,7 +481,7 @@ object CollectionManager {
     }
 
     enum class CollectionOpenFailure {
-        /** Raises [BackendException.BackendDbException.BackendDbLockedException] */
+        /** Raises [BackendException.BackendDbException.BackendDbLockedException], surfaced as [CollectionLockedException] */
         LOCKED,
 
         /** Raises [BackendException.BackendFatalError] */

--- a/anki-common/src/main/kotlin/com/ichi2/anki/exception/CollectionLockedException.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/exception/CollectionLockedException.kt
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.exception
+
+import net.ankiweb.rsdroid.BackendException
+import net.ankiweb.rsdroid.BackendException.BackendDbException.BackendDbLockedException
+
+/**
+ * The collection database is locked by another process: normally a parallel AnkiDroid install.
+ *
+ * Thrown in place of [BackendDbLockedException] for a better user-facing error:
+ *
+ * * Inform the user two apps using the same folder are not supported.
+ * * Inform them they need to change the folder (via 'AnkiDroid directory')
+ * * Inform them that they should use 'Force close' to temporarily solve it.
+ * * Inform the user the app may not be running.
+ *
+ * Note: "Anki already open, or media currently syncing." is currently hardcoded as an error.
+ * `rslib/src/error/db.rs`
+ */
+class CollectionLockedException(
+    cause: BackendDbLockedException,
+) : BackendException(messageProvider?.invoke() ?: cause.localizedMessage) {
+    init {
+        initCause(cause)
+    }
+
+    companion object {
+        /**
+         * Localized, user-facing guidance shown wherever this exception is displayed.
+         *
+         * Set at app startup: this module cannot access the app's string resources.
+         * TODO: after #21500, use the string directly
+         */
+        var messageProvider: (() -> String)? = null
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

## Purpose / Description
* A user was not given guidance when this occurred
* There was no way to open 'AnkiDroid directory' from these errors

## Fixes
* Fixes #21051

## Approach
* Define a `CollectionLockedException`, replacing `BackendDbLockedException`
* Update the string
* Display the error in a dialog
* Add 'Settings' button, opening 'Advanced Settings'


## How Has This Been Tested?
Unit tested
<img width="319" height="362" alt="Screenshot 2026-08-15 at 15 05 37" src="https://github.com/user-attachments/assets/61b8767b-3dbc-45e6-a154-dc77b7df0505" />

```patch
Index: AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt	(revision 36eb6ffad29bfe3db410eae31adc844cc95bac53)
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt	(date 1786802726064)
@@ -510,6 +510,24 @@
 
         setViewBinding(binding)
         enableToolbar()
+
+        // TEMP (#21051): manual testing of the locked-collection dialogs. DO NOT COMMIT
+        // 1. Uncomment the next line, relaunch -> 'Database Locked' startup dialog:
+         CollectionManager.emulatedOpenFailure = CollectionManager.CollectionOpenFailure.LOCKED
+        // 2. Or long-press the toolbar to toggle the lock at runtime, then:
+        //    - tap Sync (or open a deck) -> runtime error dialog
+        //    - Settings - Sync - AnkiWeb account - Log in -> login error dialog
+        // Force-stop the app to clear the emulated lock if the UI becomes unreachable.
+        findViewById<Toolbar>(R.id.toolbar).setOnLongClickListener {
+            CollectionManager.emulatedOpenFailure =
+                if (CollectionManager.emulatedOpenFailure == null) {
+                    CollectionManager.CollectionOpenFailure.LOCKED
+                } else {
+                    null
+                }
+            showThemedToast(this, "emulated lock: ${CollectionManager.emulatedOpenFailure != null}", true)
+            true
+        }
         // TODO This method is run on every activity recreation, which can happen often.
         //  It seems that the original idea was for this to only run once, on app start.
         //  This method triggers backups, sync, and may re-show dialogs
```

## Learning (optional, can help others)
* The error string is hardcoded upstream. 
* It is not possible for media syncing to cause this

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)