### PR TITLE
fix: `windowBackground` was wrong under edge to edge

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -196,9 +196,8 @@ open class CardBrowser :
         if (showedActivityFailedScreen(savedInstanceState)) {
             return
         }
-        // match the status bar theme of the rest of the app
-        enableEdgeToEdge(statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT))
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge(statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT))
         binding = ActivityCardBrowserBinding.inflate(layoutInflater)
         if (!ensureStorageIsReady()) {
             return

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -483,13 +483,11 @@ open class DeckPicker :
             return
         }
 
-        // match the status bar theme of the rest of the app
+        super.onCreate(savedInstanceState)
         enableEdgeToEdge(
             statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT),
             navigationBarStyle = BottomFadeFrameLayout.navigationBarStyle(),
         )
-        // Then set theme and content view
-        super.onCreate(savedInstanceState)
 
         binding = ActivityHomescreenBinding.inflate(layoutInflater)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerActivity.kt
@@ -30,8 +30,8 @@ import kotlin.reflect.jvm.jvmName
  */
 class CardViewerActivity : SingleFragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
-        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivity.kt
@@ -30,7 +30,6 @@ import com.ichi2.anki.databinding.ActivityPermissionsBinding
 import com.ichi2.anki.ui.windows.permissions.PermissionsFragment.Companion.HAS_ALL_PERMISSIONS_KEY
 import com.ichi2.anki.ui.windows.permissions.PermissionsFragment.Companion.PERMISSIONS_FRAGMENT_RESULT_KEY
 import com.ichi2.anki.utils.ext.setFragmentResultListener
-import com.ichi2.themes.Themes
 import com.ichi2.themes.setTransparentStatusBar
 import dev.androidbroadcast.vbpd.viewBinding
 import timber.log.Timber
@@ -57,7 +56,6 @@ class PermissionsActivity : AnkiActivity(R.layout.activity_permissions) {
         }
         super.onCreate(savedInstanceState)
         setViewBinding(binding)
-        Themes.setTheme(this)
         setTransparentStatusBar()
 
         binding.continueButton.setOnClickListener { finish() }

--- a/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
@@ -27,6 +27,7 @@ import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.graphics.drawable.toDrawable
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.fragment.app.FragmentActivity
+import com.ichi2.anki.BuildConfig
 import com.ichi2.anki.R
 import com.ichi2.anki.common.utils.android.systemIsInNightMode
 import com.ichi2.anki.settings.PrefsRepository
@@ -35,6 +36,7 @@ import com.ichi2.anki.settings.enums.DayTheme
 import com.ichi2.anki.settings.enums.NightTheme
 import com.ichi2.anki.settings.enums.Theme
 import com.ichi2.themes.Themes.currentTheme
+import timber.log.Timber
 
 /**
  * Helper methods to configure things related to AnkiDroid's themes
@@ -55,6 +57,15 @@ object Themes {
         val tv = TypedValue()
         activity.theme.resolveAttribute(android.R.attr.windowBackground, tv, true)
         val hadLauncherSplash = tv.resourceId == R.drawable.launch_screen
+
+        // If the decor view already exists, `windowBackground` can no longer be updated by setTheme
+        // `hadLauncherSplash` is exempt: its window background is replaced below.
+        if (!hadLauncherSplash && activity.window.peekDecorView() != null) {
+            val message =
+                "Decor view was initialized before setTheme(): windowBackground is stale. " +
+                    "Move window access (e.g. enableEdgeToEdge()) after super.onCreate()"
+            if (BuildConfig.DEBUG) throw IllegalStateException(message) else Timber.w(message)
+        }
 
         setTheme(activity as Context)
 

--- a/AnkiDroid/src/test/java/com/ichi2/themes/ThemesTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/themes/ThemesTest.kt
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.themes
+
+import android.content.Intent
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.util.TypedValue
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.AnkiActivity
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.StudyOptionsActivity
+import com.ichi2.anki.settings.PrefsRepository
+import com.ichi2.anki.settings.enums.AppTheme
+import com.ichi2.anki.settings.enums.NightTheme
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RuntimeEnvironment
+import kotlin.test.assertFailsWith
+
+@RunWith(AndroidJUnit4::class)
+class ThemesTest : RobolectricTest() {
+    /**
+     * If the decor view is created before [Themes.setTheme] applies the user's theme, the theme's
+     * windowBackground is not applied and night mode renders a white background (issue 21520).
+     * Ensure this fails fast in debug builds rather than rendering incorrectly.
+     */
+    @Test
+    fun `decor view access before setTheme fails fast`() {
+        val exception =
+            assertFailsWith<IllegalStateException> {
+                Robolectric.buildActivity(EarlyDecorViewInitActivity::class.java).create()
+            }
+        assertThat(exception.message, containsString("setTheme"))
+    }
+
+    @Test
+    fun `window background follows the night theme - issue 21520`() {
+        RuntimeEnvironment.setQualifiers("+night")
+        PrefsRepository(targetContext).apply {
+            appTheme = AppTheme.NIGHT
+            nightTheme = NightTheme.DARK
+        }
+        val activity =
+            startActivityNormallyOpenCollectionWithIntent(
+                StudyOptionsActivity::class.java,
+                Intent(),
+            )
+
+        val tv = TypedValue()
+        activity.theme.resolveAttribute(android.R.attr.windowBackground, tv, true)
+        assertThat(
+            "the theme's windowBackground is expected to be a plain color",
+            tv.type in TypedValue.TYPE_FIRST_COLOR_INT..TypedValue.TYPE_LAST_COLOR_INT,
+            equalTo(true),
+        )
+        val decorBackground = activity.window.decorView.background
+        assertThat((decorBackground as ColorDrawable).color, equalTo(tv.data))
+    }
+
+    /** simulates e.g. an [androidx.activity.enableEdgeToEdge] call before `super.onCreate` */
+    class EarlyDecorViewInitActivity : AnkiActivity() {
+        override fun onCreate(savedInstanceState: Bundle?) {
+            window.decorView
+            super.onCreate(savedInstanceState)
+        }
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

## Purpose / Description
`enableEdgeToEdge()` before `onCreate()` locks in `windowBackground`. This caused a bug when trying to migrate `StudyOptionsActivity`


## Fixes
* Part of #17334
* Part of #21520

## Approach
* Fix the issues
* Add a DEBUG-only crash

## How Has This Been Tested?
Unit test + my prep for #21520

* The previewer is unchanged

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)