### PR TITLE
fix(navigation-drawer): fix edge to edge truncation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -25,8 +25,12 @@ import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
 import androidx.core.view.GravityCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.get
 import androidx.core.view.size
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 import androidx.drawerlayout.widget.ClosableDrawerLayout
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.fragment.app.Fragment
@@ -166,6 +170,7 @@ abstract class NavigationDrawerActivity(
                 setNavigationItemSelectedListener(this@NavigationDrawerActivity)
                 menu.findItem(R.id.nav_decks)?.title = TR.actionsDecks()
                 menu.findItem(R.id.nav_stats)?.title = TR.statisticsTitle()
+                setupDrawerInsets(this)
             }
         val toolbar: Toolbar? = mainView.findViewById(R.id.toolbar)
         if (toolbar != null) {
@@ -218,6 +223,33 @@ abstract class NavigationDrawerActivity(
         enablePostShortcut(this)
         val intent = Intent("com.ichi2.widget.UPDATE_WIDGET").setClassName("com.ichi2.widget", "WidgetPermissionReceiver")
         this.sendBroadcast(intent)
+    }
+
+    /**
+     * Edge to edge: the header image and rows extend to the window edge. The text labels
+     * are not drawn underneath the system UI.
+     */
+    private fun setupDrawerInsets(navigationView: NavigationView) {
+        val contentWidth = resources.getDimensionPixelSize(R.dimen.nav_drawer_width)
+        val itemPadding = navigationView.itemHorizontalPadding
+        val dividerInset = navigationView.dividerInsetStart
+        // setting the values below requests a layout: only do so if the inset changed
+        var appliedStartInset = -1
+        ViewCompat.setOnApplyWindowInsetsListener(navigationView) { view, insets ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
+            // the top is not inset: the header image is meant to draw under the status bar
+            view.updatePadding(bottom = bars.bottom)
+
+            // Widen by the start inset, so the usable width is unchanged.
+            val startInset = if (view.layoutDirection == View.LAYOUT_DIRECTION_RTL) bars.right else bars.left
+            if (startInset != appliedStartInset) {
+                appliedStartInset = startInset
+                navigationView.itemHorizontalPadding = itemPadding + startInset
+                navigationView.dividerInsetStart = dividerInset + startInset
+                view.updateLayoutParams { width = contentWidth + startInset }
+            }
+            insets
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/res/layout/include_navigation_drawer.xml
+++ b/AnkiDroid/src/main/res/layout/include_navigation_drawer.xml
@@ -4,7 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/navdrawer_items_container"
     style="@style/NavDrawer"
-    android:layout_width="wrap_content"
+    android:layout_width="@dimen/nav_drawer_width"
     android:layout_height="match_parent"
     android:layout_gravity="start"
     app:headerLayout="@layout/view_navdrawer_header"

--- a/AnkiDroid/src/main/res/values-sw600dp/dimens.xml
+++ b/AnkiDroid/src/main/res/values-sw600dp/dimens.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="keyline_1">24dp</dimen>
+    <!-- matches the default maxWidth of a Material 3 NavigationView -->
+    <dimen name="nav_drawer_width">360dp</dimen>
     <dimen name="study_options_padding">16dp</dimen>
     <dimen name="deck_picker_left_padding_small">16dp</dimen>
     <dimen name="deck_picker_left_padding">24dp</dimen>

--- a/AnkiDroid/src/main/res/values-sw600dp/styles.xml
+++ b/AnkiDroid/src/main/res/values-sw600dp/styles.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Margin already matches ActionBar height on tablets, just modify width -->
+    <!-- Margin already matches ActionBar height on tablets -->
     <style name="NavDrawer">
-        <item name="android:layout_width">320dp</item>
         <item name="android:layout_marginRight">0dp</item>
     </style>
 </resources>

--- a/AnkiDroid/src/main/res/values/dimens.xml
+++ b/AnkiDroid/src/main/res/values/dimens.xml
@@ -11,6 +11,7 @@
 
     <!-- Match 56dp default ActionBar height on portrait orientation -->
     <dimen name="nav_drawer_margin_offset">-8dp</dimen>
+    <dimen name="nav_drawer_width">280dp</dimen>
 
     <!-- Material design dialogs -->
     <dimen name="dialog_frame_margin">24dp</dimen>

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -12,9 +12,7 @@
 
     <!-- Nav drawer style to set width specified by Material Design specification -->
     <style name="NavDrawer">
-        <item name="android:layout_width">280dp</item>
         <item name="android:layout_marginRight">@dimen/nav_drawer_margin_offset</item>
-        <item name="android:maxWidth">280dp</item>
     </style>
 
     <style name="OverflowMenuStyle" parent="Widget.Material3.PopupMenu.Overflow">

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NavigationDrawerScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NavigationDrawerScreenshotTest.kt
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki
+
+import android.annotation.SuppressLint
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.core.view.GravityCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsCompat.Type.navigationBars
+import androidx.core.view.WindowInsetsCompat.Type.statusBars
+import com.ichi2.testutils.insetsOf
+import com.ichi2.utils.dp
+import org.junit.Test
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * Screenshot tests for the navigation drawer of [NavigationDrawerActivity]
+ *
+ * [DeckPicker] is used as the host activity
+ *
+ * `./gradlew :AnkiDroid:verifyRoborazziPlayDebug -Pscreenshot --tests "com.ichi2.anki.NavigationDrawerScreenshotTest"`
+ */
+class NavigationDrawerScreenshotTest : ScreenshotTest() {
+    @Test
+    fun navigationDrawer_edgeToEdge() =
+        withDeckPicker(deckCount = 5) { deckPicker ->
+            openDrawer(deckPicker)
+            deckPicker.simulateEdgeToEdge()
+            captureScreen("navigationDrawer")
+        }
+
+    /**
+     * Landscape with 3-button navigation on the same side as the drawer: the drawer's
+     * content must clear the navigation bar rather than sliding underneath it.
+     */
+    @Test
+    fun navigationDrawer_sideNavigationBar() {
+        RuntimeEnvironment.setQualifiers("+land")
+        withDeckPicker(deckCount = 5) { deckPicker ->
+            openDrawer(deckPicker)
+            deckPicker.simulateLeftNavigationBar()
+            captureScreen("sideNavigationBar")
+        }
+    }
+
+    private fun openDrawer(deckPicker: DeckPicker) {
+        deckPicker.drawerLayout.openDrawer(GravityCompat.START, false)
+        advanceRobolectricLooper()
+    }
+
+    /**
+     * Robolectric reports zero system-bar insets by default. Inject realistic ones so the app's
+     * edge-to-edge layout responds as it would on a real device, and overlay a translucent band
+     * where the nav bar would sit to see if content is drawn underneath it.
+     */
+    private fun DeckPicker.simulateLeftNavigationBar() {
+        val navBarWidth = 48.dp
+        val insets =
+            with(targetContext) {
+                WindowInsetsCompat
+                    .Builder()
+                    .setInsets(statusBars(), insetsOf(top = 24.dp))
+                    .setInsets(navigationBars(), insetsOf(left = navBarWidth))
+                    .build()
+            }
+        ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
+
+        val decor = window.decorView as ViewGroup
+        val navBarOverlay =
+            View(this).apply {
+                // the navigationBarColor of the app's themes
+                setBackgroundResource(R.color.semi_transparent_black)
+            }
+        decor.addView(
+            navBarOverlay,
+            FrameLayout.LayoutParams(
+                navBarWidth.toPx(targetContext),
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                // windowInsets does not have a concept of "START"
+                @SuppressLint("RtlHardcoded")
+                Gravity.LEFT,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

## Fixes
* Fixes #21527

## Approach
Apply insets on the edge nearest to the screen

## How Has This Been Tested?

API 37; 

<img width="2142" height="960" alt="image" src="https://github.com/user-attachments/assets/c0e17eea-5e6e-4f23-a1f6-9dbe1b2d3d1b" />

<img width="2142" height="960" alt="image" src="https://github.com/user-attachments/assets/541d7c1c-dda1-467e-baf8-44c422674fde" />


API 30 & API 29

<img width="714" height="326" alt="Screenshot 2026-08-16 at 11 00 50" src="https://github.com/user-attachments/assets/74ae6393-3921-47e4-b9df-ccbe0ee2fb76" />
<img width="707" height="341" alt="Screenshot 2026-08-16 at 10 57 26" src="https://github.com/user-attachments/assets/13b277aa-4b51-45a9-84bd-994ffd23d720" />


## Learning (optional, can help others)
I'm unhappy with the white on white in the status bar, but I deem this to be 'Won't Fix' - it's been like this for a long time and @ShaanNarendran is working on removing the drawer.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)