### PR TITLE
fix(crash-reporting): don't crash if triggered before init

### DIFF
--- a/common/android/src/main/java/com/ichi2/anki/common/crashreporting/CrashReportService.kt
+++ b/common/android/src/main/java/com/ichi2/anki/common/crashreporting/CrashReportService.kt
@@ -69,13 +69,16 @@ interface CrashReporter {
  * Global crash reporting service. Delegates to the [CrashReporter] implementation
  * set during app initialization.
  *
+ * Until initialization, reports are logged and dropped ([UninitializedCrashReporter]):
+ * crash reporting is called from error-handling paths, so it must never throw.
+ *
  * Usage:
  * ```
  * CrashReportService.sendExceptionReport(exception, "MyClass.myMethod")
  * ```
  */
 object CrashReportService {
-    lateinit var instance: CrashReporter
+    var instance: CrashReporter = UninitializedCrashReporter
         private set
 
     fun setReporter(reporter: CrashReporter) {
@@ -84,6 +87,12 @@ object CrashReportService {
 
     @VisibleForTesting
     fun getReporter(): CrashReporter = instance
+
+    /** Reset [instance] to the initial reporter implementation which only logs exceptions */
+    @VisibleForTesting
+    fun resetForTesting() {
+        instance = UninitializedCrashReporter
+    }
 
     /**
      * Reports a non-fatal issue without a [Throwable].
@@ -143,6 +152,81 @@ object CrashReportService {
         context: Context,
         defaultValue: Boolean,
     ): Boolean = instance.isEnabled(context, defaultValue)
+}
+
+/**
+ * The [CrashReporter] in place before [CrashReportService.setReporter] is called.
+ *
+ * Log-only: [dropReport]; [warnUnexpectedUse]
+ */
+private object UninitializedCrashReporter : CrashReporter {
+    override fun sendExceptionReport(
+        message: String?,
+        origin: String?,
+    ) {
+        dropReport(null, message, origin)
+    }
+
+    override fun sendExceptionReport(
+        e: Throwable,
+        origin: String?,
+        additionalInfo: String?,
+        onlyIfSilent: Boolean,
+    ) {
+        dropReport(e, additionalInfo, origin)
+    }
+
+    override fun sendExceptionReport(
+        e: Throwable,
+        origin: String?,
+        additionalInfo: String?,
+        onlyIfSilent: Boolean,
+        context: Context,
+    ) {
+        dropReport(e, additionalInfo, origin)
+    }
+
+    override fun onPreferenceChanged(
+        ctx: Context,
+        newValue: String,
+    ) {
+        warnUnexpectedUse("onPreferenceChanged")
+    }
+
+    override fun deleteLimiterData(context: Context) {
+        warnUnexpectedUse("deleteLimiterData")
+    }
+
+    override fun setReportingMode(value: String) {
+        warnUnexpectedUse("setReportingMode")
+    }
+
+    override fun isEnabled(
+        context: Context,
+        defaultValue: Boolean,
+    ): Boolean {
+        warnUnexpectedUse("isEnabled")
+        return defaultValue
+    }
+
+    override fun sendReport(activity: Activity): Boolean {
+        warnUnexpectedUse("sendReport")
+        return false
+    }
+
+    private fun dropReport(
+        e: Throwable?,
+        message: String?,
+        origin: String?,
+    ) {
+        Timber.e("CrashReportService not initialized: dropping report of %s (%s)", e?.javaClass?.name, origin)
+        // ensure PII does not go to ACRA
+        Timber.d(e, "dropped report (%s: %s)", origin, message)
+    }
+
+    private fun warnUnexpectedUse(method: String) {
+        Timber.w("CrashReportService not initialized: %s ignored", method)
+    }
 }
 
 /**

--- a/common/android/src/test/java/com/ichi2/anki/common/crashreporting/CrashReportServiceTest.kt
+++ b/common/android/src/test/java/com/ichi2/anki/common/crashreporting/CrashReportServiceTest.kt
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.common.crashreporting
+
+import android.util.Log
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import timber.log.Timber
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class CrashReportServiceTest {
+    private data class LogEntry(
+        val priority: Int,
+        val message: String,
+        val throwable: Throwable?,
+    )
+
+    private val logs = mutableListOf<LogEntry>()
+
+    private val recordingTree =
+        object : Timber.Tree() {
+            override fun log(
+                priority: Int,
+                tag: String?,
+                message: String,
+                t: Throwable?,
+            ) {
+                logs.add(LogEntry(priority, message, t))
+            }
+        }
+
+    @BeforeEach
+    fun setUp() {
+        CrashReportService.resetForTesting()
+        Timber.plant(recordingTree)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Timber.uproot(recordingTree)
+    }
+
+    /**
+     * Crash reporting is called from error-handling paths, so it must never throw.
+     *
+     * A report can be sent before [CrashReportService.setReporter] is called during
+     * app initialization: `AnkiDroidApp.onCreate` may return early (#5887), and
+     * `ContentProvider`s are created before `Application.onCreate` completes.
+     */
+    @Test
+    fun `reporting before initialization is logged, not thrown`() {
+        val exception = Exception("reported before setReporter")
+
+        CrashReportService.sendExceptionReport(exception, origin = "CrashReportServiceTest")
+
+        // WARN is collected into ACRA reports (LOGCAT report field): no PII
+        val error = logs.single { it.priority == Log.ERROR }
+        assertNull(error.throwable, "ERROR should not contain the throwable: its message may contain PII")
+        assertFalse(error.message.contains(exception.message!!), "ERROR should not contain the exception message")
+        assertTrue(error.message.contains("java.lang.Exception"), "ERROR should contain the exception class")
+
+        // DEBUG is not collected into ACRA reports: full detail for local debugging
+        val debug = logs.single { it.priority == Log.DEBUG }
+        assertSame(debug.throwable, exception, "DEBUG should contain the dropped exception")
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

## Purpose / Description
The main rationale was for tests below `:AnkiDroid` where a reporter setup was required (and no reasonable teardown was available).

* onCreate() returns early when `setupAnkiDroidApp()` fails
* `ContentProviders` are created before `Application.onCreate()`

⚠️ Trade-off: a missed setReporter() call now degrades to warnings instead of failing fast.


## Approach
* define `UninitializedCrashReporter`
* define `resetForTesting`

## How Has This Been Tested?
⚠️ Untested

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->