### PR TITLE
Enable edge to edge support for CardAnalysisWidgetConfig

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidgetConfig.kt
@@ -22,7 +22,14 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Bundle
+import android.view.ViewGroup
+import androidx.activity.enableEdgeToEdge
 import androidx.core.os.BundleCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsCompat.Type.displayCutout
+import androidx.core.view.WindowInsetsCompat.Type.systemBars
+import androidx.core.view.updateMargins
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
@@ -77,7 +84,13 @@ class CardAnalysisWidgetConfig : AnkiActivity(R.layout.activity_card_analysis_wi
         if (!ensureStorageIsReady()) {
             return
         }
-
+        enableEdgeToEdge()
+        ViewCompat.setOnApplyWindowInsetsListener(binding.content) { _, insets ->
+            val constraints = insets.getInsets(systemBars() or displayCutout())
+            val params = binding.content.layoutParams as ViewGroup.MarginLayoutParams
+            params.updateMargins(left = constraints.left, right = constraints.right, bottom = constraints.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
         preferences = CardAnalysisWidgetPreferences(this)
         appWidgetId = intent.getAppWidgetId()
         if (appWidgetId == INVALID_APPWIDGET_ID) {

--- a/AnkiDroid/src/main/res/layout/activity_card_analysis_widget_config.xml
+++ b/AnkiDroid/src/main/res/layout/activity_card_analysis_widget_config.xml
@@ -7,6 +7,7 @@
     android:layout_height="match_parent">
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/content"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:padding="16dp">


### PR DESCRIPTION
## Purpose / Description
Enable edge to edge support for CardAnalysisWidgetConfig activity.
Some images:

API 28:

<img width="309" height="670" alt="Screenshot_20260816_182231" src="https://github.com/user-attachments/assets/53c39ed8-20d4-4407-b06e-4daa68f3a32c" />
<img width="670" height="309" alt="Screenshot_20260816_182220" src="https://github.com/user-attachments/assets/c1b1fe9d-14d6-4f53-8042-8c44cfbb81fc" />
<img width="670" height="309" alt="Screenshot_20260816_182245" src="https://github.com/user-attachments/assets/ca03d398-6292-471c-9b00-e1615fbe955e" />

API 36:

<img width="270" height="600" alt="Screenshot_20260816_182356" src="https://github.com/user-attachments/assets/12aa823d-b491-447e-a3ae-5970aa598f61" />
<img width="600" height="270" alt="Screenshot_20260816_182408" src="https://github.com/user-attachments/assets/36489d4d-22b7-4cf2-b84f-21d13567526c" />
<img width="600" height="270" alt="Screenshot_20260816_182427" src="https://github.com/user-attachments/assets/e08877ac-dbae-438f-a91b-bb6fd3c0b0f8" />


## Fixes
* Fixes #21518

## How Has This Been Tested?

Checked on emulatos: API 28(big cutout+system bars) and API 36(punch cutout+system bars)

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
