### PR TITLE
feat: Path picker GUI

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
@@ -22,7 +22,6 @@ import android.content.pm.PackageManager
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.core.app.ActivityCompat
-import androidx.preference.EditTextPreference
 import androidx.preference.Preference
 import androidx.preference.SwitchPreferenceCompat
 import com.ichi2.anki.CollectionManager
@@ -38,6 +37,7 @@ import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.startup.getDefaultAnkiDroidDirectory
 import com.ichi2.anki.utils.openUrl
+import com.ichi2.preferences.ExternalDirectorySelectionPreference
 import com.ichi2.utils.Permissions
 import com.ichi2.utils.Permissions.openAppSettingsScreen
 import com.ichi2.utils.show
@@ -73,7 +73,7 @@ class AdvancedSettingsFragment : SettingsFragment() {
         removeUnnecessaryAdvancedPrefs()
 
         // Check that input is valid before committing change in the collection path
-        requirePreference<EditTextPreference>(CollectionHelper.PREF_COLLECTION_PATH).apply {
+        requirePreference<ExternalDirectorySelectionPreference>(CollectionHelper.PREF_COLLECTION_PATH).apply {
             setOnPreferenceChangeListener { _, newValue: Any? ->
                 val newPath = newValue as String
                 try {
@@ -92,7 +92,7 @@ class AdvancedSettingsFragment : SettingsFragment() {
                         setTitle(R.string.dialog_collection_path_not_dir)
                         setPositiveButton(R.string.dialog_ok) { _, _ -> }
                         setNegativeButton(R.string.reset_custom_buttons) { _, _ ->
-                            text = getDefaultAnkiDroidDirectory(requireContext()).absolutePath
+                            value = getDefaultAnkiDroidDirectory(requireContext()).absolutePath
                         }
                     }
                     false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/File.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/File.kt
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.utils.ext
+
+import java.io.File
+
+/**
+ * @param name Relative file name or path inside this directory.
+ * @return `true` if the named file exists within this directory
+ *
+ * @throws SecurityException If [SecurityManager.checkRead] is used and access is denied.
+ */
+fun File.containsFile(name: String): Boolean {
+    if (!isDirectory) return false
+
+    val maybeFile = File(this, name).canonicalFile
+
+    // guard against path traversal
+    if (!maybeFile.path.startsWith(this.canonicalPath + File.separator)) return false
+
+    // ensure the file exists, and is not a directory
+    return maybeFile.isFile
+}

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ExternalDirectorySelectionPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ExternalDirectorySelectionPreference.kt
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: 2024 David Allison <davidallisongithub@gmail.com>
+// SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.preferences
+
+import android.content.Context
+import android.graphics.Color
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.style.ForegroundColorSpan
+import android.util.AttributeSet
+import android.view.ViewGroup
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+import androidx.preference.ListPreference
+import androidx.preference.ListPreferenceDialogFragmentCompat
+import com.ichi2.anki.R
+import com.ichi2.anki.common.crashreporting.runCatchingWithLog
+import com.ichi2.anki.common.utils.android.showThemedToast
+import com.ichi2.anki.startup.getDefaultAnkiDroidDirectory
+import com.ichi2.anki.utils.ext.containsFile
+import com.ichi2.utils.input
+import com.ichi2.utils.negativeButton
+import com.ichi2.utils.positiveButton
+import com.ichi2.utils.show
+import timber.log.Timber
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Paths
+
+/**
+ * Lets the user pick the AnkiDroid directory from a list of detected storage
+ * locations, so an SD card can be chosen without knowing its path.
+ * A custom path can still be typed in via the dialog.
+ */
+class ExternalDirectorySelectionPreference(
+    context: Context,
+    attrs: AttributeSet?,
+) : ListPreference(context, attrs),
+    DialogFragmentProvider {
+    init {
+        summaryProvider =
+            SummaryProvider<ListPreference> { pref ->
+                pref.value.takeUnless { it.isNullOrEmpty() } ?: context.getString(R.string.pref_directory_not_set)
+            }
+    }
+
+    /** The default AnkiDroid directory, or null if storage is unavailable. */
+    private val defaultAnkiDir: File?
+        get() =
+            try {
+                getDefaultAnkiDroidDirectory(context)
+            } catch (e: Exception) {
+                Timber.w(e, "Could not access default AnkiDroid directory")
+                null
+            }
+
+    /**
+     * Builds the candidate paths to show: the current value, the default
+     * directory, and anything found by scanning storage.
+     */
+    private fun loadDirectories(): List<String> =
+        buildList {
+            if (value?.isNotEmpty() == true) {
+                add(File(value))
+            }
+            defaultAnkiDir?.let { add(it) }
+            addAll(getScannedDirectories())
+        }.map { it.absolutePath }
+            .distinct()
+
+    private fun isValidAnkiDir(dir: File): Boolean {
+        try {
+            if (!dir.isDirectory || dir.name.startsWith(".")) return false
+            if (IGNORED_DIRECTORIES.contains(dir.name.lowercase())) return false
+            if (dir.name.startsWith("AnkiDroid", ignoreCase = true)) return true
+            return dir.containsFile("collection.anki2")
+        } catch (e: Exception) {
+            Timber.w(e, "Could not access directory")
+            return false
+        }
+    }
+
+    /**
+     * Scans the external storage roots for AnkiDroid directories.
+     * A root with none, or which cannot be listed, is offered as a new AnkiDroid location instead.
+     */
+    private fun getScannedDirectories(): List<File> {
+        val storageRoots =
+            runCatchingWithLog("get storage roots") {
+                context.getExternalFilesDirs(null)
+            }.getOrNull()
+                .orEmpty()
+                .filterNotNull()
+
+        fun File.getValidAnkiSubfolders(): List<File>? {
+            val subFolders = listFiles() ?: return null
+            return subFolders.filter { isValidAnkiDir(it) }.ifEmpty { null }
+        }
+
+        return storageRoots.flatMap { root ->
+            when (val ankiFolders = root.getValidAnkiSubfolders()) {
+                // If no anki directories are found, we can list this as it is likely an SD card
+                null -> listOf(File(root, "AnkiDroid"))
+                else -> ankiFolders
+            }
+        }
+    }
+
+    // TODO: Possibly move loadDirectories() to a background thread if ANR occurs
+    override fun makeDialogFragment(): DialogFragment {
+        val paths = loadDirectories()
+        entries = paths.map(::toDisplayLabel).toTypedArray()
+        entryValues = paths.toTypedArray()
+        return FullWidthListPreferenceDialogFragment()
+    }
+
+    /** Builds the display label for a path, graying out its storage root. */
+    private fun toDisplayLabel(path: String): CharSequence {
+        // Split at "/Android/" so the root is gray and the rest keeps the normal color
+        // Eg: "/storage/emulated/0" is gray, "/Android/data/com.ichi2.anki" is not
+        val androidIndex = path.indexOf("/Android/")
+        if (androidIndex == -1) return path
+        val displayString = "${path.take(androidIndex)}\n${path.substring(androidIndex)}"
+        return SpannableString(displayString).apply {
+            setSpan(ForegroundColorSpan(Color.GRAY), 0, androidIndex, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+    }
+
+    companion object {
+        private val IGNORED_DIRECTORIES = setOf("collection.media", "backups", "cache", "code_cache")
+    }
+}
+
+/** List dialog stretched to full width, with a neutral button to enter a custom path. */
+class FullWidthListPreferenceDialogFragment : ListPreferenceDialogFragmentCompat() {
+    override fun onPrepareDialogBuilder(builder: AlertDialog.Builder) {
+        super.onPrepareDialogBuilder(builder)
+        builder.setNeutralButton(R.string.pref_custom_path) { _, _ -> showCustomPathInput() }
+    }
+
+    private fun showCustomPathInput() {
+        val context = requireContext()
+        val pref = (preference as? ExternalDirectorySelectionPreference) ?: return
+        AlertDialog
+            .Builder(context)
+            .show {
+                setTitle(R.string.pref_enter_custom_path)
+                setView(R.layout.dialog_generic_text_input)
+                positiveButton(android.R.string.ok)
+                negativeButton(android.R.string.cancel)
+            }.input(
+                prefill = pref.value ?: "",
+                allowEmpty = false,
+            ) { dialog, text ->
+                try {
+                    // normalize before saving so "a//b/" and "a/b" become one entry
+                    val pathObj = Paths.get(text.toString().trim()).toAbsolutePath().normalize()
+                    val newPath = pathObj.toString()
+                    Files.createDirectories(pathObj)
+                    if (!Files.isWritable(pathObj)) {
+                        showThemedToast(
+                            context,
+                            context.getString(R.string.pref_directory_not_writable),
+                            true,
+                        )
+                        return@input
+                    }
+                    dialog.dismiss()
+                    if (pref.callChangeListener(newPath)) {
+                        pref.value = newPath
+                    }
+                } catch (e: Exception) {
+                    Timber.w(e, "Failed to set custom path")
+                    AlertDialog.Builder(context).show {
+                        setTitle(context.getString(R.string.could_not_create_dir, text.toString()))
+                        setMessage(e.stackTraceToString())
+                        positiveButton(android.R.string.ok)
+                    }
+                }
+            }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.setLayout(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+        )
+    }
+}

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -472,4 +472,10 @@ this formatter is used if the bind only applies to the answer">A: %s</string>
     <!--Keyboard shortcuts dialog-->
     <string name="open_settings" comment="Description of the shortcut that opens the app settings">Open settings</string>
     <string name="related_settings_title" comment="Title of the section for related settings">Related settings</string>
+
+    <!-- External Directory Selection Preference -->
+    <string name="pref_directory_not_set" comment="Summary of the AnkiDroid directory setting when no directory is set">Not set</string>
+    <string name="pref_custom_path" maxLength="41" comment="Dialog button letting the user type a directory path manually">Custom path</string>
+    <string name="pref_enter_custom_path" maxLength="41">Enter custom path</string>
+    <string name="pref_directory_not_writable">Directory is not writable</string>
 </resources>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -22,14 +22,12 @@
 
 <!-- Advanced Preferences -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:title="@string/pref_cat_advanced"
     android:key="@string/pref_advanced_screen_key">
-        <EditTextPreference
+        <com.ichi2.preferences.ExternalDirectorySelectionPreference
             android:defaultValue="/sdcard/AnkiDroid"
             android:key="@string/pref_ankidroid_directory_key"
-            android:title="@string/col_path"
-            app:useSimpleSummaryProvider="true"/>
+            android:title="@string/col_path"/>
         <Preference
             android:summary="@string/reset_languages_summ"
             android:title="@string/reset_languages"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/utils/ext/ContainsFileTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/utils/ext/ContainsFileTest.kt
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 Ashish Yadav <mailtoashish693@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+package com.ichi2.anki.utils.ext
+
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/** Tests for [File.containsFile] */
+class ContainsFileTest {
+    @get:Rule
+    val temp = TemporaryFolder()
+
+    @Test
+    fun `finds an existing file`() {
+        temp.newFile("collection.anki2")
+        assertTrue(temp.root.containsFile("collection.anki2"))
+    }
+
+    @Test
+    fun `false when the file does not exist`() {
+        assertFalse(temp.root.containsFile("collection.anki2"))
+    }
+
+    @Test
+    fun `false when the name points to a directory`() {
+        temp.newFolder("collection.anki2")
+        assertFalse(temp.root.containsFile("collection.anki2"))
+    }
+
+    @Test
+    fun `finds a file in a subdirectory`() {
+        temp.newFolder("sub")
+        temp.newFile("sub/collection.anki2")
+        assertTrue(temp.root.containsFile("sub/collection.anki2"))
+    }
+
+    @Test
+    fun `false for a path escaping the directory`() {
+        temp.newFile("secret.txt")
+        val sub = temp.newFolder("sub")
+        assertFalse(sub.containsFile("../secret.txt"))
+    }
+
+    @Test
+    fun `false for an empty name`() {
+        assertFalse(temp.root.containsFile(""))
+    }
+
+    @Test
+    fun `false when the receiver is not a directory`() {
+        val file = temp.newFile("plain.txt")
+        assertFalse(file.containsFile("anything"))
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/preferences/ExternalDirectorySelectionPreferenceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/preferences/ExternalDirectorySelectionPreferenceTest.kt
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+
+package com.ichi2.preferences
+
+import androidx.core.content.edit
+import androidx.preference.PreferenceManager
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.common.storage.CollectionHelper
+import com.ichi2.anki.startup.getDefaultAnkiDroidDirectory
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasItem
+import org.hamcrest.Matchers.instanceOf
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+/**
+ * Tests that [ExternalDirectorySelectionPreference] offers the directories a user
+ * would expect to pick from.
+ */
+@RunWith(AndroidJUnit4::class)
+class ExternalDirectorySelectionPreferenceTest : RobolectricTest() {
+    @Test
+    fun `the default directory is offered`() {
+        val pref = buildPreference()
+
+        assertThat(pref.entryPaths(), hasItem(getDefaultAnkiDroidDirectory(targetContext).absolutePath))
+    }
+
+    @Test
+    fun `the current directory is offered`() {
+        val current = File(targetContext.filesDir, "AnkiDroidTest").absolutePath
+        targetContext.sharedPrefs().edit(commit = true) {
+            putString(CollectionHelper.PREF_COLLECTION_PATH, current)
+        }
+
+        val pref = buildPreference()
+
+        assertThat(pref.entryPaths(), hasItem(current))
+    }
+
+    @Test
+    fun `each entry has a label`() {
+        val pref = buildPreference()
+        pref.makeDialogFragment()
+
+        assertThat(pref.entries.size, equalTo(pref.entryValues.size))
+    }
+
+    @Test
+    fun `the dialog is the full width list`() {
+        val pref = buildPreference()
+
+        assertThat(pref.makeDialogFragment(), instanceOf(FullWidthListPreferenceDialogFragment::class.java))
+    }
+
+    /** Builds the preference attached to a screen, as the settings screen does */
+    private fun buildPreference(): ExternalDirectorySelectionPreference {
+        val pref = ExternalDirectorySelectionPreference(targetContext, null)
+        pref.key = CollectionHelper.PREF_COLLECTION_PATH
+        val preferenceManager = PreferenceManager(targetContext)
+        val screen = preferenceManager.createPreferenceScreen(targetContext)
+        preferenceManager.setPreferences(screen)
+        screen.addPreference(pref)
+        return pref
+    }
+
+    /** The paths offered by the dialog */
+    private fun ExternalDirectorySelectionPreference.entryPaths(): List<String> {
+        makeDialogFragment()
+        return entryValues.map { it.toString() }
+    }
+}

--- a/common/android/src/main/java/com/ichi2/anki/common/crashreporting/CrashReportService.kt
+++ b/common/android/src/main/java/com/ichi2/anki/common/crashreporting/CrashReportService.kt
@@ -178,3 +178,29 @@ fun <T> runCatchingWithReport(
         if (e is Error) throw e
         Result.failure(e)
     }
+
+/**
+ * Runs the provided block, catching [Exception] and logging it.
+ *
+ * Unlike [runCatchingWithReport], this does **not** send a crash report.
+ *
+ * **Note**: This differs from [runCatching] - `Error` is thrown
+ *
+ * @param origin Data logged to Timber
+ * @param block Code to execute
+ *
+ * @throws Error If raised, this will be rethrown
+ *
+ * @return A Result containing either the successful result of [block] or the [Exception] thrown
+ */
+fun <T> runCatchingWithLog(
+    origin: String? = null,
+    block: () -> T,
+): Result<T> =
+    try {
+        Result.success(block())
+    } catch (e: Throwable) {
+        Timber.w(e, origin)
+        if (e is Error) throw e
+        Result.failure(e)
+    }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

> [!NOTE]
> Assisted-by: Claude Opus 5

## Purpose / Description
- This supersedes #19855 which was approved but went stale. The work is @ShaanNarendran  (built on a patch from @david-allison) and every commit carries his co-author trailer. Taken over with his permission.

## Fixes
* Fixes #3114

## Approach
See commits, i have broken down the original pr into cleaner commits and few more tests (that doesnt hurt)

## How Has This Been Tested?
Everything stays same as original PR: 
<img width="337" height="636" alt="Screenshot 2026-08-16 at 10 22 47 PM" src="https://github.com/user-attachments/assets/809ad8de-e92b-4a99-955b-21069742243e" />


## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->