### PR TITLE
fix: host the screen in AccountActivity

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/account/AccountActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/account/AccountActivity.kt
@@ -50,6 +50,6 @@ class AccountActivity : SingleFragmentActivity() {
                     Bundle().apply {
                         putBoolean(START_FROM_DECKPICKER, forResult)
                     },
-            )
+            ).setClass(context, AccountActivity::class.java)
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/IntroductionActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/IntroductionActivityTest.kt
@@ -21,6 +21,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.SingleFragmentActivity.Companion.EXTRA_FRAGMENT_NAME
+import com.ichi2.anki.account.AccountActivity
 import com.ichi2.anki.account.LoginFragment
 import com.ichi2.anki.introduction.SetupCollectionFragment
 import com.ichi2.anki.introduction.SetupCollectionFragment.CollectionSetupOption.DeckPickerWithNewCollection
@@ -67,9 +68,9 @@ class IntroductionActivityTest : RobolectricTest() {
 
             val intent = assertNotNull(shadowOf(activity).nextStartedActivity)
             assertThat(
-                "host activity is SingleFragmentActivity",
+                "host activity is AccountActivity",
                 intent.component?.shortClassName,
-                equalTo(SingleFragmentActivity::class.java.name),
+                equalTo(AccountActivity::class.java.name),
             )
             assertThat(
                 "hosted fragment is LoginFragment",


### PR DESCRIPTION


## Purpose / Description
- While porting this screen to edge to edge (#21513) I noticed that AccountActivity never actually runs. It is declared in the manifest, but nothing ever launches it.

## Fixes
NA

## Approach
Refer commit, faily straight forward

## How Has This Been Tested?
Build and API36

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->