### PR TITLE
Enable edge to edge for CardBrowserAppearanceEditor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
@@ -17,13 +17,21 @@ package com.ichi2.anki
 
 import android.content.Context
 import android.content.Intent
+import android.graphics.Color
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.EditText
 import androidx.activity.OnBackPressedCallback
+import androidx.activity.SystemBarStyle
+import androidx.activity.enableEdgeToEdge
 import androidx.annotation.CheckResult
 import androidx.appcompat.app.AlertDialog
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat.Type.displayCutout
+import androidx.core.view.WindowInsetsCompat.Type.ime
+import androidx.core.view.WindowInsetsCompat.Type.systemBars
+import androidx.core.view.updatePadding
 import androidx.core.widget.doAfterTextChanged
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.common.utils.android.showThemedToast
@@ -60,6 +68,20 @@ class CardTemplateBrowserAppearanceEditor : AnkiActivity(R.layout.activity_card_
             return
         }
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge(statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT))
+        ViewCompat.setOnApplyWindowInsetsListener(binding.toolbarContainer) { view, insets ->
+            val constraints = insets.getInsets(systemBars() or displayCutout())
+            view.updatePadding(left = constraints.left, right = constraints.right, top = constraints.top)
+            // don't mark as CONSUMED, it breaks the insets for the next view on lower API versions
+            insets
+        }
+        // handle the content, adds the ime in the constraints so the user can also scroll the
+        // content while keyboard is on
+        ViewCompat.setOnApplyWindowInsetsListener(binding.contentScroller) { view, insets ->
+            val constraints = insets.getInsets(systemBars() or displayCutout() or ime())
+            view.updatePadding(left = constraints.left, right = constraints.right, bottom = constraints.bottom)
+            insets
+        }
         val bundle = savedInstanceState ?: intent.extras
         if (bundle == null) {
             showThemedToast(this, getString(R.string.something_wrong), true)

--- a/AnkiDroid/src/main/res/layout/activity_card_browser_appearance.xml
+++ b/AnkiDroid/src/main/res/layout/activity_card_browser_appearance.xml
@@ -1,12 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical" android:layout_width="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <include layout="@layout/include_toolbar" />
+    <FrameLayout
+        android:id="@+id/toolbar_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/appBarColor">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/appBarColor"
+            android:minHeight="?attr/actionBarSize"
+            android:theme="@style/ActionBarStyle"
+            app:popupTheme="@style/ActionBar.Popup"
+            app:navigationContentDescription="@string/abc_action_bar_up_description"
+            app:navigationIcon="?attr/homeAsUpIndicator"
+            tools:title="Browser appearance"
+            />
+    </FrameLayout>
 
     <ScrollView
+        android:id="@+id/content_scroller"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 


### PR DESCRIPTION
## Purpose / Description

Enable edge to edge for CardBrowserAppearanceEditor activity.
Some images:
Initial look(I also verified the dark theme):
<img width="270" height="600" alt="Screenshot_20260817_093801" src="https://github.com/user-attachments/assets/b75f6aa3-80cd-4212-adf5-41ae9e4b0f2b" />

API 28:

<img width="308" height="662" alt="Screenshot_20260817_085239" src="https://github.com/user-attachments/assets/afc958a1-111f-4cea-8085-f1c111a07804" />
<img width="661" height="308" alt="Screenshot_20260817_085550" src="https://github.com/user-attachments/assets/6f671274-e2aa-4114-8ec9-ec26ba60a4a7" />
<img width="662" height="309" alt="Screenshot_20260817_085607" src="https://github.com/user-attachments/assets/feacf760-10e8-42e9-84bd-e4a39d72067f" />
<img width="662" height="309" alt="Screenshot_20260817_085613" src="https://github.com/user-attachments/assets/bf145a6f-8ce6-4795-b63b-1987c22ad1e7" />

API 36:

<img width="270" height="600" alt="Screenshot_20260817_085026" src="https://github.com/user-attachments/assets/961b3d80-71a3-4c56-9fd4-32e19f3f0d92" />
<img width="600" height="270" alt="Screenshot_20260817_085043" src="https://github.com/user-attachments/assets/c8c63835-3029-4372-be0e-aaba2c6d1536" />
<img width="600" height="270" alt="Screenshot_20260817_085122" src="https://github.com/user-attachments/assets/7838c7e9-84ad-4651-be17-87abc91c3b05" />
<img width="600" height="270" alt="Screenshot_20260817_085151" src="https://github.com/user-attachments/assets/6dfc502c-359d-4f7e-84d6-f7438d316644" />



## Fixes
* Fixes #21511

## How Has This Been Tested?

Manually tested on two emulators: API 28(status bars + big cutout) and API 36 (status bars + punch cutout).

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
