### PR TITLE
fix(themes): remove theme assertion on window recreation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractIntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractIntentHandler.kt
@@ -28,7 +28,7 @@ import com.ichi2.themes.Themes
 abstract class AbstractIntentHandler : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        Themes.setTheme(this)
+        Themes.setTheme(this, savedInstanceState)
         disableXiaomiForceDarkMode(this)
         setContentView(R.layout.activity_progress_bar)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -145,7 +145,7 @@ open class AnkiActivity(
         // The hardware buttons should control the music volume
         volumeControlStream = AudioManager.STREAM_MUSIC
         // Set the theme
-        Themes.setTheme(this)
+        Themes.setTheme(this, savedInstanceState)
         disableXiaomiForceDarkMode(this)
         super.onCreate(savedInstanceState)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/AppLoadedFromBackupWorkaround.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/AppLoadedFromBackupWorkaround.kt
@@ -71,7 +71,7 @@ object AppLoadedFromBackupWorkaround {
 
         // fixes: java.lang.IllegalStateException: You need to use a Theme.AppCompat theme (or descendant) with this activity.
         // on Importer
-        Themes.setTheme(this)
+        Themes.setTheme(this, savedInstanceState)
         // Avoids a SuperNotCalledException
         activitySuperOnCreate(savedInstanceState)
         // Process.killProcess is a hard kill. I suspect that some Android OSes leave has the app in

--- a/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
@@ -21,6 +21,7 @@ package com.ichi2.themes
 import android.app.Activity
 import android.content.Context
 import android.graphics.Color
+import android.os.Bundle
 import android.util.TypedValue
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.content.res.AppCompatResources
@@ -53,14 +54,23 @@ object Themes {
         context.setTheme(currentTheme.styleResId)
     }
 
-    fun setTheme(activity: Activity) {
+    /**
+     * @param savedInstanceState the bundle provided to [Activity.onCreate]
+     */
+    fun setTheme(
+        activity: Activity,
+        savedInstanceState: Bundle?,
+    ) {
         val tv = TypedValue()
         activity.theme.resolveAttribute(android.R.attr.windowBackground, tv, true)
         val hadLauncherSplash = tv.resourceId == R.drawable.launch_screen
 
         // If the decor view already exists, `windowBackground` can no longer be updated by setTheme
         // `hadLauncherSplash` is exempt: its window background is replaced below.
-        if (!hadLauncherSplash && activity.window.peekDecorView() != null) {
+        // Exclude recreation: the decor view can exist before `onCreate`, but the framework
+        // refreshes `windowBackground`.
+        val isRecreation = savedInstanceState != null
+        if (!isRecreation && !hadLauncherSplash && activity.window.peekDecorView() != null) {
             val message =
                 "Decor view was initialized before setTheme(): windowBackground is stale. " +
                     "Move window access (e.g. enableEdgeToEdge()) after super.onCreate()"

--- a/AnkiDroid/src/test/java/com/ichi2/themes/ThemesTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/themes/ThemesTest.kt
@@ -62,6 +62,17 @@ class ThemesTest : RobolectricTest() {
         assertThat((decorBackground as ColorDrawable).color, equalTo(tv.data))
     }
 
+    /**
+     * When an activity is relaunched (e.g. after a day/night theme change), the framework may
+     * preserve the window: the decor view already exists before `super.onCreate`, and the
+     * framework refreshes its `windowBackground` itself, so [Themes.setTheme] should not fail
+     * (issue 21548).
+     */
+    @Test
+    fun `recreated activity with an existing decor view does not fail - issue 21548`() {
+        Robolectric.buildActivity(EarlyDecorViewInitActivity::class.java).create(Bundle())
+    }
+
     /** simulates e.g. an [androidx.activity.enableEdgeToEdge] call before `super.onCreate` */
     class EarlyDecorViewInitActivity : AnkiActivity() {
         override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

## Purpose / Description
This caused a crash when switching themes

## Fixes
* Fixes #21548

## Approach
Relax the debug-only assertion

## How Has This Been Tested?
API 33 emulator

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)