### PR TITLE
Enable edge to edge for NoteTypeFieldEditor activity

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteTypeFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteTypeFieldEditor.kt
@@ -17,6 +17,7 @@
 package com.ichi2.anki
 
 import android.content.Context
+import android.graphics.Color
 import android.os.Bundle
 import android.text.InputType
 import android.view.LayoutInflater
@@ -25,9 +26,17 @@ import android.view.ViewGroup
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.EditText
+import androidx.activity.SystemBarStyle
+import androidx.activity.enableEdgeToEdge
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.core.os.BundleCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsCompat.Type.displayCutout
+import androidx.core.view.WindowInsetsCompat.Type.systemBars
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 import androidx.fragment.app.FragmentManager
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.CollectionManager.TR
@@ -56,6 +65,7 @@ import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.ui.FixedEditText
 import com.ichi2.utils.customView
+import com.ichi2.utils.dp
 import com.ichi2.utils.getInputField
 import com.ichi2.utils.input
 import com.ichi2.utils.moveCursorToEnd
@@ -103,6 +113,21 @@ class NoteTypeFieldEditor : AnkiActivity(R.layout.activity_note_type_field_edito
         }
         setContentView(R.layout.activity_note_type_field_editor)
         enableToolbar()
+        enableEdgeToEdge(statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT))
+        ViewCompat.setOnApplyWindowInsetsListener(binding.rootLayout) { _, insets ->
+            val constraints = insets.getInsets(systemBars() or displayCutout())
+            binding.toolbarContainer.updatePadding(left = constraints.left, right = constraints.right, top = constraints.top)
+            binding.btnAdd.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                bottomMargin = constraints.bottom + 32.dp.toPx(this@NoteTypeFieldEditor)
+                rightMargin = constraints.right + 32.dp.toPx(this@NoteTypeFieldEditor)
+            }
+            binding.fields.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                leftMargin = constraints.left
+                rightMargin = constraints.right
+                bottomMargin = constraints.bottom
+            }
+            WindowInsetsCompat.CONSUMED
+        }
         binding.notetypeName.text = intent.getStringExtra(EXTRA_NOTETYPE_NAME)
         startLoadingCollection()
         setFragmentResultListener(REQUEST_HINT_LOCALE_SELECTION) { _, bundle ->

--- a/AnkiDroid/src/main/res/layout/activity_note_type_field_editor.xml
+++ b/AnkiDroid/src/main/res/layout/activity_note_type_field_editor.xml
@@ -4,18 +4,34 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/root_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:fitsSystemWindows="true">
+    android:layout_height="match_parent">
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <include
-            layout="@layout/include_toolbar"
+        <FrameLayout
+            android:id="@+id/toolbar_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/appBarColor"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            />
+            app:layout_constraintTop_toTopOf="parent">
+
+            <androidx.appcompat.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?attr/appBarColor"
+                android:minHeight="?attr/actionBarSize"
+                android:theme="@style/ActionBarStyle"
+                app:popupTheme="@style/ActionBar.Popup"
+                app:navigationContentDescription="@string/abc_action_bar_up_description"
+                app:navigationIcon="?attr/homeAsUpIndicator"
+                tools:title="Manage fields"
+                />
+        </FrameLayout>
 
         <TextView
             android:id="@+id/notetype_name"
@@ -27,7 +43,7 @@
             android:paddingVertical="24dp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/toolbar"
+            app:layout_constraintTop_toBottomOf="@id/toolbar_container"
             tools:text="Basic"
             />
 


### PR DESCRIPTION
## Purpose / Description
Enables edge to edge for NoteTypeFieldEditor activity. Just using _fitSystemWindows_ didn't really work.

Some images:

Initial look:
<img width="270" height="600" alt="Screenshot_20260820_200518" src="https://github.com/user-attachments/assets/a0dff432-e9f8-4e67-b243-960c2eba9199" />

API 28:
<img width="308" height="662" alt="Screenshot_20260820_195710" src="https://github.com/user-attachments/assets/e2f7e87f-9e5d-4688-b1a8-5e44fdd0f45a" />
<img width="662" height="309" alt="Screenshot_20260820_195726" src="https://github.com/user-attachments/assets/450dec58-7afd-43eb-9cc0-64b0a56b55d5" />
<img width="661" height="308" alt="Screenshot_20260820_195739" src="https://github.com/user-attachments/assets/320f4288-e507-4c87-96f4-2e7327a769e7" />

API 36:

<img width="270" height="600" alt="Screenshot_20260820_195607" src="https://github.com/user-attachments/assets/f0cc0a9a-29db-442d-a62e-b61a8a66f819" />
<img width="600" height="270" alt="Screenshot_20260820_195625" src="https://github.com/user-attachments/assets/42c2f39b-f8fb-446c-b57b-30aede22b395" />
<img width="600" height="270" alt="Screenshot_20260820_195637" src="https://github.com/user-attachments/assets/3686b356-67eb-4cf2-871e-a8e8c59a7329" />

## Fixes
* Fixes #21509

## How Has This Been Tested?

Manually on two emulators(checked a dark theme as well): API 28(big notch + navigation bar) and API 36 (punch cutout _ navigation bar)

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

