### PR TITLE
fix(controls): improve post-assignment dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
@@ -27,7 +27,8 @@ import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.ext.sharedPrefs
 import com.ichi2.preferences.ControlPreference
 import com.ichi2.preferences.ReviewerControlPreference
-import com.ichi2.utils.show
+import com.ichi2.utils.negativeButton
+import com.ichi2.utils.positiveButton
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -239,23 +240,28 @@ class ControlsSettingsFragment :
             )
         for (key in answerCommandKeys) {
             (findPreference<Preference>(key) as? ReviewerControlPreference)?.let { answerPref ->
-                val items =
-                    arrayOf(
-                        getString(R.string.only_answer),
-                        getString(R.string.flip_and_answer),
-                    )
                 answerPref.setOnBindingSelectedListener { binding ->
+                    val isAlreadyAssigned =
+                        showAnswerPref?.getMappableBindings()?.any {
+                            it.binding == binding &&
+                                (it.side == CardSide.QUESTION || it.side == CardSide.BOTH)
+                        } == true
+                    if (isAlreadyAssigned) {
+                        answerPref.addBinding(binding, CardSide.ANSWER)
+                        return@setOnBindingSelectedListener true
+                    }
+
                     AlertDialog.Builder(requireContext()).show {
                         setTitle(answerPref.title)
                         setIcon(answerPref.icon)
-                        setItems(items) { _, index ->
-                            when (index) {
-                                0 -> answerPref.addBinding(binding, CardSide.ANSWER)
-                                1 -> {
-                                    answerPref.addBinding(binding, CardSide.ANSWER)
-                                    showAnswerPref?.addBinding(binding, CardSide.QUESTION)
-                                }
-                            }
+                        setMessage(getString(R.string.also_assign_binding_to_show_answer, getString(R.string.show_answer)))
+
+                        positiveButton(text = getString(R.string.dialog_assign)) {
+                            answerPref.addBinding(binding, CardSide.ANSWER)
+                            showAnswerPref?.addBinding(binding, CardSide.QUESTION)
+                        }
+                        negativeButton(text = getString(R.string.dialog_skip)) {
+                            answerPref.addBinding(binding, CardSide.ANSWER)
                         }
                     }
                     true

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -236,7 +236,7 @@
 
     <string name="note_editor_replace_newlines" maxLength="41">Replace newlines with HTML</string>
     <string name="note_editor_replace_newlines_summ">In the note editor, convert any instances of &lt;br&gt; to newlines when editing a card.</string>
-    
+
     <string name="type_in_answer_focus" maxLength="41">Focus ‘type in answer’</string>
     <string name="type_in_answer_focus_summ">Automatically focus the ‘type in answer’ field in the study screen</string>
 
@@ -464,10 +464,12 @@ this formatter is used if the bind only applies to the answer">A: %s</string>
         ><![CDATA[Improved study screen that will succeed the current one. Some features of the old screen have been changed or removed. Please report any <a href="%1$s">feedback</a> or <a href="%2$s">bugs</a>.]]></string>
     <string name="show_answer_feedback" maxLength="41">Show answer feedback</string>
     <string name="screen" maxLength="41">Screen</string>
-    <string name="only_answer" maxLength="41" comment="Configuration of the 'Answer' commands to only answer the card"
-        >Only answer</string>
-    <string name="flip_and_answer" maxLength="41" comment="Configuration of the 'Answer' commands to answer the card if on the answer side, and flip it if on the question side"
-        >Flip and answer</string>
+    <string name="also_assign_binding_to_show_answer" comment="Question shown after assigning binding to an 'Answer' command, asking whether it should also be assigned to the 'Show answer'; %1$s is 'Show answer'"
+        >Also assign to ‘%1$s’?</string>
+    <string name="dialog_skip" comment="Skip assigning binding to 'Show answer'"
+        >Skip</string>
+    <string name="dialog_assign" comment="Assign binding to 'Answer' command"
+        >Assign</string>
 
     <!--Keyboard shortcuts dialog-->
     <string name="open_settings" comment="Description of the shortcut that opens the app settings">Open settings</string>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/ControlsSettingsFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/ControlsSettingsFragmentTest.kt
@@ -15,12 +15,26 @@
  */
 package com.ichi2.anki.preferences
 
+import android.content.DialogInterface
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.cardviewer.Gesture
+import com.ichi2.anki.common.destinations.DeferredNavigation
+import com.ichi2.anki.reviewer.Binding
+import com.ichi2.anki.reviewer.CardSide
+import com.ichi2.preferences.ReviewerControlPreference
 import com.ichi2.testutils.HamcrestUtils
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasItem
+import org.hamcrest.Matchers.not
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.shadows.ShadowDialog
+import kotlin.test.assertNull
 
 @RunWith(AndroidJUnit4::class)
 class ControlsSettingsFragmentTest : RobolectricTest() {
@@ -39,6 +53,81 @@ class ControlsSettingsFragmentTest : RobolectricTest() {
             val enumKeys = screen.getActions().map { it.preferenceKey }
 
             assertThat(xmlKeys, HamcrestUtils.containsInAnyOrder(enumKeys))
+        }
+    }
+
+    /**
+     * Tests for alert dialog behavior in [ControlsSettingsFragment] using 'swipe up' gesture as the input binding.
+     */
+    @Test
+    fun `skip button binding only to answer`() {
+        withControlsSettings {
+            val binding = Binding.GestureInput(Gesture.SWIPE_UP)
+            answerPref.setBinding(binding)
+            clickAlertDialogButton(DialogInterface.BUTTON_NEGATIVE, checkDismissed = true)
+
+            val showAnswerBindings = showAnswerPref.getMappableBindings().map { Pair(it.binding, it.side) }
+            val answerBindings = answerPref.getMappableBindings().map { Pair(it.binding, it.side) }
+            assertThat("binding is assigned to Show answer", showAnswerBindings, not(hasItem(equalTo(Pair(binding, CardSide.QUESTION)))))
+            assertThat("binding not assigned to answer", answerBindings, hasItem(equalTo(Pair(binding, CardSide.ANSWER))))
+        }
+    }
+
+    @Test
+    fun `assign buttons binding to both answer and show answer`() {
+        withControlsSettings {
+            val binding = Binding.GestureInput(Gesture.SWIPE_UP)
+            answerPref.setBinding(binding)
+            clickAlertDialogButton(DialogInterface.BUTTON_POSITIVE, checkDismissed = true)
+
+            val showAnswerBindings = showAnswerPref.getMappableBindings().map { Pair(it.binding, it.side) }
+            val answerBindings = answerPref.getMappableBindings().map { Pair(it.binding, it.side) }
+            assertThat("binding not assigned to Show answer", showAnswerBindings, hasItem(equalTo(Pair(binding, CardSide.QUESTION))))
+            assertThat("binding not assigned to answer", answerBindings, hasItem(equalTo(Pair(binding, CardSide.ANSWER))))
+        }
+    }
+
+    @Test
+    fun `no dialog if binding is already assigned to show answer`() {
+        withControlsSettings {
+            val binding = Binding.GestureInput(Gesture.SWIPE_UP)
+            showAnswerPref.addBinding(binding, CardSide.QUESTION)
+
+            answerPref.setBinding(binding)
+
+            assertNull(ShadowDialog.getLatestDialog(), "no dialog should be shown")
+            val showAnswerBindings = showAnswerPref.getMappableBindings().map { Pair(it.binding, it.side) }
+            val answerBindings = answerPref.getMappableBindings().map { Pair(it.binding, it.side) }
+            assertThat("binding not kept on Show answer", showAnswerBindings, hasItem(Pair(binding, CardSide.QUESTION)))
+            assertThat("binding not assigned to answer", answerBindings, hasItem(Pair(binding, CardSide.ANSWER)))
+        }
+    }
+}
+
+private val ControlsSettingsFragment.showAnswerPref
+    get() = requirePreference<ReviewerControlPreference>(getString(R.string.show_answer_command_key))
+
+private val ControlsSettingsFragment.answerPref
+    get() = requirePreference<ReviewerControlPreference>(getString(R.string.answer_good_command_key))
+
+/**
+ * launches the [ControlsSettingsFragment] and runs [block] on it.
+ */
+context(_: DeferredNavigation)
+private fun withControlsSettings(block: ControlsSettingsFragment.() -> Unit) {
+    val intent =
+        PreferencesActivity.getIntent(
+            ApplicationProvider.getApplicationContext(),
+            ControlsSettingsFragment::class,
+        )
+    ActivityScenario.launch<PreferencesActivity>(intent).use { scenario ->
+        scenario.onActivity { activity ->
+            val preferencesFragment = activity.fragment as PreferencesFragment
+            val controlsSettingsFragment =
+                preferencesFragment.childFragmentManager.findFragmentByTag(
+                    ControlsSettingsFragment::class.java.name,
+                ) as ControlsSettingsFragment
+            controlsSettingsFragment.block()
         }
     }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

<!---
Uncomment this section if AI tools were used. New contributors may not use AI tools. See:
https://github.com/ankidroid/Anki-Android/blob/main/AI_POLICY.md
> [!NOTE]
> Assisted-by: ___
--->

## Purpose / Description
The 'Only answer' option is supposed to remove the binding from 'Show answer' but it was not doing that. The dialog's appearance was not consistent with the previous subsequent dialogs in controls. Also need to implement option 3 mentioned in the issue.

## Fixes
* Fixes #20759 

## Approach

1. Update the preference resource file Strings according to the option 3.
2. In Fragment, replace the items list and logic, with a question message and consistent buttons
3. Correct the 'No' ( previously 'only answer') logic.

Before:
<img width="1080" height="574" alt="image" src="https://github.com/user-attachments/assets/d9e91b24-0ad1-4258-ac97-cb98c7a95f1a" />


After:
<img width="1080" height="666" alt="Screenshot_20260902-012825" src="https://github.com/user-attachments/assets/24a7ec0a-2db1-45f4-bfcd-339f6d0b252d" />



## How Has This Been Tested?

Unit test, API36

## Learning (optional, can help others)
Learnt about controls settings, testing and the issue related codebase of AnkiDroid

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->