### PR TITLE
feat(reviewer): call `enableEdgeToEdge` (partial support)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -12,6 +12,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
+import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -30,6 +32,8 @@ import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
+import androidx.activity.SystemBarStyle
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.CheckResult
 import androidx.annotation.DrawableRes
@@ -42,7 +46,14 @@ import androidx.appcompat.widget.Toolbar
 import androidx.appcompat.widget.TooltipCompat
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsCompat.Type.displayCutout
+import androidx.core.view.WindowInsetsCompat.Type.ime
+import androidx.core.view.WindowInsetsCompat.Type.navigationBars
+import androidx.core.view.WindowInsetsCompat.Type.systemBars
 import androidx.core.view.isGone
+import androidx.core.view.updatePadding
 import androidx.lifecycle.lifecycleScope
 import anki.frontend.SetSchedulingStatesRequest
 import anki.scheduler.CardAnswer.Rating
@@ -115,7 +126,6 @@ import com.ichi2.anki.utils.ext.flag
 import com.ichi2.anki.utils.ext.getLongOrNull
 import com.ichi2.anki.utils.ext.setUserFlagForCards
 import com.ichi2.anki.utils.ext.showDialogFragment
-import com.ichi2.anki.utils.navBarNeedsScrim
 import com.ichi2.anki.utils.remainingTime
 import com.ichi2.themes.Themes
 import com.ichi2.themes.Themes.currentTheme
@@ -234,9 +244,7 @@ open class Reviewer :
         toolbar = findViewById(R.id.toolbar)
         micToolBarLayer = findViewById(R.id.mic_tool_bar_layer)
         processor = BindingMap(sharedPrefs(), ViewerCommand.entries, this)
-        if (sharedPrefs().getString("answerButtonPosition", "bottom") == "bottom" && !navBarNeedsScrim) {
-            setNavigationBarColor(R.attr.showAnswerColor)
-        }
+        setupEdgeToEdge()
         if (!sharedPrefs().getBoolean("showDeckTitle", false)) {
             // avoid showing "AnkiDroid"
             supportActionBar?.title = ""
@@ -362,7 +370,115 @@ open class Reviewer :
             FullScreenMode.BUTTONS_AND_MENU -> R.layout.activity_reviewer
         }
 
-    public override fun fitsSystemWindows(): Boolean = !fullscreenMode.isFullScreenReview()
+    // insets are handled manually: see setupEdgeToEdge()
+    public override fun fitsSystemWindows(): Boolean = false
+
+    /**
+     * Enables edge-to-edge and applies insets so no content is occluded by the system bars.
+     */
+    private fun setupEdgeToEdge() {
+        if (fullscreenMode.isFullScreenReview()) {
+            // TODO: awaiting follow-up commit for edge to edge support
+            return
+        }
+
+        val answerButtonsPosition =
+            sharedPrefs().getString(getString(R.string.answer_buttons_position_preference), "bottom")
+        val answerButtonsAtBottom = answerButtonsPosition == "bottom"
+        enableEdgeToEdge(
+            // the status bar sits over the app bar, which is dark in every theme except E-Ink
+            statusBarStyle =
+                SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT) {
+                    currentTheme != DayTheme.EINK
+                },
+            navigationBarStyle =
+                if (answerButtonsAtBottom) {
+                    // The answer area is `showAnswerColor` (dark) in every theme
+                    SystemBarStyle.dark(Color.TRANSPARENT)
+                } else {
+                    // the navigation bar sits over an empty window-background strip below the
+                    // card. The dark scrim is only used below API 26, where light navigation
+                    // icons are unsupported (androidx.activity.EdgeToEdge.DefaultDarkScrim)
+                    SystemBarStyle.auto(Color.TRANSPARENT, Color.argb(0x80, 0x1b, 0x1b, 0x1b)) {
+                        Themes.isNightTheme
+                    }
+                },
+        )
+
+        // systemBars handles the 3-button nav bar
+        fun WindowInsetsCompat.bars() = getInsets(systemBars() or displayCutout())
+
+        val zero: (WindowInsetsCompat) -> Int = { 0 }
+        val bottomBars: (WindowInsetsCompat) -> Int = { it.bars().bottom }
+        val bottomBarsAndKeyboard: (WindowInsetsCompat) -> Int = {
+            it.getInsets(systemBars() or displayCutout() or ime()).bottom
+        }
+
+        // Exactly one view is bottom-most and absorbs the bottom inset:
+        // 'bottom' => the answer area.
+        // 'top' => the card and its overlays.
+        // 'none' => type the answer + ime
+        val cardBottom = if (answerButtonsPosition == "top") bottomBars else zero
+        val bottomAreaBottom = if (answerButtonsPosition == "none") bottomBarsAndKeyboard else zero
+        val whiteboardPaletteBottom = if (answerButtonsAtBottom) zero else bottomBars
+
+        /**
+         * Pads [view]'s content past the side insets and, per [bottom], the bottom inset;
+         * `null` leaves the bottom padding untouched.
+         */
+        fun clearInsets(
+            view: View,
+            basePadding: Int = 0,
+            bottom: ((WindowInsetsCompat) -> Int)? = null,
+        ) {
+            ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
+                val bars = insets.bars()
+                v.updatePadding(
+                    left = basePadding + bars.left,
+                    right = basePadding + bars.right,
+                    bottom = bottom?.invoke(insets) ?: v.paddingBottom,
+                )
+                insets
+            }
+        }
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.toolbar_container)) { container, insets ->
+            val bars = insets.bars()
+            container.updatePadding(left = bars.left, top = bars.top, right = bars.right)
+            if (answerButtonsAtBottom && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                // SystemBarStyle.dark suits a bottom bar over the dark answer area, but a
+                // side bar sits over the window background, where light icons would be
+                // unreadable in day themes: have the system draw its contrasting scrim there
+                val nav = insets.getInsets(navigationBars())
+                window.isNavigationBarContrastEnforced = nav.left > 0 || nav.right > 0
+            }
+            insets
+        }
+        clearInsets(findViewById(R.id.top_bar), basePadding = resources.getDimensionPixelSize(R.dimen.side_margin))
+        clearInsets(micToolBarLayer)
+        // the card and its overlays reach the bottom of the screen when the answer buttons
+        // are shown above them
+        clearInsets(findViewById(R.id.flashcard), bottom = cardBottom)
+        clearInsets(findViewById(R.id.touch_layer), bottom = cardBottom)
+        clearInsets(findViewById(R.id.whiteboard), bottom = cardBottom)
+
+        clearInsets(colorPalette, bottom = whiteboardPaletteBottom)
+        clearInsets(findViewById(R.id.bottom_area_layout), bottom = bottomAreaBottom)
+
+        val answerArea = findViewById<View>(R.id.answer_options_layout)
+        // the shared answer-buttons layout enables android:fitsSystemWindows for the
+        // fullscreen modes: here, insets are handled manually
+        answerArea.fitsSystemWindows = false
+        if (answerButtonsAtBottom) {
+            // extends the answer area's color underneath the navigation bar, replacing the
+            // pre-edge-to-edge setNavigationBarColor(R.attr.showAnswerColor)
+            answerArea.setBackgroundColor(MaterialColors.getColor(this, R.attr.showAnswerColor, 0))
+            ViewCompat.setOnApplyWindowInsetsListener(answerArea) { area, insets ->
+                area.updatePadding(bottom = bottomBarsAndKeyboard(insets))
+                insets
+            }
+        }
+    }
 
     override fun onCollectionLoaded(col: Collection) {
         super.onCollectionLoaded(col)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/Resources.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/Resources.kt
@@ -15,14 +15,10 @@
  */
 package com.ichi2.anki.utils
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.Resources
 import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
-import androidx.fragment.app.FragmentActivity
-import com.ichi2.anki.common.annotations.NeedsTest
-import com.ichi2.anki.common.crashreporting.CrashReportService
 
 /**
  * @param resId must be a [StringRes] or a [PluralsRes]
@@ -44,27 +40,6 @@ fun Context.getFormattedStringOrPlurals(
     resId: Int,
     quantity: Int,
 ): String = resources.getFormattedStringOrPlurals(resId, quantity)
-
-@SuppressLint("DiscouragedApi") // Resources.getIdentifier: Use of this function is discouraged
-// because resource reflection makes it harder to perform build optimizations and compile-time
-// verification of code. It is much more efficient to retrieve resources by identifier
-// (e.g. `R.foo.bar`) than by name (e.g. `getIdentifier("bar", "foo", null)`)
-private fun Context.getSystemBoolean(resName: String, fallback: Boolean): Boolean =
-    try {
-        val id = Resources.getSystem().getIdentifier(resName, "bool", "android")
-        if (id != 0) {
-            createPackageContext("android", 0).resources.getBoolean(id)
-        } else {
-            fallback
-        }
-    } catch (e: Exception) {
-        CrashReportService.sendExceptionReport(e, "Context::getSystemBoolean")
-        fallback
-    }
-
-@NeedsTest("true if the navbar is transparent and needs a scrim, false if not")
-val FragmentActivity.navBarNeedsScrim: Boolean
-    get() = getSystemBoolean("config_navBarNeedsScrim", true)
 
 // https://m3.material.io/foundations/layout/applying-layout/window-size-classes
 // adopted smallestScreenWidthDp instead of screenWidthDp

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerInsetsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerInsetsTest.kt
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki
+
+import android.view.View
+import androidx.core.content.edit
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsCompat.Type.displayCutout
+import androidx.core.view.WindowInsetsCompat.Type.ime
+import androidx.core.view.WindowInsetsCompat.Type.navigationBars
+import androidx.core.view.WindowInsetsCompat.Type.statusBars
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.reviewer.FullScreenMode
+import com.ichi2.testutils.insetsOf
+import com.ichi2.utils.Dp
+import com.ichi2.utils.dp
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Edge-to-edge inset handling for the legacy [Reviewer].
+ *
+ * The app bar's background spans the full width and draws behind the status bar; only its
+ * content is inset. The counts bar, card and answer area are held inside the safe area, with
+ * the answer area's background extending underneath the navigation bar.
+ */
+@RunWith(AndroidJUnit4::class)
+class ReviewerInsetsTest : RobolectricTest() {
+    // rendering a card requires a media folder
+    override fun getCollectionStorageMode() = CollectionStorageMode.IN_MEMORY_WITH_MEDIA
+
+    @Test
+    fun `app bar draws behind the status bar, with its content inset`() =
+        withReviewer { reviewer ->
+            reviewer.dispatchInsets()
+
+            assertThat(
+                "the root does not consume the top inset, so the app bar draws behind the status bar",
+                reviewer.rootLayout.paddingTop,
+                equalTo(0),
+            )
+            assertThat(
+                "app bar content is pushed clear of the status bar",
+                reviewer.toolbarContainer.paddingTop,
+                equalTo(24.dp.toPx(targetContext)),
+            )
+        }
+
+    @Test
+    fun `app bar and counts bar are padded past a side navigation bar and cutout`() =
+        withReviewer { reviewer ->
+            // landscape with 3-button navigation: the navigation bar is a side inset and the
+            // camera cutout is on the opposite side
+            reviewer.dispatchInsets(navBarRight = 48.dp, cutoutLeft = 32.dp)
+
+            assertThat(
+                "app bar content clears the cutout",
+                reviewer.toolbarContainer.paddingLeft,
+                equalTo(32.dp.toPx(targetContext)),
+            )
+            assertThat(
+                "app bar content clears the side navigation bar",
+                reviewer.toolbarContainer.paddingRight,
+                equalTo(48.dp.toPx(targetContext)),
+            )
+
+            val sideMargin = targetContext.resources.getDimensionPixelSize(R.dimen.side_margin)
+            assertThat(
+                "the counts bar keeps its side margin past the cutout",
+                reviewer.countsBar.paddingLeft,
+                equalTo(32.dp.toPx(targetContext) + sideMargin),
+            )
+            assertThat(
+                "the counts bar keeps its side margin past the navigation bar",
+                reviewer.countsBar.paddingRight,
+                equalTo(48.dp.toPx(targetContext) + sideMargin),
+            )
+        }
+
+    @Test
+    fun `the card is padded past a side navigation bar and cutout`() =
+        withReviewer { reviewer ->
+            reviewer.dispatchInsets(navBarRight = 48.dp, cutoutLeft = 32.dp)
+
+            assertThat("card clears the cutout", reviewer.cardContainer.paddingLeft, equalTo(32.dp.toPx(targetContext)))
+            assertThat(
+                "card clears the side navigation bar",
+                reviewer.cardContainer.paddingRight,
+                equalTo(48.dp.toPx(targetContext)),
+            )
+        }
+
+    @Test
+    fun `answer buttons clear the navigation bar`() =
+        withReviewer { reviewer ->
+            reviewer.dispatchInsets(navBarBottom = 48.dp)
+
+            assertThat(
+                "the answer area rests a navigation bar's height above the screen's bottom",
+                reviewer.answerArea.paddingBottom,
+                equalTo(48.dp.toPx(targetContext)),
+            )
+            assertThat(
+                "the card sits above the answer area and needs no bottom inset",
+                reviewer.cardContainer.paddingBottom,
+                equalTo(0),
+            )
+        }
+
+    @Test
+    fun `answer buttons at the top - the card clears the navigation bar`() =
+        withReviewer(answerButtonsPosition = "top") { reviewer ->
+            reviewer.dispatchInsets(navBarBottom = 48.dp)
+
+            assertThat(
+                "the card is the bottom-most element and clears the navigation bar",
+                reviewer.cardContainer.paddingBottom,
+                equalTo(48.dp.toPx(targetContext)),
+            )
+            assertThat(
+                "the answer area is at the top and needs no bottom inset",
+                reviewer.answerArea.paddingBottom,
+                equalTo(0),
+            )
+        }
+
+    @Test
+    fun `no answer buttons - the type-answer area clears the navigation bar`() =
+        withReviewer(answerButtonsPosition = "none") { reviewer ->
+            reviewer.dispatchInsets(navBarBottom = 48.dp)
+
+            assertThat(
+                "the bottom area (holding the type-answer field) clears the navigation bar",
+                reviewer.bottomArea.paddingBottom,
+                equalTo(48.dp.toPx(targetContext)),
+            )
+        }
+
+    @Test
+    fun `the answer area clears the keyboard`() =
+        withReviewer { reviewer ->
+            // edge-to-edge disables adjustResize: the answer buttons - and the type-answer
+            // field above them - are kept above the keyboard via the ime inset
+            reviewer.dispatchInsets(navBarBottom = 48.dp, imeBottom = 300.dp)
+
+            assertThat(
+                "the answer area rests above the keyboard",
+                reviewer.answerArea.paddingBottom,
+                equalTo(300.dp.toPx(targetContext)),
+            )
+        }
+
+    @Test
+    fun `fullscreen review keeps the legacy fitsSystemWindows handling`() {
+        FullScreenMode.setPreference(targetContext.sharedPrefs(), FullScreenMode.BUTTONS_ONLY)
+        withReviewer { reviewer ->
+            reviewer.dispatchInsets(navBarBottom = 48.dp)
+
+            assertThat(
+                "the answer area is padded by android:fitsSystemWindows, not by a listener",
+                reviewer.answerArea.paddingBottom,
+                equalTo(48.dp.toPx(targetContext)),
+            )
+            assertThat(
+                "fitsSystemWindows also applies the top inset",
+                reviewer.answerArea.paddingTop,
+                equalTo(24.dp.toPx(targetContext)),
+            )
+        }
+    }
+
+    private val Reviewer.rootLayout: View
+        get() = findViewById(R.id.root_layout)
+
+    private val Reviewer.toolbarContainer: View
+        get() = findViewById(R.id.toolbar_container)
+
+    private val Reviewer.countsBar: View
+        get() = findViewById(R.id.top_bar)
+
+    private val Reviewer.cardContainer: View
+        get() = findViewById(R.id.flashcard)
+
+    private val Reviewer.bottomArea: View
+        get() = findViewById(R.id.bottom_area_layout)
+
+    private val Reviewer.answerArea: View
+        get() = findViewById(R.id.answer_options_layout)
+
+    /** Dispatches realistic system-bar insets, which Robolectric otherwise reports as zero. */
+    private fun Reviewer.dispatchInsets(
+        navBarBottom: Dp = 0.dp,
+        navBarRight: Dp = 0.dp,
+        cutoutLeft: Dp = 0.dp,
+        imeBottom: Dp = 0.dp,
+    ) {
+        val insets =
+            with(targetContext) {
+                WindowInsetsCompat
+                    .Builder()
+                    .setInsets(statusBars(), insetsOf(top = 24.dp))
+                    .setInsets(navigationBars(), insetsOf(right = navBarRight, bottom = navBarBottom))
+                    .setInsets(displayCutout(), insetsOf(left = cutoutLeft))
+                    .setInsets(ime(), insetsOf(bottom = imeBottom))
+                    .build()
+            }
+        ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
+    }
+
+    private fun withReviewer(
+        answerButtonsPosition: String? = null,
+        block: (Reviewer) -> Unit,
+    ) {
+        answerButtonsPosition?.let { position ->
+            targetContext.sharedPrefs().edit {
+                putString(targetContext.getString(R.string.answer_buttons_position_preference), position)
+            }
+        }
+        addBasicNote("Hello", "World")
+        block(ReviewerTest.startReviewer(this))
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.kt
@@ -257,9 +257,10 @@ class ReviewerNoParamTest : RobolectricTest() {
     }
 
     @Test
-    fun normalReviewerFitsSystemWindows() {
+    fun normalReviewerDoesNotFitSystemWindows() {
+        // edge-to-edge: insets are applied manually, see Reviewer.setupEdgeToEdge()
         val reviewer = startReviewer()
-        assertThat(reviewer.fitsSystemWindows(), equalTo(true))
+        assertThat(reviewer.fitsSystemWindows(), equalTo(false))
     }
 
     @Test


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

## Purpose / Description
This kicks off edge to edge support in the Reviewer via calling `enableEdgeToEdge()`, the insets for the various components are then set.

This does not impact fullscreenMode yet.

(note: this will be a very complex change, multiple PRs will be added, so this change alone does not provide perfect support)

highlights:

* The nav bar is now transparent, taking the color above it
  * Fixes the 3-button nav on some devices
* in landscape, the app bar and counts bar now render in the camera notch

A bottom inset (based on answer position) is added:

* bottom (default): the answer area clears the navigation bar and, since edge-to-edge disables adjustResize, the keyboard (ime())
* top: the card is the bottom-most element and takes the inset
* none: the bottom area (type-answer field) takes the inset


## Fixes
* Issue #17334
* Part of #21504


## Approach
* call `enableEdgeToEdge`
* Define the insets for each view which would have been affected, moving it back to its correct position


## How Has This Been Tested?
Pixel 9 Pro - API 37

**1**
<img width="400" alt="image" src="https://github.com/user-attachments/assets/60d6d308-9257-4184-b4a3-ed4312cf6c51" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/e3aeb43a-8596-4e03-b76b-350a4ce85b59" />

**2**
<img width="400" alt="image" src="https://github.com/user-attachments/assets/9ab02833-70ea-4b95-be6e-92ab15c5b1b0" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/785536c4-23e4-4a56-9b20-1d85a27a16b3" />

**3**
<img width="400" alt="image" src="https://github.com/user-attachments/assets/0e805210-f6d3-4599-917a-e6d0cd80fb87" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/a899b1ce-7dc0-4141-86d0-95dd77a49ce7" />

**4**
<img width="400" alt="image" src="https://github.com/user-attachments/assets/1166bb05-6a54-4d5a-b2aa-ae94acc3a94c" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/744b3fe6-a421-4c49-8f67-e60b255a73a4" />

**5**
<img width="400" alt="image" src="https://github.com/user-attachments/assets/406837fc-26c5-4620-9421-6d00bef0006e" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/7349e158-b4d2-4edc-9d02-07e50a6226dc" />


**6**
<img width="400" alt="image" src="https://github.com/user-attachments/assets/8fba40be-8bf2-4ae6-98c9-11f893935c4e" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/88ffb5ed-d391-4aa1-871b-d65af2800ff0" />

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)