### PR TITLE
feat(review-reminders): edge to edge support

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
@@ -28,7 +28,11 @@ import android.view.ViewGroup
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.net.toUri
+import androidx.core.view.WindowInsetsCompat.Type.displayCutout
+import androidx.core.view.WindowInsetsCompat.Type.systemBars
 import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.ViewModelProvider
@@ -44,6 +48,7 @@ import com.ichi2.anki.databinding.FragmentReminderTroubleshootingBinding
 import com.ichi2.anki.databinding.ItemTroubleshootingCheckBinding
 import com.ichi2.anki.requireAnkiActivity
 import com.ichi2.anki.settings.Prefs
+import com.ichi2.anki.utils.doOnApplyWindowInsets
 import com.ichi2.anki.utils.ext.launchCollectionInLifecycleScope
 import com.ichi2.anki.utils.ext.onWindowFocusChanged
 import com.ichi2.anki.utils.ext.requireParcelable
@@ -110,6 +115,32 @@ class ReminderTroubleshootingFragment : Fragment(R.layout.fragment_reminder_trou
         setupSummary()
         setupTroubleshootingChecks()
         setupSettingChangeDetector()
+        setupContentInsets()
+        renderEdgeToEdge(host)
+    }
+
+    /**
+     * Keeps the toolbar and the end of the scrolled content clear of the system bars and any
+     * display cutout.
+     *
+     * The content renders underneath the bottom bar while scrolling.
+     *
+     * These listeners are no-ops in hosts which apply the insets to this fragment's container
+     * and consume them.
+     */
+    private fun setupContentInsets() {
+        binding.troubleshootingToolbar.doOnApplyWindowInsets { view, insets, initial ->
+            val bars = insets.getInsets(systemBars() or displayCutout())
+            view.updatePadding(left = bars.left, right = bars.right)
+            // Margin must be used to align the icon and the title.
+            view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                topMargin = initial.margins.top + bars.top
+            }
+        }
+        binding.scrollView.doOnApplyWindowInsets { view, insets, initial ->
+            val bars = insets.getInsets(systemBars() or displayCutout())
+            view.updatePadding(left = bars.left, right = bars.right, bottom = initial.padding.bottom + bars.bottom)
+        }
     }
 
     private fun setupExternalActivityToolbar() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
@@ -100,8 +100,6 @@ class ReminderTroubleshootingFragment : Fragment(R.layout.fragment_reminder_trou
     ) {
         super.onViewCreated(view, savedInstanceState)
 
-        // Set up root layout insets if the host of this fragment does not support edge-to-edge
-        binding.rootLayout.fitsSystemWindows = !host.supportsEdgeToEdge
         when (host.toolbarType) {
             ScheduleRemindersFragment.ToolbarType.EXTERNAL -> setupExternalActivityToolbar()
             ScheduleRemindersFragment.ToolbarType.INTERNAL_COLLAPSIBLE,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
@@ -30,6 +30,7 @@ import android.view.Window
 import android.view.WindowManager
 import androidx.annotation.IdRes
 import androidx.annotation.RequiresApi
+import androidx.core.graphics.Insets
 import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat.Type.displayCutout
@@ -214,7 +215,10 @@ class ScheduleRemindersFragment :
         // Set up toolbar
         when (host.toolbarType) {
             ToolbarType.EXTERNAL -> setupExternalActivityToolbar()
-            ToolbarType.INTERNAL_COLLAPSIBLE -> setupInternalFragmentToolbar(isCollapsible = true)
+            ToolbarType.INTERNAL_COLLAPSIBLE -> {
+                setCollapsibleToolbarInsets()
+                setupInternalFragmentToolbar(isCollapsible = true)
+            }
             ToolbarType.INTERNAL_NON_COLLAPSIBLE -> {
                 setNonCollapsibleToolbarInsets()
                 setupInternalFragmentToolbar(isCollapsible = false)
@@ -326,17 +330,39 @@ class ScheduleRemindersFragment :
         }
     }
 
+    private fun setCollapsibleToolbarInsets() {
+        val styleExpandedTitleMarginStart = binding.collapsingToolbarLayout.expandedTitleMarginStart
+        val styleExpandedTitleMarginEnd = binding.collapsingToolbarLayout.expandedTitleMarginEnd
+        setRootInsetsListener { bars ->
+            // the top inset is left to the appbar's fitsSystemWindows attribute. The padding
+            // goes on the collapsing layout, not the app bar, so the collapsed content scrim
+            // extends behind the cutout
+            binding.collapsingToolbarLayout.updatePadding(left = bars.left, right = bars.right)
+            // the expanded title ignores the padding: its margins are from the layout's edges
+            val isRtl = binding.collapsingToolbarLayout.layoutDirection == View.LAYOUT_DIRECTION_RTL
+            binding.collapsingToolbarLayout.expandedTitleMarginStart =
+                styleExpandedTitleMarginStart + if (isRtl) bars.right else bars.left
+            binding.collapsingToolbarLayout.expandedTitleMarginEnd =
+                styleExpandedTitleMarginEnd + if (isRtl) bars.left else bars.right
+        }
+    }
+
+    private fun setNonCollapsibleToolbarInsets() {
+        setRootInsetsListener { bars ->
+            // the collapsible toolbar (first in the shared appbar) consumes the insets
+            // so apply them manually
+            binding.appbar.updatePadding(left = bars.left, top = bars.top, right = bars.right)
+        }
+    }
+
     /**
      * Replace the root CoordinatorLayout's inset handling.
      *
      * No-op in [FragmentHost.STUDY_OPTIONS_FRAGMENT] and [FragmentHost.STUDY_OPTIONS_FRAME]
      */
-    private fun setNonCollapsibleToolbarInsets() {
+    private fun setRootInsetsListener(block: (bars: Insets) -> Unit) {
         ViewCompat.setOnApplyWindowInsetsListener(binding.rootLayout) { _, insets ->
-            val bars = insets.getInsets(systemBars() or displayCutout())
-            // the collapsible toolbar (first in the shared appbar) consumes the insets
-            // so apply them manually
-            binding.appbar.updatePadding(left = bars.left, top = bars.top, right = bars.right)
+            block(insets.getInsets(systemBars() or displayCutout()))
             insets
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
@@ -24,12 +24,14 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import android.view.ViewGroup
 import androidx.annotation.IdRes
 import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat.Type.displayCutout
-import androidx.core.view.WindowInsetsCompat.Type.statusBars
+import androidx.core.view.WindowInsetsCompat.Type.systemBars
 import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -52,6 +54,7 @@ import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.utils.ConfigAwareSingleFragmentActivity
+import com.ichi2.anki.utils.doOnApplyWindowInsets
 import com.ichi2.anki.utils.ext.getParcelableCompat
 import com.ichi2.anki.utils.ext.launchCollectionInLifecycleScope
 import com.ichi2.anki.utils.showDialogFragment
@@ -177,6 +180,8 @@ class ScheduleRemindersFragment :
 
     override val baseSnackbarBuilder: SnackbarBuilder = {
         anchorView = binding.floatingActionButtonAdd
+        // reposition if the anchor moves, e.g. when the window insets arrive after showing
+        isAnchorViewLayoutListenerEnabled = true
     }
 
     /**
@@ -208,6 +213,7 @@ class ScheduleRemindersFragment :
                 setupInternalFragmentToolbar(isCollapsible = false)
             }
         }
+        setContentInsets()
 
         binding.floatingActionButtonAdd.setOnClickListener { addReminder() }
         troubleshootingViewModel.state.launchCollectionInLifecycleScope(::setupTroubleshootingSnackbar)
@@ -319,11 +325,37 @@ class ScheduleRemindersFragment :
      */
     private fun setNonCollapsibleToolbarInsets() {
         ViewCompat.setOnApplyWindowInsetsListener(binding.rootLayout) { _, insets ->
-            val bars = insets.getInsets(statusBars() or displayCutout())
+            val bars = insets.getInsets(systemBars() or displayCutout())
             // the collapsible toolbar (first in the shared appbar) consumes the insets
             // so apply them manually
             binding.appbar.updatePadding(left = bars.left, top = bars.top, right = bars.right)
             insets
+        }
+    }
+
+    /**
+     * Keeps the list, the 'no reminders' placeholder and the 'add reminder' button clear of the
+     * navigation bar and any display cutout.
+     *
+     * These listeners are no-ops in hosts which apply the insets to this fragment's container
+     * and consume them.
+     */
+    private fun setContentInsets() {
+        binding.recyclerView.doOnApplyWindowInsets { view, insets, initial ->
+            val bars = insets.getInsets(systemBars() or displayCutout())
+            view.updatePadding(left = bars.left, right = bars.right, bottom = initial.padding.bottom + bars.bottom)
+        }
+        binding.noRemindersPlaceholder.doOnApplyWindowInsets { view, insets, _ ->
+            val bars = insets.getInsets(systemBars() or displayCutout())
+            view.updatePadding(left = bars.left, right = bars.right)
+        }
+        binding.floatingActionButtonAdd.doOnApplyWindowInsets { view, insets, initial ->
+            val bars = insets.getInsets(systemBars() or displayCutout())
+            view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                leftMargin = initial.margins.left + bars.left
+                rightMargin = initial.margins.right + bars.right
+                bottomMargin = initial.margins.bottom + bars.bottom
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
@@ -33,6 +33,7 @@ import androidx.annotation.RequiresApi
 import androidx.core.graphics.Insets
 import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat.Type.displayCutout
 import androidx.core.view.WindowInsetsCompat.Type.systemBars
 import androidx.core.view.isVisible
@@ -739,27 +740,30 @@ class ScheduleRemindersFragment :
  * @see WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
  *
  * Needed even on API 35+: the app opts out of edge-to-edge enforcement
- * (`windowOptOutEdgeToEdgeEnforcement`), so these windows letterbox the cutout on every
+ * (`windowOptOutEdgeToEdgeEnforcement`), so these windows fit the system windows on every
  * API level.
  */
 internal fun Fragment.renderEdgeToEdge(host: FragmentHost) {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) return
     // these hosts call `enableEdgeToEdge`
     if (host == FragmentHost.STUDY_OPTIONS_FRAGMENT || host == FragmentHost.STUDY_OPTIONS_FRAME) return
+    if (host == FragmentHost.SETTINGS && isTwoPaneSettings) return
     val window = requireActivity().window
 
     viewLifecycleOwner.lifecycle.addObserver(
         object : DefaultLifecycleObserver {
             // resume/pause rather than view creation/destruction: when this fragment is replaced
-            // by one which also renders into the cutout, the new fragment's view is created
-            // before the old fragment restores the mode, but it is resumed afterwards
+            // by one which also renders edge to edge, the new fragment's view is created
+            // before the old fragment restores the window, but it is resumed afterwards
             override fun onResume(owner: LifecycleOwner) {
+                WindowCompat.setDecorFitsSystemWindows(window, false)
                 window.setLayoutInDisplayCutoutMode(
                     WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES,
                 )
             }
 
             override fun onPause(owner: LifecycleOwner) {
+                WindowCompat.setDecorFitsSystemWindows(window, true)
                 window.setLayoutInDisplayCutoutMode(
                     WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT,
                 )
@@ -767,6 +771,13 @@ internal fun Fragment.renderEdgeToEdge(host: FragmentHost) {
         },
     )
 }
+
+/**
+ * Whether the settings screen is showing its two-pane (sw600dp) layout,
+ * with the headers pane alongside the content pane.
+ */
+private val Fragment.isTwoPaneSettings: Boolean
+    get() = requireActivity().findViewById<View>(R.id.lateral_nav_container) != null
 
 @RequiresApi(Build.VERSION_CODES.P)
 private fun Window.setLayoutInDisplayCutoutMode(mode: Int) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.reviewreminders
 
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.Menu
@@ -25,7 +26,10 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.view.Window
+import android.view.WindowManager
 import androidx.annotation.IdRes
+import androidx.annotation.RequiresApi
 import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat.Type.displayCutout
@@ -36,7 +40,9 @@ import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.commit
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.snackbar.Snackbar
@@ -48,6 +54,7 @@ import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.requireAnkiActivity
 import com.ichi2.anki.reviewreminders.AddEditReminderDialog.Companion.registerAddEditReminderHandler
+import com.ichi2.anki.reviewreminders.ScheduleRemindersFragment.FragmentHost
 import com.ichi2.anki.runCatching
 import com.ichi2.anki.services.AlarmManagerService
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
@@ -214,6 +221,7 @@ class ScheduleRemindersFragment :
             }
         }
         setContentInsets()
+        renderEdgeToEdge(host)
 
         binding.floatingActionButtonAdd.setOnClickListener { addReminder() }
         troubleshootingViewModel.state.launchCollectionInLifecycleScope(::setupTroubleshootingSnackbar)
@@ -695,4 +703,47 @@ class ScheduleRemindersFragment :
                 )
             }
     }
+}
+
+/**
+ * TODO: remove once all [FragmentHost]s are edge-to-edge.
+ *
+ * Renders the host window into a display cutout, removing a black bar.
+ *
+ * @see WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+ *
+ * Needed even on API 35+: the app opts out of edge-to-edge enforcement
+ * (`windowOptOutEdgeToEdgeEnforcement`), so these windows letterbox the cutout on every
+ * API level.
+ */
+internal fun Fragment.renderEdgeToEdge(host: FragmentHost) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) return
+    // these hosts call `enableEdgeToEdge`
+    if (host == FragmentHost.STUDY_OPTIONS_FRAGMENT || host == FragmentHost.STUDY_OPTIONS_FRAME) return
+    val window = requireActivity().window
+
+    viewLifecycleOwner.lifecycle.addObserver(
+        object : DefaultLifecycleObserver {
+            // resume/pause rather than view creation/destruction: when this fragment is replaced
+            // by one which also renders into the cutout, the new fragment's view is created
+            // before the old fragment restores the mode, but it is resumed afterwards
+            override fun onResume(owner: LifecycleOwner) {
+                window.setLayoutInDisplayCutoutMode(
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES,
+                )
+            }
+
+            override fun onPause(owner: LifecycleOwner) {
+                window.setLayoutInDisplayCutoutMode(
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT,
+                )
+            }
+        },
+    )
+}
+
+@RequiresApi(Build.VERSION_CODES.P)
+private fun Window.setLayoutInDisplayCutoutMode(mode: Int) {
+    if (attributes.layoutInDisplayCutoutMode == mode) return
+    attributes = attributes.also { it.layoutInDisplayCutoutMode = mode }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
@@ -88,21 +88,17 @@ class ScheduleRemindersFragment :
      * Possible hosts of this fragment. Certain stylistic changes need to be made based on where this
      * fragment is opened from / nested within.
      *
-     * TODO: Implement edge-to-edge for Settings and ConfigAwareSingleFragmentActivity.
-     * Then, remove the supportsEdgeToEdge property below and test this fragment's UI behavior 1) on both small and wide screens,
-     * 2) with all app display themes, and 3) from all possible locations this fragment can be opened from. In particular,
-     * make sure there is no weird clipping of the collapsible toolbar content scrim when this fragment is opened from the Settings screen upon scrolling.
+     * This fragment applies the system bar insets to its own views. Hosts which instead apply the
+     * insets to this fragment's container ([STUDY_OPTIONS_FRAGMENT] and [STUDY_OPTIONS_FRAME])
+     * consume them, so that they are not applied a second time here.
      *
      * @param containerId The XML ID of the container in which this fragment is hosted.
      * @param toolbarType The type of toolbar to display for this fragment.
-     * @param supportsEdgeToEdge Whether the host of this fragment currently supports edge-to-edge rendering.
-     * The legacy fitsSystemWindows property is deprecated and should be migrated away from.
      */
     @Parcelize
     enum class FragmentHost(
         @IdRes val containerId: Int,
         val toolbarType: ToolbarType,
-        val supportsEdgeToEdge: Boolean,
     ) : Parcelable {
         /**
          * App-wide review reminders editing screen accessed via Settings.
@@ -111,7 +107,6 @@ class ScheduleRemindersFragment :
         SETTINGS(
             containerId = R.id.settings_container,
             toolbarType = ToolbarType.INTERNAL_COLLAPSIBLE,
-            supportsEdgeToEdge = false,
         ),
 
         /**
@@ -121,7 +116,6 @@ class ScheduleRemindersFragment :
         STUDY_OPTIONS_FRAGMENT(
             containerId = R.id.studyoptions_fragment,
             toolbarType = ToolbarType.INTERNAL_NON_COLLAPSIBLE,
-            supportsEdgeToEdge = true,
         ),
 
         /**
@@ -132,7 +126,6 @@ class ScheduleRemindersFragment :
         STUDY_OPTIONS_FRAME(
             containerId = R.id.studyoptions_frame,
             toolbarType = ToolbarType.EXTERNAL,
-            supportsEdgeToEdge = true,
         ),
 
         /**
@@ -143,7 +136,6 @@ class ScheduleRemindersFragment :
         STANDALONE_ACTIVITY(
             containerId = R.id.fragment_container,
             toolbarType = ToolbarType.INTERNAL_NON_COLLAPSIBLE,
-            supportsEdgeToEdge = false,
         ),
     }
 
@@ -207,22 +199,14 @@ class ScheduleRemindersFragment :
     ) {
         super.onViewCreated(view, savedInstanceState)
 
-        // Set up root layout insets if the host of this fragment does not support edge-to-edge
-        if (host.supportsEdgeToEdge) {
-            binding.rootLayout.fitsSystemWindows = false // No need for legacy insets behavior
-        } else {
-            binding.rootLayout.fitsSystemWindows = true // Legacy insets behavior to avoid overlapping the status bar
-            if (host.toolbarType == ToolbarType.INTERNAL_NON_COLLAPSIBLE) {
-                // The legacy behavior is broken for the non-collapsible toolbar, also implement a manual workaround for it
-                setNonCollapsibleToolbarInsets()
-            }
-        }
-
         // Set up toolbar
         when (host.toolbarType) {
             ToolbarType.EXTERNAL -> setupExternalActivityToolbar()
             ToolbarType.INTERNAL_COLLAPSIBLE -> setupInternalFragmentToolbar(isCollapsible = true)
-            ToolbarType.INTERNAL_NON_COLLAPSIBLE -> setupInternalFragmentToolbar(isCollapsible = false)
+            ToolbarType.INTERNAL_NON_COLLAPSIBLE -> {
+                setNonCollapsibleToolbarInsets()
+                setupInternalFragmentToolbar(isCollapsible = false)
+            }
         }
 
         binding.floatingActionButtonAdd.setOnClickListener { addReminder() }
@@ -329,26 +313,15 @@ class ScheduleRemindersFragment :
     }
 
     /**
-     * The collapsible and non-collapsible toolbar are both located within the appbar.
-     * At most one is visible at a time (both are hidden if an external toolbar is being used).
-     * They must be nested within the same appbar because having more than one appbar causes issues with where
-     * the second one is rendered on the screen. If edge-to-edge is not implemented for the [FragmentHost] of this fragment
-     * yet, this fragment's layout and appbar has the fitsSystemWindows attribute set to ensure its
-     * child toolbar is rendered below the status bar.
+     * Replace the root CoordinatorLayout's inset handling.
      *
-     * However, because the collapsible toolbar is before the non-collapsible toolbar in the layout file,
-     * it consumes the fitsSystemWindows inset first and does not pass any to the non-collapsible toolbar.
-     * Hence, we manually set the insets of the non-collapsible toolbar when it is visible
-     * via the modern setOnApplyWindowInsetsListener API. We cannot use this API for both the
-     * collapsible and non-collapsible toolbars and then omit fitsSystemWindows on the appbar. This is
-     * because doing so causes UI glitches within the status bar when the collapsible toolbar transitions
-     * between its expanded and collapsed states.
-     *
-     * This should only be used for the non-collapsible toolbar if edge-to-edge is not implemented on the host yet.
+     * No-op in [FragmentHost.STUDY_OPTIONS_FRAGMENT] and [FragmentHost.STUDY_OPTIONS_FRAME]
      */
     private fun setNonCollapsibleToolbarInsets() {
         ViewCompat.setOnApplyWindowInsetsListener(binding.rootLayout) { _, insets ->
             val bars = insets.getInsets(statusBars() or displayCutout())
+            // the collapsible toolbar (first in the shared appbar) consumes the insets
+            // so apply them manually
             binding.appbar.updatePadding(left = bars.left, top = bars.top, right = bars.right)
             insets
         }

--- a/AnkiDroid/src/main/res/layout/fragment_reminder_troubleshooting.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_reminder_troubleshooting.xml
@@ -6,6 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?android:attr/colorBackground"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
     <com.google.android.material.appbar.MaterialToolbar

--- a/AnkiDroid/src/main/res/layout/fragment_reminder_troubleshooting.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_reminder_troubleshooting.xml
@@ -6,7 +6,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?android:attr/colorBackground"
-    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
     <com.google.android.material.appbar.MaterialToolbar
@@ -20,7 +19,8 @@
     <androidx.core.widget.NestedScrollView
         android:id="@+id/scroll_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:clipToPadding="false">
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/AnkiDroid/src/main/res/layout/fragment_schedule_reminders.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_schedule_reminders.xml
@@ -5,7 +5,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbar"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersInsetsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersInsetsTest.kt
@@ -11,6 +11,8 @@ import androidx.core.view.WindowInsetsCompat.Type.displayCutout
 import androidx.core.view.WindowInsetsCompat.Type.navigationBars
 import androidx.core.view.WindowInsetsCompat.Type.statusBars
 import androidx.core.view.isVisible
+import androidx.core.view.marginBottom
+import androidx.core.view.marginRight
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
@@ -59,6 +61,12 @@ class ReviewRemindersInsetsTest : RobolectricTest() {
     /** The size of the simulated navigation bar: its height, or its width when on the side of the screen */
     private val navigationBarSize = 48.dp
 
+    /** The 'add reminder' button's margin, from the layout XML */
+    private val fabMargin = 16.dp
+
+    /** The list's bottom padding, from the layout XML: lets content scroll clear of the 'add reminder' button */
+    private val listBottomPadding = 84.dp
+
     @Test
     fun `standalone host - toolbar content clears the status bar and cutout`() =
         withStandaloneScheduleReminders { activity, binding ->
@@ -73,6 +81,46 @@ class ReviewRemindersInsetsTest : RobolectricTest() {
                 "toolbar content clears the cutout",
                 binding.appbar.paddingLeft,
                 equalTo(32.dp.toPx(targetContext)),
+            )
+        }
+
+    @Test
+    fun `standalone host - button and list content clear the navigation bar`() =
+        withStandaloneScheduleReminders { activity, binding ->
+            activity.dispatchInsets(navBarBottom = navigationBarSize)
+
+            assertThat(
+                "the 'add reminder' button rests above the navigation bar",
+                binding.floatingActionButtonAdd.marginBottom,
+                equalTo((fabMargin + navigationBarSize).toPx(targetContext)),
+            )
+            assertThat(
+                "scrolled list content clears the navigation bar",
+                binding.recyclerView.paddingBottom,
+                equalTo((listBottomPadding + navigationBarSize).toPx(targetContext)),
+            )
+        }
+
+    @Test
+    fun `standalone host - content clears a side navigation bar`() =
+        withStandaloneScheduleReminders { activity, binding ->
+            // landscape with 3-button navigation: the navigation bar is a side inset
+            activity.dispatchInsets(navBarRight = navigationBarSize)
+
+            assertThat(
+                "toolbar content clears the side navigation bar",
+                binding.appbar.paddingRight,
+                equalTo(navigationBarSize.toPx(targetContext)),
+            )
+            assertThat(
+                "list content clears the side navigation bar",
+                binding.recyclerView.paddingRight,
+                equalTo(navigationBarSize.toPx(targetContext)),
+            )
+            assertThat(
+                "the 'add reminder' button clears the side navigation bar",
+                binding.floatingActionButtonAdd.marginRight,
+                equalTo((fabMargin + navigationBarSize).toPx(targetContext)),
             )
         }
 
@@ -96,7 +144,7 @@ class ReviewRemindersInsetsTest : RobolectricTest() {
     @Test
     fun `settings host - collapsible toolbar clears the status bar`() =
         withSettingsScheduleReminders { activity, binding ->
-            activity.dispatchInsets()
+            activity.dispatchInsets(navBarBottom = navigationBarSize)
 
             assertThat(
                 "the root does not pad itself; the app bar handles the inset",
@@ -107,6 +155,11 @@ class ReviewRemindersInsetsTest : RobolectricTest() {
                 "the collapsible toolbar is pushed clear of the status bar",
                 binding.toolbar.top,
                 equalTo(statusBarHeight.toPx(targetContext)),
+            )
+            assertThat(
+                "the 'add reminder' button rests above the navigation bar",
+                binding.floatingActionButtonAdd.marginBottom,
+                equalTo((fabMargin + navigationBarSize).toPx(targetContext)),
             )
         }
 
@@ -134,6 +187,11 @@ class ReviewRemindersInsetsTest : RobolectricTest() {
                 "the toolbar is provided by the host",
                 binding.appbar.isVisible,
                 equalTo(false),
+            )
+            assertThat(
+                "the fragment does not move the 'add reminder' button again",
+                binding.floatingActionButtonAdd.marginBottom,
+                equalTo(fabMargin.toPx(targetContext)),
             )
         }
 
@@ -175,6 +233,11 @@ class ReviewRemindersInsetsTest : RobolectricTest() {
                 "the panel toolbar is not pushed down by the status bar",
                 binding.nonCollapsibleToolbar.top,
                 equalTo(0),
+            )
+            assertThat(
+                "the fragment does not move the 'add reminder' button again",
+                binding.floatingActionButtonAdd.marginBottom,
+                equalTo(fabMargin.toPx(targetContext)),
             )
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersInsetsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersInsetsTest.kt
@@ -4,6 +4,7 @@ package com.ichi2.anki.reviewreminders
 
 import android.app.Activity
 import android.view.View
+import android.view.WindowManager
 import androidx.annotation.IdRes
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -13,6 +14,7 @@ import androidx.core.view.WindowInsetsCompat.Type.statusBars
 import androidx.core.view.isVisible
 import androidx.core.view.marginBottom
 import androidx.core.view.marginRight
+import androidx.core.view.marginTop
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
@@ -125,18 +127,38 @@ class ReviewRemindersInsetsTest : RobolectricTest() {
         }
 
     @Test
+    fun `standalone host - the window renders into a display cutout`() =
+        withStandaloneScheduleReminders { activity, _ ->
+            assertThat(
+                "the window renders into the cutout instead of being letterboxed",
+                activity.window.attributes.layoutInDisplayCutoutMode,
+                equalTo(WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES),
+            )
+        }
+
+    @Test
     fun `standalone host - troubleshooting content clears the system bars`() =
         withStandaloneTroubleshooting { activity, binding ->
             activity.dispatchInsets(navBarBottom = navigationBarSize)
 
             assertThat(
-                "content is pushed clear of the status bar",
-                binding.root.paddingTop,
+                "the toolbar is pushed clear of the status bar: a margin keeps the icon and title aligned",
+                binding.troubleshootingToolbar.marginTop,
                 equalTo(statusBarHeight.toPx(targetContext)),
             )
             assertThat(
-                "content clears the navigation bar",
+                "the root is not padded: scrolling content renders underneath the bottom bar",
                 binding.root.paddingBottom,
+                equalTo(0),
+            )
+            assertThat(
+                "the scroll view is not clipped: content renders into its padding while scrolling",
+                binding.scrollView.clipToPadding,
+                equalTo(false),
+            )
+            assertThat(
+                "the end of the scrolled content clears the navigation bar",
+                binding.scrollView.paddingBottom,
                 equalTo(navigationBarSize.toPx(targetContext)),
             )
         }
@@ -202,12 +224,12 @@ class ReviewRemindersInsetsTest : RobolectricTest() {
 
             assertThat(
                 "the fragment does not apply the top inset again",
-                binding.root.paddingTop,
+                binding.troubleshootingToolbar.marginTop,
                 equalTo(0),
             )
             assertThat(
                 "the fragment does not apply the bottom inset again",
-                binding.root.paddingBottom,
+                binding.scrollView.paddingBottom,
                 equalTo(0),
             )
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersInsetsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersInsetsTest.kt
@@ -166,7 +166,8 @@ class ReviewRemindersInsetsTest : RobolectricTest() {
     @Test
     fun `settings host - collapsible toolbar clears the status bar`() =
         withSettingsScheduleReminders { activity, binding ->
-            activity.dispatchInsets(navBarBottom = navigationBarSize)
+            val styleExpandedTitleMarginStart = binding.collapsingToolbarLayout.expandedTitleMarginStart
+            activity.dispatchInsets(navBarBottom = navigationBarSize, cutoutLeft = 32.dp)
 
             assertThat(
                 "the root does not pad itself; the app bar handles the inset",
@@ -177,6 +178,29 @@ class ReviewRemindersInsetsTest : RobolectricTest() {
                 "the collapsible toolbar is pushed clear of the status bar",
                 binding.toolbar.top,
                 equalTo(statusBarHeight.toPx(targetContext)),
+            )
+            // the padding sits inside the collapsing layout, not on the app bar: the
+            // collapsed content scrim covers the collapsing layout's bounds, and must
+            // extend behind the cutout to match the rest of the toolbar
+            assertThat(
+                "toolbar content clears the cutout",
+                binding.collapsingToolbarLayout.paddingLeft,
+                equalTo(32.dp.toPx(targetContext)),
+            )
+            assertThat(
+                "the app bar is not padded: it would push the scrim off the cutout",
+                binding.appbar.paddingLeft,
+                equalTo(0),
+            )
+            assertThat(
+                "the expanded title clears the cutout: it ignores the layout's padding",
+                binding.collapsingToolbarLayout.expandedTitleMarginStart,
+                equalTo(styleExpandedTitleMarginStart + 32.dp.toPx(targetContext)),
+            )
+            assertThat(
+                "the root's layout does not offset the list again: its padding handles the cutout",
+                binding.recyclerView.left,
+                equalTo(0),
             )
             assertThat(
                 "the 'add reminder' button rests above the navigation bar",

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersInsetsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersInsetsTest.kt
@@ -3,6 +3,7 @@
 package com.ichi2.anki.reviewreminders
 
 import android.app.Activity
+import android.os.Build
 import android.view.View
 import android.view.WindowManager
 import androidx.annotation.IdRes
@@ -18,8 +19,10 @@ import androidx.core.view.marginTop
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
+import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SdkSuppress
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
@@ -36,13 +39,16 @@ import com.ichi2.anki.utils.ConfigAwareSingleFragmentActivity
 import com.ichi2.anki.withDeckPicker
 import com.ichi2.testutils.BackupManagerTestUtilities
 import com.ichi2.testutils.insetsOf
+import com.ichi2.testutils.withWritePermissions
 import com.ichi2.utils.Dp
 import com.ichi2.utils.dp
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.notNullValue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
 
 /**
  * Edge-to-edge inset handling for [ScheduleRemindersFragment] and [ReminderTroubleshootingFragment]
@@ -127,6 +133,7 @@ class ReviewRemindersInsetsTest : RobolectricTest() {
         }
 
     @Test
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P) // layoutInDisplayCutoutMode
     fun `standalone host - the window renders into a display cutout`() =
         withStandaloneScheduleReminders { activity, _ ->
             assertThat(
@@ -134,6 +141,34 @@ class ReviewRemindersInsetsTest : RobolectricTest() {
                 activity.window.attributes.layoutInDisplayCutoutMode,
                 equalTo(WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES),
             )
+        }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.Q])
+    @Suppress("DEPRECATION") // systemUiVisibility: how WindowCompat un-fits the window below API 30
+    fun `standalone host - the window renders edge to edge only while resumed`() =
+        withWritePermissions {
+            val intent = ScheduleRemindersFragment.getIntent(targetContext, ReviewReminderScope.Global)
+            ActivityScenario.launch<ConfigAwareSingleFragmentActivity>(intent).use { scenario ->
+                advanceRobolectricLooper()
+                scenario.onActivity { activity ->
+                    assertThat(
+                        "the window lays out edge to edge: scrolled content renders underneath the bottom bar",
+                        activity.window.decorView.systemUiVisibility and DECOR_FITS_FLAGS,
+                        equalTo(DECOR_FITS_FLAGS),
+                    )
+                }
+
+                scenario.moveToState(Lifecycle.State.STARTED)
+                advanceRobolectricLooper()
+                scenario.onActivity { activity ->
+                    assertThat(
+                        "pausing restores the window: other screens expect it to fit the system windows",
+                        activity.window.decorView.systemUiVisibility and DECOR_FITS_FLAGS,
+                        equalTo(0),
+                    )
+                }
+            }
         }
 
     @Test
@@ -208,6 +243,27 @@ class ReviewRemindersInsetsTest : RobolectricTest() {
                 equalTo((fabMargin + navigationBarSize).toPx(targetContext)),
             )
         }
+
+    @Test
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P) // layoutInDisplayCutoutMode
+    fun `settings host - the shared two-pane window is left alone`() {
+        // sw600dp: the settings host shares its window with the headers pane, which does not
+        // handle insets. Rendering the window edge to edge would slide that pane's content
+        // behind the system bars, so the reminders screens must leave the window untouched.
+        RuntimeEnvironment.setQualifiers(RobolectricDeviceQualifiers.MediumTablet)
+        withSettingsScheduleReminders { activity, _ ->
+            assertThat(
+                "sanity: the headers pane shares the window",
+                activity.findViewById<View>(R.id.lateral_nav_container),
+                notNullValue(),
+            )
+            assertThat(
+                "the reminders pane does not change the shared window's cutout mode",
+                activity.window.attributes.layoutInDisplayCutoutMode,
+                equalTo(WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT),
+            )
+        }
+    }
 
     @Test
     fun `study options frame host - insets are applied by the host, not the fragment`() =
@@ -415,5 +471,17 @@ class ReviewRemindersInsetsTest : RobolectricTest() {
         commit { replace(containerId, fragment) }
         advanceRobolectricLooper()
         return findFragmentById(containerId)!!.requireView()
+    }
+
+    companion object {
+        /**
+         * The `systemUiVisibility` layout flags which `WindowCompat.setDecorFitsSystemWindows`
+         * sets on API < 30 for a window which does not fit the system windows.
+         */
+        @Suppress("DEPRECATION")
+        private const val DECOR_FITS_FLAGS =
+            View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
+                View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
+                View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/InsetsUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/InsetsUtils.kt
@@ -50,7 +50,7 @@ fun insetsOf(
  * Overlays are displayed as translucent bands so content can be drawn behind them.
  *
  * @param cutoutLeft simulates a display cutout on the left edge, as when a phone with a
- * top notch is rotated to landscape
+ * top notch is rotated to landscape.
  */
 @SuppressLint("RtlHardcoded") // insets and cutouts are physical: not layout-direction relative
 fun Activity.simulateSystemBars(cutoutLeft: Dp = 0.dp) {
@@ -60,7 +60,8 @@ fun Activity.simulateSystemBars(cutoutLeft: Dp = 0.dp) {
         WindowInsetsCompat
             .Builder()
             .setInsets(statusBars(), insetsOf(top = statusBarHeight))
-            .setInsets(navigationBars(), insetsOf(bottom = navBarHeight))
+            // workaround for 'systemWindowInsets', so snackbars match a real device
+            .setInsets(navigationBars(), insetsOf(left = cutoutLeft, bottom = navBarHeight))
             .setInsets(displayCutout(), insetsOf(left = cutoutLeft))
             .build()
     ViewCompat.dispatchApplyWindowInsets(findViewById(android.R.id.content), insets)


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

## Purpose / Description
`ScheduleRemindersFragment` and `ReminderTroubleshootingFragment` needed edge to edge support

## Fixes
* Part of #17334
* Fixes #21519
* built on  https://github.com/ankidroid/Anki-Android/pull/21588

## Approach
Before starting, consume the insets which will be passed to the fragments, then set the insets on a per-element basis.

There was lots of experimentation here to get the screenshots working correctly (ensuring the toolbars extended into the cutouts, ensuring scrolling), each is split into a separate commit.

I have a follow-up implemented for 'Settings', but this PR is already too large:

* https://github.com/david-allison/Anki-Android/pull/67

## How Has This Been Tested?
Screenshot tests are added. 

API 37 

<img width="400" alt="image" src="https://github.com/user-attachments/assets/8bbd5495-441c-4cfa-9144-ce4fdeeba570" />

----

<img width="400" alt="image" src="https://github.com/user-attachments/assets/e99b36d6-fd03-4cf1-a1d7-02b4517e88da" />

----

<img width="400" alt="image" src="https://github.com/user-attachments/assets/357c6ba4-c128-46da-8382-01ce9e3d630f" />
----
<img width="400" alt="image" src="https://github.com/user-attachments/assets/30dab695-df17-4747-b034-69795062f4f0" />

## Learning

* `FragmentHost` made this difficult

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)