### PR TITLE
fix(info): do not raise the buttons above the navigation bar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
@@ -25,7 +25,6 @@ import com.ichi2.anki.common.utils.android.getColorFromAttr
 import com.ichi2.anki.databinding.ActivityInfoBinding
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
-import com.ichi2.anki.utils.bottomCornerClearance
 import com.ichi2.utils.IntentUtil.canOpenIntent
 import com.ichi2.utils.IntentUtil.tryOpenIntent
 import com.ichi2.utils.VersionUtils.appName
@@ -178,11 +177,9 @@ class Info :
             // the toolbar's parent: padding on the Toolbar counts towards its minHeight,
             // which would shrink the app bar's content below actionBarSize
             binding.toolbarContainer.updatePadding(left = bars.left, top = bars.top, right = bars.right)
-            binding.content.updatePadding(
-                left = bars.left,
-                right = bars.right,
-                bottom = maxOf(bars.bottom, insets.bottomCornerClearance(binding.content)),
-            )
+            // no corner clearance: the buttons carry a 12dp horizontal margin, so the arc
+            // intrudes less than the navigation bar already clears
+            binding.content.updatePadding(left = bars.left, right = bars.right, bottom = bars.bottom)
             insets
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/InfoInsetsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/InfoInsetsTest.kt
@@ -94,14 +94,15 @@ class InfoInsetsTest : RobolectricTest() {
         }
 
     @Test
-    fun `bottom controls clear rounded display corners larger than the navigation bar`() =
+    fun `rounded display corners do not lift the buttons any further`() =
         withInfo { info ->
             info.dispatchInsets(navBarBottom = 24.dp, bottomCornerRadius = 48.dp)
 
             assertThat(
-                "'donate' rests above the corner arc, not just the navigation bar",
+                "the buttons' own 12dp margin puts them inboard of the corner arc, which at that " +
+                    "radius intrudes ~16dp, so the navigation bar already clears them",
                 info.content.paddingBottom,
-                equalTo(48.dp.toPx(targetContext)),
+                equalTo(24.dp.toPx(targetContext)),
             )
         }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

<!---
Uncomment this section if AI tools were used. New contributors may not use AI tools. See:
https://github.com/ankidroid/Anki-Android/blob/main/AI_POLICY.md
> [!NOTE]
> Assisted-by: ___
--->

## Purpose / Description
We don't need bottom button clearance here sorry about that so updating the code and test

## Fixes
* Fixes #21583

## Approach
ref commit

## How Has This Been Tested?
<img width="44%" height="44%" alt="image" src="https://github.com/user-attachments/assets/6e394f37-9ead-4938-bf5b-705ff3fe7ab8" />

## Learning (optional, can help others)
Mistakes happen :)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->