### PR TITLE
Enable edge to edge for FilteredDeckOptionsFragment

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/filtered/FilteredDeckOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/filtered/FilteredDeckOptionsFragment.kt
@@ -5,8 +5,10 @@ package com.ichi2.anki.filtered
 
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.text.InputFilter
+import android.util.TypedValue
 import android.view.MenuItem
 import android.view.View
 import android.widget.AdapterView
@@ -15,7 +17,12 @@ import android.widget.CheckBox
 import android.widget.Spinner
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AlertDialog
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat.Type.displayCutout
+import androidx.core.view.WindowInsetsCompat.Type.ime
+import androidx.core.view.WindowInsetsCompat.Type.systemBars
 import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -33,6 +40,7 @@ import com.ichi2.anki.databinding.FragmentFilteredDeckOptionsBinding
 import com.ichi2.anki.dialogs.DiscardChangesDialog
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.utils.ConfigAwareSingleFragmentActivity
+import com.ichi2.anki.utils.ext.window
 import com.ichi2.anki.utils.openUrl
 import com.ichi2.utils.cancelable
 import com.ichi2.utils.configureIconsDirection
@@ -67,6 +75,19 @@ class FilteredDeckOptionsFragment : Fragment(R.layout.fragment_filtered_deck_opt
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isNavigationBarContrastEnforced = false
+        } else {
+            val typedValue = TypedValue()
+            requireContext().theme.resolveAttribute(android.R.attr.background, typedValue, true)
+            @Suppress("DEPRECATION")
+            window.navigationBarColor = typedValue.data
+        }
+        ViewCompat.setOnApplyWindowInsetsListener(binding.content) { v, insets ->
+            val constraints = insets.getInsets(systemBars() or displayCutout() or ime())
+            v.updatePadding(left = constraints.left, right = constraints.right, top = constraints.top, bottom = constraints.bottom)
+            insets
+        }
         binding.toolbar.apply {
             title = "" // properly set in state updates
             setNavigationOnClickListener {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ConfigAwareSingleFragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ConfigAwareSingleFragmentActivity.kt
@@ -32,6 +32,8 @@ import kotlin.reflect.jvm.jvmName
  * or declare your own copy.
  */
 class ConfigAwareSingleFragmentActivity : SingleFragmentActivity() {
+    override val supportsEdgeToEdge: Boolean = true
+
     companion object {
         fun getIntent(
             context: Context,

--- a/AnkiDroid/src/main/res/layout/fragment_filtered_deck_options.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_filtered_deck_options.xml
@@ -6,6 +6,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/content"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 


### PR DESCRIPTION
## Purpose / Description

Enable edge to edge for FilteredDeckOptionsFragment. I had this implemented manually but waited  after seeing criticalAY's latest PR.

The changed activity, ConfigAwareSingleFragmentActivity is used both by FilteredDeckOptionsFragment and by ScheduleRemindersFragment(in DeckPicker). With these changes ScheduleRemindersFragment doesn't respect edge to edge but I didn't do anything about this yet to wait for  #21519.

Some images:

API 28:

<img width="308" height="662" alt="Screenshot_20260824_184141" src="https://github.com/user-attachments/assets/bcba0c1f-44bd-4655-8c54-b8b58f360000" />
<img width="662" height="309" alt="Screenshot_20260824_184151" src="https://github.com/user-attachments/assets/45416691-ccfb-42a7-b1eb-dbcf6864b514" />
<img width="661" height="308" alt="Screenshot_20260824_184200" src="https://github.com/user-attachments/assets/f870221c-0d09-46ad-beea-ae5c0ac27465" />

API 36:

<img width="270" height="600" alt="Screenshot_20260824_183950" src="https://github.com/user-attachments/assets/0afda7ff-674d-4334-911f-a4919a0a5032" />
<img width="600" height="270" alt="Screenshot_20260824_184006" src="https://github.com/user-attachments/assets/c0b7415c-88de-4810-a9eb-60506c1a3ebc" />
<img width="600" height="270" alt="Screenshot_20260824_184021" src="https://github.com/user-attachments/assets/eacc6f57-9232-46be-ad39-83a5056a2b63" />

## Fixes
* Towards #17334, didn't bother to create another issue

## How Has This Been Tested?

Manually on two devices: API 28(big notch + system bars) and API 36(punch cutout + system bars).

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

