### PR TITLE
Fix hasUnsavedChanges() false positive with sticky fields

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -211,6 +211,13 @@ class NoteEditorFragment :
     private var isFieldEdited = false
     private var addNoteJob = RunOnlyOnce(scope = lifecycleScope)
 
+    /**
+     * The field values of a new note immediately after they were last (re)populated -
+     * e.g. after a sticky field was carried over from the previous note. Used so
+     * [hasUnsavedChanges] can tell sticky-carried-over content apart from an actual edit.
+     */
+    private var addNoteFieldBaseline: List<String> = emptyList()
+
     private val getColUnsafe: Collection
         get() = CollectionManager.getColUnsafe()
 
@@ -1160,8 +1167,10 @@ class NoteEditorFragment :
             }
 
             if (!isFieldEdited) return false
-            // BUG: Does not account for sticky fields
-            return editFields!!.any { it.text.toString() != "" }
+            // compare against the sticky-populated baseline rather than "any field non-empty",
+            // otherwise a sticky field alone would always look like an unsaved change
+            val currentStrings = editFields!!.map { it.text?.toString() ?: "" }
+            return currentStrings != addNoteFieldBaseline
         }
 
         // changed note type?
@@ -2171,12 +2180,14 @@ class NoteEditorFragment :
             editFields!!.first().focusWithKeyboard {
                 editFields!!.forEach { it.setText("") }
                 updateFieldsFromStickyText()
+                if (addNote) addNoteFieldBaseline = editFields!!.map { it.text?.toString() ?: "" }
             }
         } else {
             populateEditFields(changeType)
             if (changeType.type != Type.CHANGE_FIELD_COUNT) {
                 updateFieldsFromStickyText()
             }
+            if (addNote) addNoteFieldBaseline = editFields!!.map { it.text?.toString() ?: "" }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -1167,8 +1167,6 @@ class NoteEditorFragment :
             }
 
             if (!isFieldEdited) return false
-            // compare against the sticky-populated baseline rather than "any field non-empty",
-            // otherwise a sticky field alone would always look like an unsaved change
             val currentStrings = editFields!!.map { it.text?.toString() ?: "" }
             return currentStrings != addNoteFieldBaseline
         }
@@ -2180,14 +2178,18 @@ class NoteEditorFragment :
             editFields!!.first().focusWithKeyboard {
                 editFields!!.forEach { it.setText("") }
                 updateFieldsFromStickyText()
-                if (addNote) addNoteFieldBaseline = editFields!!.map { it.text?.toString() ?: "" }
+                if (addNote) {
+                    addNoteFieldBaseline = editFields!!.map { it.text?.toString() ?: "" }
+                }
             }
         } else {
             populateEditFields(changeType)
             if (changeType.type != Type.CHANGE_FIELD_COUNT) {
                 updateFieldsFromStickyText()
             }
-            if (addNote) addNoteFieldBaseline = editFields!!.map { it.text?.toString() ?: "" }
+            if (addNote) {
+                addNoteFieldBaseline = editFields!!.map { it.text?.toString() ?: "" }
+            }
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -653,6 +653,35 @@ class NoteEditorTest : RobolectricTest() {
         }
 
     @Test
+    fun `hasUnsavedChanges - sticky field content alone is not an unsaved change`() =
+        runTest {
+            val basic = makeNoteForType(NoteType.BASIC)
+            basic!!.fields[0].sticky = true
+
+            val editor =
+                getNoteEditorAdding(NoteType.BASIC)
+                    .withFirstField("Hello")
+                    .withSecondField("World")
+                    .build()
+
+            editor.saveNote()
+            advanceRobolectricLooper()
+
+            // sticky field 0 carries "Hello" into the next note; nothing has actually been edited yet
+            assertThat(editor.currentFieldStrings.toList(), contains("Hello", ""))
+            assertFalse(editor.hasUnsavedChanges(), "fresh screen after save: no real edits yet")
+
+            // user types into the non-sticky field, then reverts their own edit
+            editor.setFieldValueFromUi(1, "x")
+            editor.setFieldValueFromUi(1, "")
+
+            assertFalse(
+                editor.hasUnsavedChanges(),
+                "user's only edit was reverted; only the sticky field remains populated - should not count as unsaved",
+            )
+        }
+
+    @Test
     fun `changing deck with multiple card ids moves all sibling cards`() =
         runTest {
             // Create a note with 2 cards (Basic and Reversed)


### PR DESCRIPTION
Fixes #21564

## Purpose / Description
The note editor was treating a sticky field as an "unsaved change" even when the user hadnt actually done anything. Since sticky fields carry their value forward from the previous note on purpose, the old check (any field non-empty = changed) basically always fired once a sticky field had content in it. So youd save a note, sticky field carries over like its supposed to, and then just trying to leave the screen would pop up a discard-changes warning for no reason.

## Approach
Instead of checking "is any field non-empty", now it captures a baseline of what the fields look like right after theyre (re)populated (fresh load or right after a save-and-continue), and compares the current fields against that baseline. So sticky content that was never touched by the user doesnt count as an edit anymore, only stuff that actually changed from that baseline does.

## How Has This Been Tested?
Added a Robolectric test that marks a field sticky, saves a note, and checks hasUnsavedChanges() right after (should be false since nothing was typed). Also checked the case where the user types into the other field and then reverts it back to empty - should still be false since net-net nothing changed. Confirmed the test fails on the old code and passes with the fix, also reverted the fix temporarily to make sure only this one test breaks and nothing else does.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
