### PR TITLE
test[DeckPickerContextMenu]: load the backend so the test can run first

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
@@ -31,6 +31,7 @@ import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.testutils.BackupManagerTestUtilities.setupSpaceForBackup
+import com.ichi2.testutils.JvmTest
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert
 import org.junit.After
@@ -41,8 +42,12 @@ import timber.log.Timber
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
+// JvmTest loads the rust backend. Without it this class only passes when it happens to run
+// after a test which loads it, which is filesystem order dependent (#14796)
+// TODO: PERF: JvmTest also opens a collection, which these tests never use. They only
+// need the backend for the menu's translated labels
 @RunWith(AndroidJUnit4::class)
-class DeckPickerContextMenuTest {
+class DeckPickerContextMenuTest : JvmTest() {
     private val scenariosForCleanup = ArrayList<FragmentScenario<*>>()
 
     @Before


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 5

## Purpose / Description

`DeckPickerContextMenuTest` does not extend `RobolectricTest`, so it never calls `RustBackendLoader.ensureSetup()`. It only passes when some test that *does* happens to run earlier in the same JVM. When it runs first, every one of its tests dies on:

```
java.lang.UnsatisfiedLinkError: 'byte[][] net.ankiweb.rsdroid.NativeMethods.openBackend(byte[])'
    at net.ankiweb.rsdroid.Backend.<init>(Backend.kt:86)
    at com.ichi2.anki.CollectionManager.getTR(CollectionManager.kt:188)
    at com.ichi2.anki.dialogs.DeckPickerContextMenu$DeckPickerContextMenuOption.label(DeckPickerContextMenu.kt:98)
```

## Fixes
- Part of #14796

## How Has This Been Tested?
CI and here:
- `./gradlew :AnkiDroid:testPlayDebugUnitTest --tests "com.ichi2.anki.dialogs.DeckPickerContextMenuTest"` 

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner]