### PR TITLE
fix(export): sanitise deck names for plain text exports

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
@@ -256,13 +256,10 @@ class ExportDialogFragment : AnalyticsDialogFragment() {
 
     private fun handleAnkiPackageExport() {
         val limits = buildExportLimit()
-        var packagePrefix = getNonCollectionNamePrefix()
-        // files can't have `/` in their names
-        packagePrefix = packagePrefix.replace("/", "_")
         val exportPath =
             File(
                 getExportRootFile(),
-                "$packagePrefix-${getTimestamp(TimeManager.time)}.apkg",
+                "${getNonCollectionNamePrefix()}-${getTimestamp(TimeManager.time)}.apkg",
             ).path
         requireAnkiActivity().exportApkgPackage(
             exportPath = exportPath,
@@ -278,12 +275,18 @@ class ExportDialogFragment : AnalyticsDialogFragment() {
      * Builds the prefix for the name of the exported file. This will be  either a deck's name or a
      * localized "SelectedNotes" text.
      */
-    private fun getNonCollectionNamePrefix(): String =
-        when (arguments?.getSerializableCompat<ExportType>(ARG_TYPE)) {
-            ExportType.Notes, ExportType.Cards -> CollectionManager.TR.exportingSelectedNotes()
-            // notes/cards weren't selected so export the chosen deck(s)
-            null -> (binding.deckSelector.adapter as DeckDisplayAdapter).getItem(binding.deckSelector.selectedItemPosition).name
-        }
+    // TODO: return [Filename] once the construction of export paths is refactored
+    private fun getNonCollectionNamePrefix(): String {
+        val filename =
+            Filename.sanitize(
+                when (arguments?.getSerializableCompat<ExportType>(ARG_TYPE)) {
+                    ExportType.Notes, ExportType.Cards -> CollectionManager.TR.exportingSelectedNotes()
+                    // notes/cards weren't selected so export the chosen deck(s)
+                    null -> (binding.deckSelector.adapter as DeckDisplayAdapter).getItem(binding.deckSelector.selectedItemPosition).name
+                },
+            )
+        return filename.value
+    }
 
     private fun handleNotesInPlainTextExport() {
         val exportLimit = buildExportLimit()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/Filename.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/Filename.kt
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.export
+
+/** The name of a file, without a path or an extension. */
+@JvmInline
+value class Filename private constructor(
+    val value: String,
+) {
+    init {
+        require(!INVALID_CHARACTERS.containsMatchIn(value)) { "'$value' contains invalid characters" }
+    }
+
+    override fun toString() = value
+
+    companion object {
+        /**
+         * @see <a href="https://github.com/ankitects/anki/blob/d4fdbefcebeb4318e3732a450923cbf94c877362/qt/aqt/import_export/exporting.py#L176">exporting.py</a>
+         */
+        private val INVALID_CHARACTERS = Regex("""[\\/?<>:*|"^]""")
+
+        fun sanitize(value: String) = Filename(INVALID_CHARACTERS.replace(value, "_"))
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/export/FilenameTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/export/FilenameTest.kt
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.export
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+
+class FilenameTest {
+    @Test
+    fun `a valid name is unchanged`() {
+        assertThat(Filename.sanitize("Japanese Vocab").value, equalTo("Japanese Vocab"))
+    }
+
+    @Test
+    fun `each invalid character is replaced`() {
+        assertThat(
+            Filename.sanitize("""a\b/c?d<e>f:g*h|i"j^k""").value,
+            equalTo("a_b_c_d_e_f_g_h_i_j_k"),
+        )
+    }
+
+    @Test
+    fun `a colon in a deck name is replaced`() {
+        assertThat(Filename.sanitize("Ratio 1:2").value, equalTo("Ratio 1_2"))
+    }
+
+    @Test
+    fun `the subdeck separator is replaced`() {
+        assertThat(Filename.sanitize("Japanese::Kanji").value, equalTo("Japanese__Kanji"))
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude sonnet(test fixes)

## Purpose / Description

Exporting a deck whose name contains a character that isn't valid in a file name fails for
both plain-text formats.

The export file name is built from the deck name, and `/` is a path separator, so a deck named
e.g. `Hi/This` produces a path pointing at directories which don't exist, and the export fails
with an IO error. The same deck exports fine as `.apkg`.

## Fixes

#21591

## Approach

`handleAnkiPackageExport()` already replaced `/` with `_` before building the path, but
`handleNotesInPlainTextExport()` and `handleCardsInPlainTextExport()` built theirs straight from
`getNonCollectionNamePrefix()` without it. All three were added in the same commit (8aff5233d4),
so this looks like an oversight rather than intentional.

Added a `Filename` value class which performs the validation: `sanitize()` replaces the
characters Anki Desktop strips (`exporting.py`), and an `init` block guarantees no invalid
character can survive. `getNonCollectionNamePrefix()` builds one and returns `filename.value`,
with a TODO for refactoring the export paths to use `Filename` throughout.

`:` is in that set, so a subdeck exports as `Japanese__Kanji` the regex replaces per
character,

## How Has This Been Tested?

`FilenameTest` covers a valid name being unchanged, every invalid character being replaced,
a single colon (`Ratio 1:2`), and the subdeck separator.

Verified the original failure first — before the fix the prefix for `Der/Die/Das` was
`Der/Die/Das` rather than `Der_Die_Das`. `ExportDialogFragmentTest` is unchanged and still
passes, covering the `.apkg` path being unaffected.

Manually on OPPO A58:

1. Created a deck `Der/Die/Das` with one note
2. Deck Picker → long-press → Export deck → Notes in Plain Text (.txt) → Export
3. Before: `No such file or directory (os error 2)`
4. After: the file exports successfully
5. `Cards in Plain Text (.txt)` behaves the same
6. `.apkg` export of the same deck works before and after

## Checklist

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner]
