### PR TITLE
fix(permissions): don't crash if we can't open app settings

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -18,6 +18,7 @@ package com.ichi2.utils
 
 import android.Manifest
 import android.app.Activity
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -261,12 +262,17 @@ object Permissions {
      */
     fun Activity.openAppSettingsScreen() {
         Timber.i("launching ACTION_APPLICATION_DETAILS_SETTINGS")
-        startActivity(
-            Intent(
-                Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-                Uri.fromParts("package", packageName, null),
-            ),
-        )
+        try {
+            startActivity(
+                Intent(
+                    Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                    Uri.fromParts("package", packageName, null),
+                ),
+            )
+        } catch (e: ActivityNotFoundException) {
+            Timber.w(e, "No app can show the app settings screen")
+            showThemedToast(this, R.string.activity_start_failed, false)
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -259,15 +259,21 @@ object Permissions {
      * Opens the Android settings for AnkiDroid if the device provide this feature.
      * Lets a user grant any missing permissions which have been permanently denied.
      */
-    fun Fragment.openAppSettingsScreen() {
+    fun Activity.openAppSettingsScreen() {
         Timber.i("launching ACTION_APPLICATION_DETAILS_SETTINGS")
         startActivity(
             Intent(
                 Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-                Uri.fromParts("package", requireActivity().packageName, null),
+                Uri.fromParts("package", packageName, null),
             ),
         )
     }
+
+    /**
+     * Opens the Android settings for AnkiDroid if the device provide this feature.
+     * Lets a user grant any missing permissions which have been permanently denied.
+     */
+    fun Fragment.openAppSettingsScreen() = requireActivity().openAppSettingsScreen()
 
     /**
      * Opens the Android notifications settings for AnkiDroid if the device provides this feature.

--- a/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
@@ -34,6 +34,7 @@ import androidx.test.filters.SdkSuppress
 import com.ichi2.anki.PermissionSet
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ui.windows.permissions.PermissionsBottomSheet
+import com.ichi2.utils.Permissions.openAppSettingsScreen
 import com.ichi2.utils.Permissions.requestPermissionThroughDialogOrSettings
 import com.ichi2.utils.Permissions.showToastAndOpenAppSettingsScreen
 import io.mockk.every
@@ -49,7 +50,10 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
@@ -86,6 +90,14 @@ class PermissionsTest {
     fun tearDown() {
         unmockkAll()
         Prefs.notificationsPermissionRequested = false
+    }
+
+    @Test
+    fun `openAppSettingsScreen is a no-op if no app can show the app settings screen`() {
+        val realActivity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        // throw when resolving `ACTION_APPLICATION_DETAILS_SETTINGS`
+        shadowOf(realActivity.application).checkActivities(true)
+        assertDoesNotThrow { realActivity.openAppSettingsScreen() }
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
@@ -26,6 +26,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -54,6 +55,7 @@ import org.robolectric.annotation.Config
 @RunWith(AndroidJUnit4::class)
 class PermissionsTest {
     private lateinit var activity: Activity
+    private lateinit var fragmentActivity: FragmentActivity
     private lateinit var context: Context
     private lateinit var fragment: Fragment
     private lateinit var fragmentManager: FragmentManager
@@ -64,7 +66,9 @@ class PermissionsTest {
     fun setUp() {
         context = getApplicationContext()
         activity = mockk(relaxed = true)
+        fragmentActivity = mockk(relaxed = true)
         fragment = mockk(relaxed = true)
+        every { fragment.requireActivity() } returns fragmentActivity
         fragmentManager = mockk(relaxed = true)
         permissionRequestLauncher = mockk(relaxed = true)
         permissionsSpy = spyk(Permissions)
@@ -169,7 +173,7 @@ class PermissionsTest {
         verify(exactly = 0) { permissionRequestLauncher.launch(DUMMY_PERMISSION_STRING) }
 
         val intentSlot = slot<Intent>()
-        verify(exactly = 1) { fragment.startActivity(capture(intentSlot)) }
+        verify(exactly = 1) { fragmentActivity.startActivity(capture(intentSlot)) }
         assertThat(intentSlot.captured.action, equalTo(Settings.ACTION_APPLICATION_DETAILS_SETTINGS))
     }
 


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

## Purpose / Description
* extra safety against unusual devices
* extends functionality to work for `Activity`

## Approach
* try...catch

## How Has This Been Tested?
Unit test added

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)