### PR TITLE
fix(permissions): `allowTemplatesToRecordAudio` was always false

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -43,6 +43,7 @@ import kotlin.reflect.KProperty
 //  after the UI classes of that package are moved to `com.ichi2.anki.ui.preferences`
 object Prefs : PrefsRepository(AnkiDroidApp.sharedPrefs(), AnkiDroidApp.appResources)
 
+// TODO: enforce that `preferences.xml` is used
 open class PrefsRepository(
     val sharedPrefs: SharedPreferences,
     private val resources: Resources,
@@ -388,7 +389,7 @@ open class PrefsRepository(
 
     val isHtmlTypeAnswerEnabled by booleanPref(R.string.use_input_tag_key, defaultValue = false)
     var useFixedPortInReviewer by booleanPref(R.string.use_fixed_port_pref_key, false)
-    var allowTemplatesToRecordAudio by booleanPref(R.string.allow_templates_to_record_audio, false)
+    var allowTemplatesToRecordAudio by booleanPref(R.string.pref_allow_template_audio_recording, false)
 
     var reviewerPort by intPref(R.string.reviewer_port_pref_key, defaultValue = 0)
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/AdvancedSettingsFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/AdvancedSettingsFragmentTest.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.preferences
+
+import androidx.preference.SwitchPreferenceCompat
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.R
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.common.destinations.DeferredNavigation
+import com.ichi2.anki.common.destinations.PreferencesDestination
+import com.ichi2.anki.common.destinations.launchActivity
+import com.ichi2.anki.settings.PrefsRepository
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AdvancedSettingsFragmentTest : RobolectricTest() {
+    // not `Prefs` - the singleton is not cleared
+    private val prefs get() = PrefsRepository(targetContext)
+
+    @Test
+    fun `'allow templates to record audio' switch updates the pref read by the card viewers`() {
+        grantRecordAudioPermission()
+        prefs.allowTemplatesToRecordAudio = false
+
+        withAdvancedSettings {
+            allowTemplatesToRecordAudioSwitch.performClick()
+            assertThat("enabled after checking the switch", prefs.allowTemplatesToRecordAudio, equalTo(true))
+
+            allowTemplatesToRecordAudioSwitch.performClick()
+            assertThat("disabled after unchecking the switch", prefs.allowTemplatesToRecordAudio, equalTo(false))
+        }
+    }
+
+    @Test
+    fun `'allow templates to record audio' switch is unchecked if the microphone permission is missing`() {
+        prefs.allowTemplatesToRecordAudio = true
+
+        withAdvancedSettings {
+            assertThat("switch is unchecked", allowTemplatesToRecordAudioSwitch.isChecked, equalTo(false))
+        }
+    }
+}
+
+private val AdvancedSettingsFragment.allowTemplatesToRecordAudioSwitch
+    get() = requirePreference<SwitchPreferenceCompat>(R.string.pref_allow_template_audio_recording)
+
+/** Runs [block] on the 'Advanced' settings screen */
+context(_: DeferredNavigation)
+private fun withAdvancedSettings(block: AdvancedSettingsFragment.() -> Unit) = withPreferences(PreferencesDestination.Advanced, block)
+
+/**
+ * Opens the settings screen at [destination] and runs [block] on the fragment which displays it.
+ */
+context(_: DeferredNavigation)
+private inline fun <reified F : SettingsFragment> withPreferences(
+    destination: PreferencesDestination,
+    crossinline block: F.() -> Unit,
+) {
+    launchActivity<PreferencesActivity>(destination).use { scenario ->
+        scenario.onActivity { activity ->
+            val preferencesFragment = activity.fragment as PreferencesFragment
+            val settingsFragment = preferencesFragment.childFragmentManager.findFragmentByTag(F::class.java.name) as F
+            settingsFragment.block()
+        }
+    }
+}


### PR DESCRIPTION

> [!NOTE]
> Assisted-by: Claude [Opus/Fable] 5

## Purpose / Description
As in the title

## Fixes
* Part of #20111
* Introduced in c4adb1253dd9aa35db0410a2c4273790455e2e85

## Approach
Use the preference key

## How Has This Been Tested?
Test added

## Learning (optional, can help others)
We need better enforcement here, thankfully 'false' is 'fail-safe'

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)