### PR TITLE
Fix IntentHandler crash on COPY_DEBUG_INFO without clip_data extra

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -113,9 +113,13 @@ class IntentHandler : AbstractIntentHandler() {
 
     private fun copyDebugInfoToClipboard(intent: Intent) {
         Timber.i("Copying debug info to clipboard")
-        // null string is handled by copyToClipboard in try-catch
+        val clipboardData =
+            intent.getStringExtra(EXTRA_CLIPBOARD_DATA) ?: run {
+                Timber.w("copyDebugInfoToClipboard: missing '%s' extra", EXTRA_CLIPBOARD_DATA)
+                return
+            }
         this.copyToClipboard(
-            text = (intent.getStringExtra(EXTRA_CLIPBOARD_DATA)!!),
+            text = clipboardData,
             failureMessageId = R.string.about_ankidroid_error_copy_debug_info,
         )
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/IntentHandlerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/IntentHandlerTest.kt
@@ -12,11 +12,22 @@ import com.ichi2.anki.IntentHandler.LaunchType
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.runner.RunWith
 import org.mockito.Mockito
+import org.robolectric.Robolectric
 
 @RunWith(AndroidJUnit4::class)
 class IntentHandlerTest {
+    @Test
+    fun `COPY_DEBUG_INFO without clip_data does not crash`() {
+        val intent = Intent("com.ichi2.anki.COPY_DEBUG_INFO")
+
+        assertDoesNotThrow {
+            Robolectric.buildActivity(IntentHandler::class.java, intent).create()
+        }
+    }
+
     // COULD_BE_BETTER: We're testing class internals here, would like to see these tests be replaced with
     // higher-level tests at a later date when we better extract dependencies
     @Test


### PR DESCRIPTION
Fixes #21630

## Purpose / Description
IntentHandler is exported with no permission requirement, so any app on the device (or adb) can send it a COPY_DEBUG_INFO intent. copyDebugInfoToClipboard() was using a !! on the clip_data extra, which throws an uncaught NullPointerException if the extra is missing. Theres even a comment above it claiming the null case is handled by copyToClipboard in a try-catch, but thats wrong - the !! blows up before copyToClipboard is ever called.

## Approach
Swapped the !! for a ?: return, so a missing extra just no-ops instead of crashing.

## How Has This Been Tested?
Added a Robolectric test that launches IntentHandler with the bare COPY_DEBUG_INFO action and no clip_data extra. Confirmed it fails with the NPE on the old code, passes after the fix. Also reverted the fix temporarily to make sure only this one test breaks and nothing else does.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
