### PR TITLE
fix(strings): sentence-case the restore-to-default menu title

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -1038,7 +1038,7 @@ open class CardTemplateEditor : AnkiActivity(R.layout.activity_card_template_edi
          * Setups the part of the menu that can be used either in template editor or in previewer fragment.
          */
         fun setupCommonMenu(menu: Menu) {
-            menu.findItem(R.id.action_restore_to_default).title = TR.cardTemplatesRestoreToDefault()
+            menu.findItem(R.id.action_restore_to_default).title = TR.sentenceCase.restoreToDefault
             menu.findItem(R.id.action_card_browser_appearance).title = TR.sentenceCase.browserAppearance
             if (noteTypeCreatesDynamicNumberOfNotes()) {
                 Timber.d("Editing cloze/occlusion note type, disabling add/delete card template and deck override functionality")
@@ -1170,7 +1170,7 @@ open class CardTemplateEditor : AnkiActivity(R.layout.activity_card_template_edi
                                 stockNotetypeKinds.map { getStockNotetype(it).name }
                             }
                         AlertDialog.Builder(requireContext()).show {
-                            setTitle(TR.cardTemplatesRestoreToDefault())
+                            setTitle(TR.sentenceCase.restoreToDefault)
                             setNegativeButton(R.string.dialog_cancel) { _, _ -> }
                             listItems(stockNotetypesNames) { _: DialogInterface, index: Int ->
                                 val kind = stockNotetypeKinds[index]


### PR DESCRIPTION
## Summary
- Uses the existing `TR.sentenceCase.restoreToDefault` instead of the raw Title Case backend string (`TR.cardTemplatesRestoreToDefault()`) for the "Restore to Default" menu item and dialog title in the Card Template Editor.

Part of the "Main screen" section in #15760 (one PR per feature, as requested).

## Test plan
- [x] Covered by the existing `SentenceCaseTest.kt`, which pins `TR.sentenceCase.restoreToDefault` to "Restore to default".
- [ ] Manually verified the menu/dialog title reads "Restore to default" in the Card Template Editor.