### PR TITLE
fix(strings): sentence-case advanced settings titles

### DIFF
--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -134,9 +134,9 @@
     <string name="select_locale_title">Select language</string>
     <string name="software_render" maxLength="41">Disable card hardware render</string>
     <string name="software_render_summ">Hardware render is faster but may have problems, specifically on Android 8/8.1. If you cannot see parts of the card review user interface, try this setting.</string>
-    <string name="disable_extended_text_ui" maxLength="41">Disable Single-Field Edit Mode</string>
+    <string name="disable_extended_text_ui" maxLength="41">Disable single-field edit mode</string>
     <!--See: multimedia_editor_popup_cloze. We can't use format strings as this is auto-generated-->
-    <string name="disable_extended_text_ui_summ">Allows \'Cloze Deletion\' context menu when in landscape mode.</string>
+    <string name="disable_extended_text_ui_summ">Allows \'cloze deletion\' context menu when in landscape mode.</string>
     <string name="vertical_centering" maxLength="41">Center align</string>
     <string name="vertical_centering_summ">Center the content of cards vertically</string>
     <string name="pref_double_tap_time_interval" maxLength="41">Double tap time interval</string>
@@ -294,7 +294,7 @@ this formatter is used if the bind only applies to the answer">A: %s</string>
     <string name="readtext_reviewer_warn" tools:ignore="UnusedResources">Please upgrade to the new text to speech format</string>
     <string name="allow_templates_to_record_audio" maxLength="41">Allow templates to record audio</string>
     <string name="template_is_trying_to_record_audio">This template is trying to record audio</string>
-    <string name="pref_fixed_port_title" maxLength="41">localStorage in Study Screen</string>
+    <string name="pref_fixed_port_title" maxLength="41">localStorage in study screen</string>
     <string name="pref_fixed_port_summary"
         >Enables JavaScript localStorage by using a fixed server port in the Study Screen</string>
 


### PR DESCRIPTION
## Summary
- Converts "Disable Single-Field Edit Mode" to "Disable single-field edit mode"
- Converts "'Cloze Deletion'" to "'cloze deletion'" in its summary
- Converts "localStorage in Study Screen" to "localStorage in study screen"

Part of the "Settings > Advanced" section in #15760 (one PR per feature, as requested).

## Test plan
- [ ] Manually verified the three strings render in sentence case under Settings > Advanced.