### PR TITLE
fix(allowTemplatesToRecordAudio): handle veto correctly and stop showing permission dialog on revocation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
@@ -52,9 +52,11 @@ class AdvancedSettingsFragment : SettingsFragment() {
 
     private val microphonePermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted: Boolean ->
-            if (isGranted) return@registerForActivityResult
+            if (isGranted) {
+                requirePreference<SwitchPreferenceCompat>(R.string.pref_allow_template_audio_recording).isChecked = true
+                return@registerForActivityResult
+            }
 
-            findPreference<SwitchPreferenceCompat>(R.string.pref_allow_template_audio_recording)?.isChecked = false
             if (ActivityCompat.shouldShowRequestPermissionRationale(requireActivity(), Manifest.permission.RECORD_AUDIO)) {
                 return@registerForActivityResult
             }
@@ -135,10 +137,14 @@ class AdvancedSettingsFragment : SettingsFragment() {
 
         requirePreference<SwitchPreferenceCompat>(R.string.pref_allow_template_audio_recording).apply {
             isChecked = isChecked && Permissions.canRecordAudio(requireContext())
-            setOnPreferenceChangeListener { newValue ->
-                if (newValue && !Permissions.canRecordAudio(requireContext())) {
-                    microphonePermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+            setOnPreferenceChangeListener { _, newValue ->
+                if (newValue !is Boolean) return@setOnPreferenceChangeListener false
+                if (!newValue || Permissions.canRecordAudio(requireContext())) {
+                    return@setOnPreferenceChangeListener true
                 }
+                // veto the opt-in until the permission is granted
+                microphonePermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                false
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
@@ -135,8 +135,8 @@ class AdvancedSettingsFragment : SettingsFragment() {
 
         requirePreference<SwitchPreferenceCompat>(R.string.pref_allow_template_audio_recording).apply {
             isChecked = isChecked && Permissions.canRecordAudio(requireContext())
-            setOnPreferenceChangeListener {
-                if (!Permissions.canRecordAudio(requireContext())) {
+            setOnPreferenceChangeListener { newValue ->
+                if (newValue && !Permissions.canRecordAudio(requireContext())) {
                     microphonePermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
                 }
             }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/AdvancedSettingsFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/AdvancedSettingsFragmentTest.kt
@@ -2,6 +2,7 @@
 
 package com.ichi2.anki.preferences
 
+import android.Manifest
 import androidx.preference.SwitchPreferenceCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.R
@@ -10,10 +11,13 @@ import com.ichi2.anki.common.destinations.DeferredNavigation
 import com.ichi2.anki.common.destinations.PreferencesDestination
 import com.ichi2.anki.common.destinations.launchActivity
 import com.ichi2.anki.settings.PrefsRepository
+import com.ichi2.testutils.denyPermissions
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.nullValue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
 
 @RunWith(AndroidJUnit4::class)
 class AdvancedSettingsFragmentTest : RobolectricTest() {
@@ -31,6 +35,27 @@ class AdvancedSettingsFragmentTest : RobolectricTest() {
 
             allowTemplatesToRecordAudioSwitch.performClick()
             assertThat("disabled after unchecking the switch", prefs.allowTemplatesToRecordAudio, equalTo(false))
+        }
+    }
+
+    @Test
+    fun `'allow templates to record audio' switch does not request the permission when toggled off`() {
+        grantRecordAudioPermission()
+        prefs.allowTemplatesToRecordAudio = true
+
+        withAdvancedSettings {
+            // the switch is forced off when the screen opens without the permission,
+            // so an opt-out without it requires a revocation while the screen is open
+            denyPermissions(Manifest.permission.RECORD_AUDIO)
+
+            allowTemplatesToRecordAudioSwitch.performClick()
+
+            assertThat("opt-out is persisted", prefs.allowTemplatesToRecordAudio, equalTo(false))
+            assertThat(
+                "no permission request is launched",
+                shadowOf(requireActivity()).lastRequestedPermission,
+                nullValue(),
+            )
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/AdvancedSettingsFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/AdvancedSettingsFragmentTest.kt
@@ -3,6 +3,7 @@
 package com.ichi2.anki.preferences
 
 import android.Manifest
+import android.content.pm.PackageManager
 import androidx.preference.SwitchPreferenceCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.R
@@ -56,6 +57,43 @@ class AdvancedSettingsFragmentTest : RobolectricTest() {
                 shadowOf(requireActivity()).lastRequestedPermission,
                 nullValue(),
             )
+        }
+    }
+
+    /**
+     * The opt-in is durable state read by the card viewers: it must not
+     * persist while the microphone permission request it depends on is still unresolved,
+     * e.g. if the process dies before the user answers the system dialog.
+     */
+    @Test
+    fun `'allow templates to record audio' switch does not persist the opt-in before the permission is granted`() {
+        prefs.allowTemplatesToRecordAudio = false
+
+        withAdvancedSettings {
+            allowTemplatesToRecordAudioSwitch.performClick()
+
+            assertThat("switch stays unchecked", allowTemplatesToRecordAudioSwitch.isChecked, equalTo(false))
+            assertThat("no opt-in is persisted", prefs.allowTemplatesToRecordAudio, equalTo(false))
+        }
+    }
+
+    @Test
+    fun `'allow templates to record audio' switch applies the opt-in once the permission is granted`() {
+        prefs.allowTemplatesToRecordAudio = false
+
+        withAdvancedSettings {
+            allowTemplatesToRecordAudioSwitch.performClick()
+
+            grantRecordAudioPermission()
+            val request = shadowOf(requireActivity()).lastRequestedPermission
+            requireActivity().onRequestPermissionsResult(
+                request.requestCode,
+                request.requestedPermissions,
+                intArrayOf(PackageManager.PERMISSION_GRANTED),
+            )
+
+            assertThat("switch is checked once the permission is granted", allowTemplatesToRecordAudioSwitch.isChecked, equalTo(true))
+            assertThat("the opt-in is persisted", prefs.allowTemplatesToRecordAudio, equalTo(true))
         }
     }
 


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

## Purpose / Description
A couple more issues with `allowTemplatesToRecordAudio`:

* it requested audio permissions if it was unchecked
* if the app was closed before the permissions dialog, approval stayed


## Approach
* don't request permissions on uncheck
* approve after the permissions dialog

## How Has This Been Tested?
Unit tests

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)