### PR TITLE
fix(strings): sentence-case the export type options

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
@@ -166,10 +166,10 @@ class ExportDialogFragment : AnalyticsDialogFragment() {
                         requireActivity(),
                         android.R.layout.simple_spinner_item,
                         listOf(
-                            "${exportingAnkiCollectionPackage()} (.colpkg)",
-                            "${exportingAnkiDeckPackage()} (.apkg)",
-                            "${exportingNotesInPlainText()} (.txt)",
-                            "${exportingCardsInPlainText()} (.txt)",
+                            "${TR.sentenceCase.ankiCollectionPackage} (.colpkg)",
+                            "${TR.sentenceCase.ankiDeckPackage} (.apkg)",
+                            "${TR.sentenceCase.notesInPlainText} (.txt)",
+                            "${TR.sentenceCase.cardsInPlainText} (.txt)",
                         ),
                     ).apply { setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item) }
                 adapter = exportTypesAdapter

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
@@ -242,6 +242,18 @@ object SentenceCase {
     val allDecks get() = TR.exportingAllDecks().toSentenceCase(R.string.sentence_all_decks)
 
     context(_: Fragment)
+    val ankiCollectionPackage get() = TR.exportingAnkiCollectionPackage().toSentenceCase(R.string.sentence_anki_collection_package)
+
+    context(_: Fragment)
+    val ankiDeckPackage get() = TR.exportingAnkiDeckPackage().toSentenceCase(R.string.sentence_anki_deck_package)
+
+    context(_: Fragment)
+    val notesInPlainText get() = TR.exportingNotesInPlainText().toSentenceCase(R.string.sentence_notes_in_plain_text)
+
+    context(_: Fragment)
+    val cardsInPlainText get() = TR.exportingCardsInPlainText().toSentenceCase(R.string.sentence_cards_in_plain_text)
+
+    context(_: Fragment)
     val browserOptions get() = TR.browsingBrowserOptions().toSentenceCase(R.string.sentence_browser_options)
 
     context(_: Fragment)

--- a/AnkiDroid/src/main/res/values/sentence-case.xml
+++ b/AnkiDroid/src/main/res/values/sentence-case.xml
@@ -92,4 +92,8 @@ undoActionUndone()
     <string name="sentence_answer_hard" maxLength="41">Answer hard</string>
     <string name="sentence_answer_good" maxLength="41">Answer good</string>
     <string name="sentence_copy_to_clipboard">Copy to clipboard</string>
+    <string name="sentence_anki_collection_package">Anki collection package</string>
+    <string name="sentence_anki_deck_package">Anki deck package</string>
+    <string name="sentence_notes_in_plain_text">Notes in plain text</string>
+    <string name="sentence_cards_in_plain_text">Cards in plain text</string>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/export/ExportDialogFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/export/ExportDialogFragmentTest.kt
@@ -27,6 +27,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.not
 import org.junit.Test
@@ -39,7 +40,7 @@ class ExportDialogFragmentTest : RobolectricTest() {
         onExportDialog {
             // Select export type as anki collection package.
             onView(withId(R.id.export_type_selector)).inRoot(isDialog()).perform(click())
-            onData(containsString(TR.exportingAnkiCollectionPackage()))
+            onData(containsString(TR.sentenceCase.ankiCollectionPackage))
                 .inAdapterView(withId(R.id.export_type_selector))
                 .perform(click())
 
@@ -63,7 +64,7 @@ class ExportDialogFragmentTest : RobolectricTest() {
         onExportDialog {
             // Select export type as anki deck package.
             onView(withId(R.id.export_type_selector)).inRoot(isDialog()).perform(click())
-            onData(containsString(TR.exportingAnkiDeckPackage()))
+            onData(containsString(TR.sentenceCase.ankiDeckPackage))
                 .inAdapterView(withId(R.id.export_type_selector))
                 .perform(click())
 
@@ -99,7 +100,7 @@ class ExportDialogFragmentTest : RobolectricTest() {
         onExportDialog {
             // check legacy checkboxes status for collection export
             onView(withId(R.id.export_type_selector)).inRoot(isDialog()).perform(click())
-            onData(containsString(TR.exportingAnkiCollectionPackage()))
+            onData(containsString(TR.sentenceCase.ankiCollectionPackage))
                 .inAdapterView(withId(R.id.export_type_selector))
                 .perform(click())
             onView(withId(R.id.collection_export_legacy))
@@ -114,7 +115,7 @@ class ExportDialogFragmentTest : RobolectricTest() {
 
             // check legacy checkboxes status for apkg export
             onView(withId(R.id.export_type_selector)).inRoot(isDialog()).perform(click())
-            onData(containsString(TR.exportingAnkiDeckPackage()))
+            onData(containsString(TR.sentenceCase.ankiDeckPackage))
                 .inAdapterView(withId(R.id.export_type_selector))
                 .perform(click())
             onView(withId(R.id.apkg_export_legacy))
@@ -129,7 +130,7 @@ class ExportDialogFragmentTest : RobolectricTest() {
 
             // checkboxes are not shown for notes export
             onView(withId(R.id.export_type_selector)).inRoot(isDialog()).perform(click())
-            onData(containsString(TR.exportingNotesInPlainText()))
+            onData(containsString(TR.sentenceCase.notesInPlainText))
                 .inAdapterView(withId(R.id.export_type_selector))
                 .perform(click())
             onView(withId(R.id.apkg_export_legacy))
@@ -141,7 +142,7 @@ class ExportDialogFragmentTest : RobolectricTest() {
 
             // checkboxes are not shown for cards export
             onView(withId(R.id.export_type_selector)).inRoot(isDialog()).perform(click())
-            onData(containsString(TR.exportingCardsInPlainText()))
+            onData(containsString(TR.sentenceCase.cardsInPlainText))
                 .inAdapterView(withId(R.id.export_type_selector))
                 .perform(click())
             onView(withId(R.id.apkg_export_legacy))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
@@ -52,6 +52,10 @@ class SentenceCaseTest : RobolectricTest() {
                     assertThat(TR.sentenceCase.allFields, equalTo("All fields"))
                     assertThat(TR.sentenceCase.tagMissing, equalTo("Tag missing"))
                     assertThat(TR.sentenceCase.checkMediaDeleteUnused, equalTo("Delete unused"))
+                    assertThat(TR.sentenceCase.ankiCollectionPackage, equalTo("Anki collection package"))
+                    assertThat(TR.sentenceCase.ankiDeckPackage, equalTo("Anki deck package"))
+                    assertThat(TR.sentenceCase.notesInPlainText, equalTo("Notes in plain text"))
+                    assertThat(TR.sentenceCase.cardsInPlainText, equalTo("Cards in plain text"))
 
                     // input-taking accessors: a Title Case input only maps to the sentence form
                     // if the correct sentence-case resource is wired


### PR DESCRIPTION
## Summary
- Converts the export type dropdown options to sentence case: "Anki Collection Package" -> "Anki collection package", "Anki Deck Package" -> "Anki deck package", "Notes in Plain Text" -> "Notes in plain text", "Cards in Plain Text" -> "Cards in plain text"
- Adds the corresponding `TR.sentenceCase` properties, following the same pattern already used for `allDecks` in the same dropdown

Part of the "Export" section in #15760 (one PR per feature, as requested).

## Test plan
- [x] Updated `ExportDialogFragmentTest` to select by the new sentence-case text; confirmed it failed against the old Title Case strings before the fix, and passes after
- [x] Added pinning assertions for the new properties in `SentenceCaseTest`
- [x] `./gradlew :AnkiDroid:testPlayDebugUnitTest --tests "com.ichi2.anki.export.ExportDialogFragmentTest" --tests "com.ichi2.anki.ui.internationalization.SentenceCaseTest"` passes