### PR TITLE
Fix plaintext export crash on slash in deck names

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
@@ -287,11 +287,13 @@ class ExportDialogFragment : AnalyticsDialogFragment() {
 
     private fun handleNotesInPlainTextExport() {
         val exportLimit = buildExportLimit()
+        val packagePrefix = getNonCollectionNamePrefix().replace("/", "_")
         val exportPath =
-            File(
-                getExportRootFile(),
-                "${getNonCollectionNamePrefix()}-${getTimestamp(TimeManager.time)}.txt",
-            ).path
+        File(
+        getExportRootFile(),
+        "${packagePrefix}-${getTimestamp(TimeManager.time)}.txt",
+        ).path
+
         requireAnkiActivity().exportSelectedNotes(
             exportPath = exportPath,
             withHtml = binding.notesIncludeHtml.isChecked,
@@ -305,11 +307,13 @@ class ExportDialogFragment : AnalyticsDialogFragment() {
 
     private fun handleCardsInPlainTextExport() {
         val exportLimit = buildExportLimit()
+        val packagePrefix = getNonCollectionNamePrefix().replace("/", "_")
         val exportPath =
-            File(
-                getExportRootFile(),
-                "${getNonCollectionNamePrefix()}-${getTimestamp(TimeManager.time)}.txt",
-            ).path
+        File(
+        getExportRootFile(),
+        "${packagePrefix}-${getTimestamp(TimeManager.time)}.txt",
+        ).path
+
         requireAnkiActivity().exportSelectedCards(
             exportPath = exportPath,
             withHtml = binding.cardsIncludeHtml.isChecked,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
@@ -284,6 +284,7 @@ class ExportDialogFragment : AnalyticsDialogFragment() {
             // notes/cards weren't selected so export the chosen deck(s)
             null -> (binding.deckSelector.adapter as DeckDisplayAdapter).getItem(binding.deckSelector.selectedItemPosition).name
         }
+
     private fun handleNotesInPlainTextExport() {
         val exportLimit = buildExportLimit()
         val packagePrefix = getNonCollectionNamePrefix().replace("/", "_")
@@ -302,7 +303,7 @@ class ExportDialogFragment : AnalyticsDialogFragment() {
             limit = exportLimit,
         )
     }
-    
+
     private fun handleCardsInPlainTextExport() {
         val exportLimit = buildExportLimit(
         val packagePrefix = getNonCollectionNamePrefix().replace("/", "_")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
@@ -284,14 +284,13 @@ class ExportDialogFragment : AnalyticsDialogFragment() {
             // notes/cards weren't selected so export the chosen deck(s)
             null -> (binding.deckSelector.adapter as DeckDisplayAdapter).getItem(binding.deckSelector.selectedItemPosition).name
         }
-
     private fun handleNotesInPlainTextExport() {
         val exportLimit = buildExportLimit()
         val packagePrefix = getNonCollectionNamePrefix().replace("/", "_")
         val exportPath =
             File(
                 getExportRootFile(),
-                "${packagePrefix}-${getTimestamp(TimeManager.time)}.txt"
+                "$packagePrefix-${getTimestamp(TimeManager.time)}.txt",
             ).path
         requireAnkiActivity().exportSelectedNotes(
             exportPath = exportPath,
@@ -303,14 +302,14 @@ class ExportDialogFragment : AnalyticsDialogFragment() {
             limit = exportLimit,
         )
     }
-
+    
     private fun handleCardsInPlainTextExport() {
-        val exportLimit = buildExportLimit()
+        val exportLimit = buildExportLimit(
         val packagePrefix = getNonCollectionNamePrefix().replace("/", "_")
         val exportPath =
             File(
                 getExportRootFile(),
-                "${packagePrefix}-${getTimestamp(TimeManager.time)}.txt"
+                "$packagePrefix-${getTimestamp(TimeManager.time)}.txt",
             ).path
         requireAnkiActivity().exportSelectedCards(
             exportPath = exportPath,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
@@ -291,7 +291,7 @@ class ExportDialogFragment : AnalyticsDialogFragment() {
         val exportPath =
             File(
                 getExportRootFile(),
-                "${packagePrefix}-${getTimestamp(TimeManager.time)}.txt",
+                "${packagePrefix}-${getTimestamp(TimeManager.time)}.txt"
             ).path
         requireAnkiActivity().exportSelectedNotes(
             exportPath = exportPath,
@@ -310,7 +310,7 @@ class ExportDialogFragment : AnalyticsDialogFragment() {
         val exportPath =
             File(
                 getExportRootFile(),
-                "${packagePrefix}-${getTimestamp(TimeManager.time)}.txt",
+                "${packagePrefix}-${getTimestamp(TimeManager.time)}.txt"
             ).path
         requireAnkiActivity().exportSelectedCards(
             exportPath = exportPath,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
@@ -289,11 +289,10 @@ class ExportDialogFragment : AnalyticsDialogFragment() {
         val exportLimit = buildExportLimit()
         val packagePrefix = getNonCollectionNamePrefix().replace("/", "_")
         val exportPath =
-        File(
-        getExportRootFile(),
-        "${packagePrefix}-${getTimestamp(TimeManager.time)}.txt",
-        ).path
-
+            File(
+                getExportRootFile(),
+                "${packagePrefix}-${getTimestamp(TimeManager.time)}.txt",
+            ).path
         requireAnkiActivity().exportSelectedNotes(
             exportPath = exportPath,
             withHtml = binding.notesIncludeHtml.isChecked,
@@ -309,11 +308,10 @@ class ExportDialogFragment : AnalyticsDialogFragment() {
         val exportLimit = buildExportLimit()
         val packagePrefix = getNonCollectionNamePrefix().replace("/", "_")
         val exportPath =
-        File(
-        getExportRootFile(),
-        "${packagePrefix}-${getTimestamp(TimeManager.time)}.txt",
-        ).path
-
+            File(
+                getExportRootFile(),
+                "${packagePrefix}-${getTimestamp(TimeManager.time)}.txt",
+            ).path
         requireAnkiActivity().exportSelectedCards(
             exportPath = exportPath,
             withHtml = binding.cardsIncludeHtml.isChecked,


### PR DESCRIPTION
## Purpose / Description
Fixes an `IOException` crash when exporting notes or cards in plain text if the source deck or prefix contains slashes (`/`) representing subdecks as the relevant issue stated.

## Fixes
* Fixes Issue #21591

## Approach
Replaced direct calls to `getNonCollectionNamePrefix()` with a sanitized `packagePrefix` variable that replaces forward slashes (`/`) with underscores (`_`) in `handleNotesInPlainTextExport` and `handleCardsInPlainTextExport`.

## How Has This Been Tested?
Code only change modeled directly after the working logic already present for `.apkg` exports in `handleAnkiPackageExport` here.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
