### PR TITLE
refactor(note-editor): [PART 1] convert to destination

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorIntentTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorIntentTest.kt
@@ -21,7 +21,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.NoteEditorFragment.Companion.intentLaunchedWithImage
-import com.ichi2.anki.noteeditor.NoteEditorLauncher
+import com.ichi2.anki.common.destinations.NoteEditorDestination
+import com.ichi2.anki.common.destinations.toIntent
 import com.ichi2.anki.tests.InstrumentedTest
 import com.ichi2.anki.testutil.GrantStoragePermission
 import com.ichi2.anki.testutil.getNoteEditorFragment
@@ -75,6 +76,6 @@ class NoteEditorIntentTest : InstrumentedTest() {
     private val noteEditorTextIntent: Intent
         get() {
             val bundle = Bundle().apply { putString(Intent.EXTRA_TEXT, "sample text") }
-            return NoteEditorLauncher.PassArguments(bundle).toIntent(testContext, Intent.ACTION_SEND)
+            return NoteEditorDestination.PassArguments(bundle, action = Intent.ACTION_SEND).toIntent()
         }
 }

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorTest.kt
@@ -15,12 +15,12 @@
  */
 package com.ichi2.anki
 
-import android.content.Context
 import android.content.Intent
 import android.os.Build
 import androidx.test.ext.junit.rules.ActivityScenarioRule
-import androidx.test.platform.app.InstrumentationRegistry
-import com.ichi2.anki.noteeditor.NoteEditorLauncher
+import com.ichi2.anki.common.destinations.NoteEditorDestination
+import com.ichi2.anki.common.destinations.toIntent
+import com.ichi2.anki.tests.InstrumentedTest
 import com.ichi2.anki.testutil.GrantStoragePermission
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.not
@@ -29,7 +29,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.rules.TestRule
 
-abstract class NoteEditorTest protected constructor() {
+abstract class NoteEditorTest protected constructor() : InstrumentedTest() {
     /*
      * Rules mean that we get a failure on API 25.
      * Even if we ignore the tests, the rules cause a failure.
@@ -51,9 +51,7 @@ abstract class NoteEditorTest protected constructor() {
         ).takeUnless { isInvalid }
 
     private val noteEditorIntent: Intent
-        get() {
-            return NoteEditorLauncher.AddNote().toIntent(targetContext)
-        }
+        get() = NoteEditorDestination.AddNote().toIntent()
 
     @Before
     fun before() {
@@ -77,6 +75,4 @@ abstract class NoteEditorTest protected constructor() {
 
     protected open val invalidSdks: List<Int>
         get() = ArrayList()
-    protected val targetContext: Context
-        get() = InstrumentationRegistry.getInstrumentation().targetContext
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -18,6 +18,7 @@ import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.destinations.BrowserDestination
 import com.ichi2.anki.common.destinations.NoteEditorDestination
+import com.ichi2.anki.common.destinations.addNextIntent
 import com.ichi2.anki.common.destinations.navigate
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.storage.CollectionHelper
@@ -30,7 +31,6 @@ import com.ichi2.anki.dialogs.DialogHandlerMessage
 import com.ichi2.anki.dialogs.requireDeckPickerOrShowError
 import com.ichi2.anki.exception.SystemStorageException
 import com.ichi2.anki.libanki.DeckId
-import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ui.windows.reviewer.ReviewerFragment
 import com.ichi2.anki.utils.MimeTypeUtils
@@ -275,12 +275,10 @@ class IntentHandler : AbstractIntentHandler() {
                 data.data
             }
 
-        val intentImageOcclusion = NoteEditorLauncher.ImageOcclusion(imageUri).toIntent(this)
-
         TaskStackBuilder
             .create(this)
             .addNextIntentWithParentStack(Intent(this, DeckPicker::class.java))
-            .addNextIntent(intentImageOcclusion)
+            .addNextIntent(NoteEditorDestination.ImageOcclusion(imageUri))
             .startActivities()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -17,8 +17,10 @@ import androidx.work.WorkManager
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.destinations.BrowserDestination
+import com.ichi2.anki.common.destinations.DeferredNavigation
 import com.ichi2.anki.common.destinations.NoteEditorDestination
 import com.ichi2.anki.common.destinations.navigate
+import com.ichi2.anki.common.destinations.toIntent
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.common.storage.StorageDecision
@@ -291,7 +293,7 @@ class IntentHandler : AbstractIntentHandler() {
             navigate(NoteEditorDestination.PassArguments.from(data, dataExtras))
         } else {
             // Fallback if no extras, though this shouldn't happen for ACTION_SEND
-            val noteEditorIntent = NoteEditorLauncher.AddNote().toIntent(this)
+            val noteEditorIntent = with(DeferredNavigation) { NoteEditorDestination.AddNote().toIntent() }
             noteEditorIntent.setDataAndType(data.data, data.type)
             startActivity(noteEditorIntent)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -17,10 +17,8 @@ import androidx.work.WorkManager
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.destinations.BrowserDestination
-import com.ichi2.anki.common.destinations.DeferredNavigation
 import com.ichi2.anki.common.destinations.NoteEditorDestination
 import com.ichi2.anki.common.destinations.navigate
-import com.ichi2.anki.common.destinations.toIntent
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.common.storage.StorageDecision
@@ -288,15 +286,12 @@ class IntentHandler : AbstractIntentHandler() {
 
     private fun handleSharedText(data: Intent) {
         Timber.i("Handling shared text content for note creation")
-        val dataExtras = data.extras
-        if (dataExtras != null) {
-            navigate(NoteEditorDestination.PassArguments.from(data, dataExtras))
-        } else {
-            // Fallback if no extras, though this shouldn't happen for ACTION_SEND
-            val noteEditorIntent = with(DeferredNavigation) { NoteEditorDestination.AddNote().toIntent() }
-            noteEditorIntent.setDataAndType(data.data, data.type)
-            startActivity(noteEditorIntent)
-        }
+        val destination =
+            data.extras
+                ?.let { NoteEditorDestination.PassArguments.from(data, it) }
+                // Fallback if no extras, though this shouldn't happen for ACTION_SEND
+                ?: NoteEditorDestination.AddNote()
+        navigate(destination)
     }
 
     private fun deleteDownloadedDeck(sharedDeckUri: Uri?) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -17,6 +17,7 @@ import androidx.work.WorkManager
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.destinations.BrowserDestination
+import com.ichi2.anki.common.destinations.NoteEditorDestination
 import com.ichi2.anki.common.destinations.navigate
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.storage.CollectionHelper
@@ -285,15 +286,15 @@ class IntentHandler : AbstractIntentHandler() {
 
     private fun handleSharedText(data: Intent) {
         Timber.i("Handling shared text content for note creation")
-        val noteEditorIntent =
-            if (data.extras != null) {
-                NoteEditorLauncher.PassArguments(data.extras!!).toIntent(this, data.action)
-            } else {
-                // Fallback if no extras, though this shouldn't happen for ACTION_SEND
-                NoteEditorLauncher.AddNote().toIntent(this)
-            }
-        noteEditorIntent.setDataAndType(data.data, data.type)
-        startActivity(noteEditorIntent)
+        val dataExtras = data.extras
+        if (dataExtras != null) {
+            navigate(NoteEditorDestination.PassArguments.from(data, dataExtras))
+        } else {
+            // Fallback if no extras, though this shouldn't happen for ACTION_SEND
+            val noteEditorIntent = NoteEditorLauncher.AddNote().toIntent(this)
+            noteEditorIntent.setDataAndType(data.data, data.type)
+            startActivity(noteEditorIntent)
+        }
     }
 
     private fun deleteDownloadedDeck(sharedDeckUri: Uri?) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler2.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler2.kt
@@ -18,6 +18,8 @@ package com.ichi2.anki
 
 import android.os.Bundle
 import com.ichi2.anki.NoteEditorFragment.Companion.NoteEditorCaller
+import com.ichi2.anki.common.destinations.NoteEditorDestination
+import com.ichi2.anki.common.destinations.navigate
 import com.ichi2.anki.common.utils.android.showThemedToast
 import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import timber.log.Timber
@@ -37,17 +39,15 @@ class IntentHandler2 : AbstractIntentHandler() {
             Timber.i("Intent contained an image")
             intent.putExtra(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.ADD_IMAGE.value)
         }
-        if (intent.extras == null) {
+        val intentExtras = intent.extras
+        if (intentExtras == null) {
             Timber.w("Intent unexpectedly has no extras. Notifying user, defaulting to add note.")
             showThemedToast(this, getString(R.string.something_wrong), false)
             startActivity(NoteEditorLauncher.AddNote().toIntent(this))
             finish()
         } else {
             Timber.i("Opening Note Editor from intent")
-            val noteEditorIntent =
-                NoteEditorLauncher.PassArguments(intent.extras!!).toIntent(this, intent.action)
-            noteEditorIntent.setDataAndType(intent.data, intent.type)
-            startActivity(noteEditorIntent)
+            navigate(NoteEditorDestination.PassArguments.from(intent, intentExtras))
             finish()
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler2.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler2.kt
@@ -21,7 +21,6 @@ import com.ichi2.anki.NoteEditorFragment.Companion.NoteEditorCaller
 import com.ichi2.anki.common.destinations.NoteEditorDestination
 import com.ichi2.anki.common.destinations.navigate
 import com.ichi2.anki.common.utils.android.showThemedToast
-import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import timber.log.Timber
 
 /**
@@ -43,7 +42,7 @@ class IntentHandler2 : AbstractIntentHandler() {
         if (intentExtras == null) {
             Timber.w("Intent unexpectedly has no extras. Notifying user, defaulting to add note.")
             showThemedToast(this, getString(R.string.something_wrong), false)
-            startActivity(NoteEditorLauncher.AddNote().toIntent(this))
+            navigate(NoteEditorDestination.AddNote())
             finish()
         } else {
             Timber.i("Opening Note Editor from intent")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -79,6 +79,8 @@ import com.ichi2.anki.common.android.animationEnabled
 import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.crashreporting.CrashReportService
+import com.ichi2.anki.common.destinations.NoteEditorDestination
+import com.ichi2.anki.common.destinations.navigate
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.ui.TransitionDirection
 import com.ichi2.anki.common.utils.HashUtil
@@ -1537,7 +1539,7 @@ class NoteEditorFragment :
         }
 
     private fun addNewNote() {
-        launchNoteEditor(NoteEditorLauncher.AddNote(deckId))
+        requestAddLauncher.navigate(NoteEditorDestination.AddNote(deckId))
     }
 
     fun copyNote() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -1543,11 +1543,7 @@ class NoteEditorFragment :
     }
 
     fun copyNote() {
-        launchNoteEditor(NoteEditorLauncher.CopyNote(deckId, fieldsText, selectedTags))
-    }
-
-    private fun launchNoteEditor(arguments: NoteEditorLauncher) {
-        requestAddLauncher.launch(arguments.toIntent(requireContext()))
+        requestAddLauncher.navigate(NoteEditorDestination.CopyNote(deckId, fieldsText, selectedTags))
     }
 
     // ----------------------------------------------------------------------------

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -58,6 +58,8 @@ import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.destinations.CardInfoDestination
 import com.ichi2.anki.common.destinations.CardInfoDestination.EntryPoint
+import com.ichi2.anki.common.destinations.NoteEditorDestination
+import com.ichi2.anki.common.destinations.navigate
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.utils.android.HandlerUtils.executeFunctionWithDelay
@@ -80,7 +82,6 @@ import com.ichi2.anki.multimedia.audio.AudioRecordingController.Companion.isReco
 import com.ichi2.anki.multimedia.audio.AudioRecordingController.Companion.setEditorStatus
 import com.ichi2.anki.multimedia.audio.AudioRecordingController.Companion.tempAudioPath
 import com.ichi2.anki.multimedia.audio.AudioRecordingController.RecordingState
-import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.pages.PostRequestUri
 import com.ichi2.anki.pages.toIntent
@@ -787,11 +788,9 @@ open class Reviewer :
     }
 
     fun addNote(fromGesture: Gesture? = null) {
-        val animation = getAnimationTransitionFromGesture(fromGesture)
-        val inverseAnimation = animation.invert()
+        val inverseAnimation = getAnimationTransitionFromGesture(fromGesture).invert()
         Timber.i("launching 'add note'")
-        val intent = NoteEditorLauncher.AddNoteFromReviewer(inverseAnimation).toIntent(this)
-        addNoteLauncher.launch(intent)
+        addNoteLauncher.navigate(NoteEditorDestination.AddNoteFromReviewer(inverseAnimation))
     }
 
     @NeedsTest("Starting animation from swipe is inverse to the finishing one")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -23,6 +23,7 @@ import com.ichi2.anki.OnErrorListener
 import com.ichi2.anki.PermissionSet
 import com.ichi2.anki.common.destinations.BrowserDestination
 import com.ichi2.anki.common.destinations.DeckOptionsDestination
+import com.ichi2.anki.common.destinations.NoteEditorDestination
 import com.ichi2.anki.configureRenderingMode
 import com.ichi2.anki.launchCatchingIO
 import com.ichi2.anki.libanki.CardId
@@ -34,7 +35,6 @@ import com.ichi2.anki.libanki.sched.DeckNode
 import com.ichi2.anki.libanki.undoAvailable
 import com.ichi2.anki.libanki.undoLabel
 import com.ichi2.anki.libanki.utils.extend
-import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.notetype.ManageNoteTypesDestination
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.performBackupInBackground
@@ -289,7 +289,7 @@ class DeckPickerViewModel :
         if (deckId != null && setAsCurrent) {
             withCol { decks.select(deckId) }
         }
-        flowOfDestination.emit(NoteEditorLauncher.AddNote(deckId))
+        flowOfNavigate.emit(NoteEditorDestination.AddNote(deckId))
     }
 
     val flowOfShowContextMenu = MutableSharedFlow<DeckId>(extraBufferCapacity = 1)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
@@ -43,6 +43,8 @@ import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.CustomActionModeCallback
 import com.ichi2.anki.R
+import com.ichi2.anki.common.destinations.NoteEditorDestination
+import com.ichi2.anki.common.destinations.navigate
 import com.ichi2.anki.common.utils.android.showThemedToast
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.databinding.ActivityInstantNoteEditorBinding
@@ -54,7 +56,6 @@ import com.ichi2.anki.dialogs.startDeckSelection
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.NotetypeJson
 import com.ichi2.anki.model.SelectableDeck
-import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.servicelayer.NoteService
 import com.ichi2.anki.startup.ensureStorageIsReady
 import com.ichi2.anki.withProgress
@@ -191,8 +192,7 @@ class InstantNoteEditorActivity : AnkiActivity(R.layout.activity_instant_note_ed
 
     private fun openNoteEditor() {
         val sharedText = clozeEditTextField.text.toString()
-        val noteEditorIntent = NoteEditorLauncher.AddInstantNote(sharedText).toIntent(this)
-        startActivity(noteEditorIntent)
+        navigate(NoteEditorDestination.AddInstantNote(sharedText))
         finish()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/navigation/AnkiDroidNavigator.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/navigation/AnkiDroidNavigator.kt
@@ -12,10 +12,12 @@ import com.ichi2.anki.common.destinations.CsvImporterDestination
 import com.ichi2.anki.common.destinations.DeckOptionsDestination
 import com.ichi2.anki.common.destinations.Destination
 import com.ichi2.anki.common.destinations.Navigator
+import com.ichi2.anki.common.destinations.NoteEditorDestination
 import com.ichi2.anki.common.destinations.PreferencesDestination
 import com.ichi2.anki.common.destinations.ReviewDeckDestination
 import com.ichi2.anki.common.destinations.StatisticsDestination
 import com.ichi2.anki.common.destinations.StudyOptionsDestination
+import com.ichi2.anki.noteeditor.toIntent
 import com.ichi2.anki.pages.toIntent
 import com.ichi2.anki.preferences.toIntent
 import com.ichi2.anki.toIntent
@@ -32,6 +34,7 @@ object AnkiDroidNavigator : Navigator {
         when (destination) {
             is BrowserDestination -> destination.toIntent(navContext)
             is CardInfoDestination -> destination.toIntent(navContext)
+            is NoteEditorDestination -> destination.toIntent(navContext)
             is CsvImporterDestination -> destination.toIntent(navContext)
             is DeckOptionsDestination -> destination.toIntent(navContext)
             is ChangelogDestination -> destination.toIntent(navContext)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
@@ -101,26 +101,6 @@ sealed interface NoteEditorLauncher : Destination {
                 putBoolean(NoteEditorFragment.IN_CARD_BROWSER_ACTIVITY, inCardBrowserActivity)
             }
     }
-
-    /**
-     * Represents copying a note to the NoteEditor.
-     * @property deckId The ID of the deck where the note should be copied.
-     * @property fieldsText The text content of the fields to copy.
-     * @property tags Optional list of tags to assign to the copied note.
-     */
-    data class CopyNote(
-        val deckId: DeckId,
-        val fieldsText: String,
-        val tags: List<String>? = null,
-    ) : NoteEditorLauncher {
-        override fun toBundle(): Bundle =
-            Bundle().apply {
-                putInt(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.NOTEEDITOR.value)
-                putLong(NoteEditorFragment.EXTRA_DID, deckId)
-                putString(NoteEditorFragment.EXTRA_CONTENTS, fieldsText)
-                tags?.let { tags -> putStringArray(NoteEditorFragment.EXTRA_TAGS, tags.toTypedArray()) }
-            }
-    }
 }
 
 fun NoteEditorDestination.toIntent(context: Context): Intent =
@@ -144,6 +124,13 @@ fun NoteEditorDestination.toIntent(context: Context): Intent =
             Intent(context, NoteEditorActivity::class.java).also { intent ->
                 intent.putExtra(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.PREVIEWER_EDIT.value)
                 intent.putExtra(NoteEditorFragment.EXTRA_EDIT_FROM_CARD_ID, cardId)
+            }
+        is NoteEditorDestination.CopyNote ->
+            Intent(context, NoteEditorActivity::class.java).also { intent ->
+                intent.putExtra(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.NOTEEDITOR.value)
+                intent.putExtra(NoteEditorFragment.EXTRA_DID, deckId)
+                intent.putExtra(NoteEditorFragment.EXTRA_CONTENTS, fieldsText)
+                tags?.let { intent.putExtra(NoteEditorFragment.EXTRA_TAGS, it.toTypedArray()) }
             }
         is NoteEditorDestination.PassArguments ->
             Intent(context, NoteEditorActivity::class.java).also { intent ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
@@ -66,20 +66,6 @@ sealed interface NoteEditorLauncher : Destination {
     }
 
     /**
-     * Represents adding a note to the NoteEditor from the reviewer.
-     * @property animation The animation direction to use when transitioning.
-     */
-    data class AddNoteFromReviewer(
-        val animation: TransitionDirection? = null,
-    ) : NoteEditorLauncher {
-        override fun toBundle(): Bundle =
-            Bundle().apply {
-                putInt(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.REVIEWER_ADD.value)
-                animation?.let { putParcelable(AnkiActivity.EXTRA_FINISH_ANIMATION, it as Parcelable) }
-            }
-    }
-
-    /**
      * Opens the NoteEditor for the current selection (card or note).
      * @property cardIds The selected card ID when editing a card, or the IDs of cards of the same note when editing a note.
      * @property animation The animation direction.
@@ -124,6 +110,11 @@ fun NoteEditorDestination.toIntent(context: Context): Intent =
             Intent(context, NoteEditorActivity::class.java).also { intent ->
                 intent.putExtra(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.PREVIEWER_EDIT.value)
                 intent.putExtra(NoteEditorFragment.EXTRA_EDIT_FROM_CARD_ID, cardId)
+            }
+        is NoteEditorDestination.AddNoteFromReviewer ->
+            Intent(context, NoteEditorActivity::class.java).also { intent ->
+                intent.putExtra(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.REVIEWER_ADD.value)
+                animation?.let { intent.putExtra(AnkiActivity.EXTRA_FINISH_ANIMATION, it as Parcelable) }
             }
         is NoteEditorDestination.CopyNote ->
             Intent(context, NoteEditorActivity::class.java).also { intent ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
@@ -12,6 +12,7 @@ import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.NoteEditorActivity
 import com.ichi2.anki.NoteEditorFragment
 import com.ichi2.anki.NoteEditorFragment.Companion.NoteEditorCaller
+import com.ichi2.anki.common.destinations.NoteEditorDestination
 import com.ichi2.anki.common.ui.TransitionDirection
 import com.ichi2.anki.libanki.CardId
 import com.ichi2.anki.libanki.DeckId
@@ -57,16 +58,6 @@ sealed interface NoteEditorLauncher : Destination {
                 putInt(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.IMG_OCCLUSION.value)
                 putParcelable(NoteEditorFragment.EXTRA_IMG_OCCLUSION, imageUri)
             }
-    }
-
-    /**
-     * Represents opening the NoteEditor with custom arguments.
-     * @property arguments The bundle of arguments to pass.
-     */
-    data class PassArguments(
-        val arguments: Bundle,
-    ) : NoteEditorLauncher {
-        override fun toBundle(): Bundle = arguments
     }
 
     /**
@@ -189,3 +180,15 @@ sealed interface NoteEditorLauncher : Destination {
             }
     }
 }
+
+fun NoteEditorDestination.toIntent(context: Context): Intent =
+    when (this) {
+        is NoteEditorDestination.PassArguments -> {
+            val destination = this
+            Intent(context, NoteEditorActivity::class.java).apply {
+                putExtras(destination.arguments)
+                destination.action?.let { action = it }
+                setDataAndType(destination.data, destination.type)
+            }
+        }
+    }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
@@ -61,20 +61,6 @@ sealed interface NoteEditorLauncher : Destination {
     }
 
     /**
-     * Represents adding a note to the NoteEditor within a specific deck (Optional).
-     * @property deckId The ID of the deck where the note should be added.
-     */
-    data class AddNote(
-        val deckId: DeckId? = null,
-    ) : NoteEditorLauncher {
-        override fun toBundle(): Bundle =
-            Bundle().apply {
-                putInt(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.DECKPICKER.value)
-                deckId?.let { deckId -> putLong(NoteEditorFragment.EXTRA_DID, deckId) }
-            }
-    }
-
-    /**
      * Represents adding a note to the NoteEditor from the card browser.
      * @property searchTerms The current search terms from the card browser.
      * @property deckId The card browser's last deck, used as the deck for the new note.
@@ -183,6 +169,11 @@ sealed interface NoteEditorLauncher : Destination {
 
 fun NoteEditorDestination.toIntent(context: Context): Intent =
     when (this) {
+        is NoteEditorDestination.AddNote ->
+            Intent(context, NoteEditorActivity::class.java).apply {
+                putExtra(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.DECKPICKER.value)
+                deckId?.let { putExtra(NoteEditorFragment.EXTRA_DID, it) }
+            }
         is NoteEditorDestination.PassArguments -> {
             val destination = this
             Intent(context, NoteEditorActivity::class.java).apply {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
@@ -103,20 +103,6 @@ sealed interface NoteEditorLauncher : Destination {
     }
 
     /**
-     * Represents editing a note in the NoteEditor from the previewer.
-     * @property cardId The ID of the card associated with the note to edit.
-     */
-    data class EditNoteFromPreviewer(
-        val cardId: CardId,
-    ) : NoteEditorLauncher {
-        override fun toBundle(): Bundle =
-            Bundle().apply {
-                putInt(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.PREVIEWER_EDIT.value)
-                putLong(NoteEditorFragment.EXTRA_EDIT_FROM_CARD_ID, cardId)
-            }
-    }
-
-    /**
      * Represents copying a note to the NoteEditor.
      * @property deckId The ID of the deck where the note should be copied.
      * @property fieldsText The text content of the fields to copy.
@@ -153,6 +139,11 @@ fun NoteEditorDestination.toIntent(context: Context): Intent =
             Intent(context, NoteEditorActivity::class.java).also { intent ->
                 intent.putExtra(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.INSTANT_NOTE_EDITOR.value)
                 intent.putExtra(Intent.EXTRA_TEXT, sharedText)
+            }
+        is NoteEditorDestination.EditNoteFromPreviewer ->
+            Intent(context, NoteEditorActivity::class.java).also { intent ->
+                intent.putExtra(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.PREVIEWER_EDIT.value)
+                intent.putExtra(NoteEditorFragment.EXTRA_EDIT_FROM_CARD_ID, cardId)
             }
         is NoteEditorDestination.PassArguments ->
             Intent(context, NoteEditorActivity::class.java).also { intent ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
@@ -80,21 +80,6 @@ sealed interface NoteEditorLauncher : Destination {
     }
 
     /**
-     * Allows to move from Instant note editor to standard note editor while keeping the text content
-     *
-     * @property sharedText The shared text content for the instant note.
-     */
-    data class AddInstantNote(
-        val sharedText: String,
-    ) : NoteEditorLauncher {
-        override fun toBundle(): Bundle =
-            Bundle().apply {
-                putInt(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.INSTANT_NOTE_EDITOR.value)
-                putString(Intent.EXTRA_TEXT, sharedText)
-            }
-    }
-
-    /**
      * Opens the NoteEditor for the current selection (card or note).
      * @property cardIds The selected card ID when editing a card, or the IDs of cards of the same note when editing a note.
      * @property animation The animation direction.
@@ -163,6 +148,11 @@ fun NoteEditorDestination.toIntent(context: Context): Intent =
             Intent(context, NoteEditorActivity::class.java).also { intent ->
                 intent.putExtra(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.IMG_OCCLUSION.value)
                 intent.putExtra(NoteEditorFragment.EXTRA_IMG_OCCLUSION, imageUri)
+            }
+        is NoteEditorDestination.AddInstantNote ->
+            Intent(context, NoteEditorActivity::class.java).also { intent ->
+                intent.putExtra(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.INSTANT_NOTE_EDITOR.value)
+                intent.putExtra(Intent.EXTRA_TEXT, sharedText)
             }
         is NoteEditorDestination.PassArguments ->
             Intent(context, NoteEditorActivity::class.java).also { intent ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
@@ -5,7 +5,6 @@ package com.ichi2.anki.noteeditor
 
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.os.Parcelable
 import com.ichi2.anki.AnkiActivity
@@ -45,20 +44,6 @@ sealed interface NoteEditorLauncher : Destination {
      * @return Bundle containing arguments specific to this configuration.
      */
     fun toBundle(): Bundle
-
-    /**
-     * Represents opening the NoteEditor with an image occlusion.
-     * @property imageUri The URI of the image to occlude.
-     */
-    data class ImageOcclusion(
-        val imageUri: Uri?,
-    ) : NoteEditorLauncher {
-        override fun toBundle(): Bundle =
-            Bundle().apply {
-                putInt(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.IMG_OCCLUSION.value)
-                putParcelable(NoteEditorFragment.EXTRA_IMG_OCCLUSION, imageUri)
-            }
-    }
 
     /**
      * Represents adding a note to the NoteEditor from the card browser.
@@ -173,6 +158,11 @@ fun NoteEditorDestination.toIntent(context: Context): Intent =
             Intent(context, NoteEditorActivity::class.java).apply {
                 putExtra(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.DECKPICKER.value)
                 deckId?.let { putExtra(NoteEditorFragment.EXTRA_DID, it) }
+            }
+        is NoteEditorDestination.ImageOcclusion ->
+            Intent(context, NoteEditorActivity::class.java).also { intent ->
+                intent.putExtra(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.IMG_OCCLUSION.value)
+                intent.putExtra(NoteEditorFragment.EXTRA_IMG_OCCLUSION, imageUri)
             }
         is NoteEditorDestination.PassArguments ->
             Intent(context, NoteEditorActivity::class.java).also { intent ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
@@ -174,12 +174,9 @@ fun NoteEditorDestination.toIntent(context: Context): Intent =
                 putExtra(NoteEditorFragment.EXTRA_CALLER, NoteEditorCaller.DECKPICKER.value)
                 deckId?.let { putExtra(NoteEditorFragment.EXTRA_DID, it) }
             }
-        is NoteEditorDestination.PassArguments -> {
-            val destination = this
-            Intent(context, NoteEditorActivity::class.java).apply {
-                putExtras(destination.arguments)
-                destination.action?.let { action = it }
-                setDataAndType(destination.data, destination.type)
+        is NoteEditorDestination.PassArguments ->
+            Intent(context, NoteEditorActivity::class.java).also { intent ->
+                intent.putExtras(arguments)
+                intent.action = action
             }
-        }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
@@ -37,6 +37,7 @@ import com.ichi2.anki.Flag
 import com.ichi2.anki.R
 import com.ichi2.anki.browser.IdsFile
 import com.ichi2.anki.common.annotations.NeedsTest
+import com.ichi2.anki.common.destinations.navigate
 import com.ichi2.anki.databinding.FragmentPreviewerBinding
 import com.ichi2.anki.previewer.PreviewerFragment.Companion.CARD_IDS_FILE_ARG
 import com.ichi2.anki.reviewer.BindingMap
@@ -271,8 +272,7 @@ class PreviewerFragment :
 
     private fun editCard() {
         lifecycleScope.launch {
-            val intent = viewModel.getNoteEditorDestination().toIntent(requireContext())
-            startActivity(intent)
+            navigate(viewModel.getNoteEditorDestination())
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -24,9 +24,9 @@ import com.ichi2.anki.asyncIO
 import com.ichi2.anki.browser.IdsFile
 import com.ichi2.anki.cardviewer.SingleCardSide
 import com.ichi2.anki.common.annotations.NeedsTest
+import com.ichi2.anki.common.destinations.NoteEditorDestination
 import com.ichi2.anki.launchCatchingIO
 import com.ichi2.anki.libanki.Card
-import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.pages.AnkiServer
@@ -173,7 +173,7 @@ class PreviewerViewModel(
         }
     }
 
-    suspend fun getNoteEditorDestination() = NoteEditorLauncher.EditNoteFromPreviewer(currentCard.await().id)
+    suspend fun getNoteEditorDestination() = NoteEditorDestination.EditNoteFromPreviewer(currentCard.await().id)
 
     fun replayMedia() {
         launchCatchingIO {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -209,10 +209,6 @@ class ReviewerFragment :
             navigate(destination)
         }
 
-        viewModel.destinationFlow.collectIn(lifecycleScope) { destination ->
-            startActivity(destination.toIntent(requireContext()))
-        }
-
         binding.webViewContainer.setFrameStyle()
 
         if (Prefs.showAnswerFeedback) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -22,6 +22,7 @@ import com.ichi2.anki.common.destinations.CardInfoDestination
 import com.ichi2.anki.common.destinations.CardInfoDestination.EntryPoint
 import com.ichi2.anki.common.destinations.DeckOptionsDestination
 import com.ichi2.anki.common.destinations.DeckOptionsEntry
+import com.ichi2.anki.common.destinations.NoteEditorDestination
 import com.ichi2.anki.common.destinations.StatisticsDestination
 import com.ichi2.anki.launchCatchingIO
 import com.ichi2.anki.libanki.Card
@@ -261,9 +262,8 @@ class ReviewerViewModel(
 
     private suspend fun emitEditNoteDestination() {
         val cardId = currentCard.await().id
-        val destination = NoteEditorLauncher.EditNoteFromPreviewer(cardId)
         Timber.i("Opening 'edit note' for card %d", cardId)
-        destinationFlow.emit(destination)
+        navigateFlow.emit(NoteEditorDestination.EditNoteFromPreviewer(cardId))
     }
 
     private suspend fun emitAddNoteDestination() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -54,7 +54,6 @@ import com.ichi2.anki.ui.windows.reviewer.autoadvance.AnswerAction
 import com.ichi2.anki.ui.windows.reviewer.autoadvance.AutoAdvance
 import com.ichi2.anki.ui.windows.reviewer.autoadvance.AutoAdvanceAction
 import com.ichi2.anki.ui.windows.reviewer.autoadvance.QuestionAction
-import com.ichi2.anki.utils.Destination
 import com.ichi2.anki.utils.ext.answerCard
 import com.ichi2.anki.utils.ext.cardStatsNoCardClean
 import com.ichi2.anki.utils.ext.flag
@@ -100,7 +99,6 @@ class ReviewerViewModel(
     val typeAnswerFlow = MutableStateFlow<TypeAnswer?>(null)
     val onTypedAnswerResultFlow = MutableSharedFlow<CompletableDeferred<String>>()
     val onCardUpdatedFlow = MutableSharedFlow<Unit>()
-    val destinationFlow = MutableSharedFlow<Destination>()
     val navigateFlow = MutableSharedFlow<NavigateDestination>()
     val editNoteTagsFlow = MutableSharedFlow<NoteId>()
     val setDueDateFlow = MutableSharedFlow<CardId>()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -33,7 +33,6 @@ import com.ichi2.anki.libanki.NoteId
 import com.ichi2.anki.libanki.redoLabel
 import com.ichi2.anki.libanki.sched.CurrentQueueState
 import com.ichi2.anki.libanki.undoLabel
-import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.pages.AnkiServer
@@ -268,7 +267,7 @@ class ReviewerViewModel(
 
     private suspend fun emitAddNoteDestination() {
         Timber.i("Launching 'add note'")
-        destinationFlow.emit(NoteEditorLauncher.AddNoteFromReviewer())
+        navigateFlow.emit(NoteEditorDestination.AddNoteFromReviewer())
     }
 
     private suspend fun emitCardInfoDestination() {

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AddNoteWidget.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AddNoteWidget.kt
@@ -7,7 +7,9 @@ import android.content.Context
 import android.widget.RemoteViews
 import androidx.core.app.PendingIntentCompat
 import com.ichi2.anki.R
-import com.ichi2.anki.noteeditor.NoteEditorLauncher
+import com.ichi2.anki.common.destinations.DeferredNavigation
+import com.ichi2.anki.common.destinations.NoteEditorDestination
+import com.ichi2.anki.common.destinations.toIntent
 
 class AddNoteWidget : AnalyticsWidgetProvider() {
     override fun performUpdate(
@@ -33,7 +35,7 @@ class AddNoteWidget : AnalyticsWidgetProvider() {
             appWidgetIds: AppWidgetIds,
         ) {
             val remoteViews = RemoteViews(context.packageName, R.layout.widget_add_note)
-            val intent = NoteEditorLauncher.AddNote().toIntent(context)
+            val intent = with(DeferredNavigation) { NoteEditorDestination.AddNote().toIntent() }
             val pendingIntent = PendingIntentCompat.getActivity(context, 0, intent, 0, false)
             remoteViews.setOnClickPendingIntent(R.id.widget_add_note_button, pendingIntent)
             appWidgetManager.updateAppWidget(appWidgetIds, remoteViews)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -811,7 +811,7 @@ class NoteEditorTest : RobolectricTest() {
         ensureCollectionLoadIsSynchronous()
         val bundle =
             when (from) {
-                REVIEWER -> NoteEditorLauncher.AddNoteFromReviewer().toBundle()
+                REVIEWER -> NoteEditorDestination.AddNoteFromReviewer().toIntent().extras!!
                 DECK_LIST -> NoteEditorFragment.addNoteArgs()
             }
         return openNoteEditorWithArgs(bundle)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -23,6 +23,8 @@ import com.ichi2.anki.NoteEditorTest.FromScreen.DECK_LIST
 import com.ichi2.anki.NoteEditorTest.FromScreen.REVIEWER
 import com.ichi2.anki.api.AddContentApi.Companion.DEFAULT_DECK_ID
 import com.ichi2.anki.common.annotations.DuplicatedCode
+import com.ichi2.anki.common.destinations.NoteEditorDestination
+import com.ichi2.anki.common.destinations.toIntent
 import com.ichi2.anki.common.ui.TransitionDirection.DEFAULT
 import com.ichi2.anki.libanki.Consts
 import com.ichi2.anki.libanki.DeckId
@@ -197,7 +199,7 @@ class NoteEditorTest : RobolectricTest() {
     @Test
     fun verifyStartupAndCloseWithNoCollectionDoesNotCrash() {
         enableNullCollection()
-        val intent = NoteEditorLauncher.AddNote().toIntent(targetContext)
+        val intent = NoteEditorDestination.AddNote().toIntent()
         ActivityScenario.launchActivityForResult<NoteEditorActivity>(intent).use { scenario ->
             scenario.onNoteEditor { noteEditor ->
                 noteEditor.requireActivity().onBackPressedDispatcher.onBackPressed()
@@ -210,7 +212,7 @@ class NoteEditorTest : RobolectricTest() {
 
     @Test
     fun testHandleMultimediaActionsDisplaysBottomSheet() {
-        val intent = NoteEditorLauncher.AddNote().toIntent(targetContext)
+        val intent = NoteEditorDestination.AddNote().toIntent()
         ActivityScenario.launchActivityForResult<NoteEditorActivity>(intent).use { scenario ->
             scenario.onNoteEditor { noteEditor ->
                 noteEditor.showMultimediaBottomSheet()
@@ -480,7 +482,7 @@ class NoteEditorTest : RobolectricTest() {
         val activity =
             startActivityNormallyOpenCollectionWithIntent(
                 NoteEditorActivity::class.java,
-                NoteEditorLauncher.AddNote(testDeckId1).toIntent(targetContext),
+                NoteEditorDestination.AddNote(testDeckId1).toIntent(),
             )
         val editor = activity.getNoteEditorFragment()
         val deckNameView = editor.view?.findViewById<TextView>(R.id.note_deck_name)
@@ -810,7 +812,7 @@ class NoteEditorTest : RobolectricTest() {
         val bundle =
             when (from) {
                 REVIEWER -> NoteEditorLauncher.AddNoteFromReviewer().toBundle()
-                DECK_LIST -> NoteEditorLauncher.AddNote().toBundle()
+                DECK_LIST -> NoteEditorFragment.addNoteArgs()
             }
         return openNoteEditorWithArgs(bundle)
     }
@@ -831,7 +833,7 @@ class NoteEditorTest : RobolectricTest() {
         val bundle =
             when (from) {
                 REVIEWER -> NoteEditorLauncher.EditSelection(listOf(n.firstCard().id), DEFAULT).toBundle()
-                DECK_LIST -> NoteEditorLauncher.AddNote().toBundle()
+                DECK_LIST -> NoteEditorFragment.addNoteArgs()
             }
         return openNoteEditorWithArgs(bundle)
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/noteeditor/NoteEditorMultimediaControllerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/noteeditor/NoteEditorMultimediaControllerTest.kt
@@ -59,6 +59,6 @@ class NoteEditorMultimediaControllerTest : RobolectricTest() {
 
     private fun openNoteEditor(): NoteEditorFragment {
         ensureCollectionLoadIsSynchronous()
-        return openNoteEditorWithArgs(NoteEditorLauncher.AddNote().toBundle())
+        return openNoteEditorWithArgs(NoteEditorFragment.addNoteArgs())
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/noteeditor/NoteEditorTestUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/noteeditor/NoteEditorTestUtils.kt
@@ -9,6 +9,7 @@ import com.ichi2.anki.NoteEditorFragment
 import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.common.annotations.DuplicatedCode
+import com.ichi2.anki.common.destinations.NoteEditorDestination
 
 /**
  * Hosts a [NoteEditorActivity] with the given launcher [arguments] and returns the
@@ -22,7 +23,7 @@ fun RobolectricTest.openNoteEditorWithArgs(
     val activity =
         startActivityNormallyOpenCollectionWithIntent(
             NoteEditorActivity::class.java,
-            NoteEditorLauncher.PassArguments(arguments).toIntent(targetContext, action),
+            NoteEditorDestination.PassArguments(arguments, action).toIntent(targetContext),
         )
     return activity.getNoteEditorFragment()
 }

--- a/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/NoteEditorDestination.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/NoteEditorDestination.kt
@@ -5,9 +5,18 @@ package com.ichi2.anki.common.destinations
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import com.ichi2.anki.libanki.DeckId
 
 /** Opens the Add Note/Note Editor screen. */
 sealed class NoteEditorDestination : Destination() {
+    /**
+     * Opens the Note Editor to add a new note.
+     * @property deckId Optional deck to pre-select for the new note.
+     */
+    data class AddNote(
+        val deckId: DeckId? = null,
+    ) : NoteEditorDestination()
+
     /**
      * Forwards an incoming intent's payload to the Note Editor.
      *

--- a/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/NoteEditorDestination.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/NoteEditorDestination.kt
@@ -27,6 +27,15 @@ sealed class NoteEditorDestination : Destination() {
     ) : NoteEditorDestination()
 
     /**
+     * Continues editing in the standard Note Editor from the instant editor,
+     * carrying the in-progress text.
+     * @property sharedText The text to pre-populate.
+     */
+    data class AddInstantNote(
+        val sharedText: String,
+    ) : NoteEditorDestination()
+
+    /**
      * Forwards an incoming intent's payload to the Note Editor.
      *
      * Relays `ACTION_SEND` (or similar) intent to the Note Editor, preserving the

--- a/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/NoteEditorDestination.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/NoteEditorDestination.kt
@@ -3,6 +3,7 @@
 package com.ichi2.anki.common.destinations
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import com.ichi2.anki.libanki.DeckId
 
@@ -14,6 +15,15 @@ sealed class NoteEditorDestination : Destination() {
      */
     data class AddNote(
         val deckId: DeckId? = null,
+    ) : NoteEditorDestination()
+
+    /**
+     * Opens the Note Editor for image occlusion editing.
+     * @property imageUri The image to occlude. May be null if not yet known.
+     */
+    // TODO: `imageUri` should be non-null. Handle in IntentHandler.handleImageImport.
+    data class ImageOcclusion(
+        val imageUri: Uri?,
     ) : NoteEditorDestination()
 
     /**

--- a/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/NoteEditorDestination.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/NoteEditorDestination.kt
@@ -45,6 +45,18 @@ sealed class NoteEditorDestination : Destination() {
     ) : NoteEditorDestination()
 
     /**
+     * Opens the Note Editor pre-populated to copy an existing note into a new one.
+     * @property deckId Target deck for the new note.
+     * @property fieldsText Pre-filled field text (the source note's content).
+     * @property tags Optional tags to apply to the copied note.
+     */
+    data class CopyNote(
+        val deckId: DeckId,
+        val fieldsText: String,
+        val tags: List<String>? = null,
+    ) : NoteEditorDestination()
+
+    /**
      * Forwards an incoming intent's payload to the Note Editor.
      *
      * Relays `ACTION_SEND` (or similar) intent to the Note Editor, preserving the

--- a/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/NoteEditorDestination.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/NoteEditorDestination.kt
@@ -3,7 +3,6 @@
 package com.ichi2.anki.common.destinations
 
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import com.ichi2.anki.libanki.DeckId
 
@@ -21,23 +20,19 @@ sealed class NoteEditorDestination : Destination() {
      * Forwards an incoming intent's payload to the Note Editor.
      *
      * Relays `ACTION_SEND` (or similar) intent to the Note Editor, preserving the
-     * originating intent's [action], [data], and [type] alongside the [arguments] bundle.
+     * originating intent's [action] alongside the [arguments] bundle.
      *
      * @property arguments Extras to forward to the Note Editor.
      * @property action Optional [Intent.setAction] value.
-     * @property data Optional [Intent.setDataAndType] data.
-     * @property type Optional [Intent.setDataAndType] MIME type.
      */
     data class PassArguments(
         val arguments: Bundle,
         val action: String? = null,
-        val data: Uri? = null,
-        val type: String? = null,
     ) : NoteEditorDestination() {
         companion object {
             /**
-             * Snapshots [intent]'s action, data, and type alongside the [extras]
-             * for forwarding to the Note Editor.
+             * Snapshots [intent]'s action alongside the [extras] for forwarding
+             * to the Note Editor.
              */
             fun from(
                 intent: Intent,
@@ -47,8 +42,6 @@ sealed class NoteEditorDestination : Destination() {
                 PassArguments(
                     arguments = extras,
                     action = intent.action,
-                    data = intent.data,
-                    type = intent.type,
                 )
         }
     }

--- a/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/NoteEditorDestination.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/NoteEditorDestination.kt
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.common.destinations
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+
+/** Opens the Add Note/Note Editor screen. */
+sealed class NoteEditorDestination : Destination() {
+    /**
+     * Forwards an incoming intent's payload to the Note Editor.
+     *
+     * Relays `ACTION_SEND` (or similar) intent to the Note Editor, preserving the
+     * originating intent's [action], [data], and [type] alongside the [arguments] bundle.
+     *
+     * @property arguments Extras to forward to the Note Editor.
+     * @property action Optional [Intent.setAction] value.
+     * @property data Optional [Intent.setDataAndType] data.
+     * @property type Optional [Intent.setDataAndType] MIME type.
+     */
+    data class PassArguments(
+        val arguments: Bundle,
+        val action: String? = null,
+        val data: Uri? = null,
+        val type: String? = null,
+    ) : NoteEditorDestination() {
+        companion object {
+            /**
+             * Snapshots [intent]'s action, data, and type alongside the [extras]
+             * for forwarding to the Note Editor.
+             */
+            fun from(
+                intent: Intent,
+                // extras should come from the intent, have the caller perform the null-check
+                extras: Bundle,
+            ): PassArguments =
+                PassArguments(
+                    arguments = extras,
+                    action = intent.action,
+                    data = intent.data,
+                    type = intent.type,
+                )
+        }
+    }
+}

--- a/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/NoteEditorDestination.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/NoteEditorDestination.kt
@@ -5,6 +5,7 @@ package com.ichi2.anki.common.destinations
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import com.ichi2.anki.common.ui.TransitionDirection
 import com.ichi2.anki.libanki.CardId
 import com.ichi2.anki.libanki.DeckId
 
@@ -42,6 +43,15 @@ sealed class NoteEditorDestination : Destination() {
      */
     data class EditNoteFromPreviewer(
         val cardId: CardId,
+    ) : NoteEditorDestination()
+
+    /**
+     * Opens the Note Editor to add a new note from the reviewer.
+     * @property animation The animation direction to use when transitioning. Defaults
+     * to no specific animation.
+     */
+    data class AddNoteFromReviewer(
+        val animation: TransitionDirection? = null,
     ) : NoteEditorDestination()
 
     /**

--- a/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/NoteEditorDestination.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/NoteEditorDestination.kt
@@ -5,6 +5,7 @@ package com.ichi2.anki.common.destinations
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import com.ichi2.anki.libanki.CardId
 import com.ichi2.anki.libanki.DeckId
 
 /** Opens the Add Note/Note Editor screen. */
@@ -33,6 +34,14 @@ sealed class NoteEditorDestination : Destination() {
      */
     data class AddInstantNote(
         val sharedText: String,
+    ) : NoteEditorDestination()
+
+    /**
+     * Opens the Note Editor to edit the note belonging to a card shown in the previewer.
+     * @property cardId The card whose note should be edited.
+     */
+    data class EditNoteFromPreviewer(
+        val cardId: CardId,
     ) : NoteEditorDestination()
 
     /**


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - most of the work
> Assisted-by: Claude Fable 5 - final commit, self- review

## Purpose / Description
Standard decoupling pattern, creating `NoteEditorDestination`

## Fixes
* Part of #20737

## How Has This Been Tested?
N/A, simple refactor ⚠️

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)