### PR TITLE
fix(card-viewer): more issues in audio permission requests

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
@@ -57,8 +57,12 @@ import com.ichi2.themes.Themes
 import com.ichi2.utils.Permissions
 import com.ichi2.utils.Permissions.openAppSettingsScreen
 import com.ichi2.utils.isBlockedCardScheme
+import com.ichi2.utils.message
+import com.ichi2.utils.negativeButton
+import com.ichi2.utils.positiveButton
 import com.ichi2.utils.show
 import com.ichi2.utils.stripDangerousPermissions
+import com.ichi2.utils.title
 import com.ichi2.utils.usesDangerousScheme
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -93,12 +97,10 @@ abstract class CardViewerFragment(
                 }
 
                 AlertDialog.Builder(requireContext()).show {
-                    setTitle(R.string.permission_denied)
-                    setMessage(R.string.microphone_permission_denied_message)
-                    setPositiveButton(R.string.dialog_ok) { _, _ ->
-                        openAppSettingsScreen()
-                    }
-                    setNegativeButton(R.string.dialog_cancel, null)
+                    title(R.string.permission_denied)
+                    message(R.string.microphone_permission_denied_message)
+                    positiveButton(R.string.dialog_ok) { openAppSettingsScreen() }
+                    negativeButton(R.string.dialog_cancel)
                 }
             }
             pendingWebViewPermissionRequest = null
@@ -380,8 +382,8 @@ abstract class CardViewerFragment(
             }
 
             AlertDialog.Builder(requireContext()).show {
-                setMessage(R.string.template_is_trying_to_record_audio)
-                setPositiveButton(R.string.dialog_allow) { _, _ ->
+                message(R.string.template_is_trying_to_record_audio)
+                positiveButton(R.string.dialog_allow) {
                     if (canRecordAudio) {
                         Prefs.allowTemplatesToRecordAudio = true
                         grantRequest()
@@ -390,9 +392,7 @@ abstract class CardViewerFragment(
                         microphonePermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
                     }
                 }
-                setNegativeButton(R.string.dialog_cancel) { _, _ ->
-                    request.deny()
-                }
+                negativeButton(R.string.dialog_cancel) { request.deny() }
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
@@ -84,8 +84,7 @@ abstract class CardViewerFragment(
             Prefs.allowTemplatesToRecordAudio = isGranted
 
             if (isGranted) {
-                Timber.i("Granting audio capture permission to WebView")
-                pendingWebViewPermissionRequest?.grant(arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE))
+                pendingWebViewPermissionRequest?.grantAudioCapture()
             } else {
                 Timber.i("Denying audio capture permission to WebView")
                 pendingWebViewPermissionRequest?.deny()
@@ -105,6 +104,33 @@ abstract class CardViewerFragment(
             }
             pendingWebViewPermissionRequest = null
         }
+
+    /**
+     * Asks whether the card template may record audio, granting [request] if the user allows it.
+     *
+     * If AnkiDroid lacks the microphone permission, requests it first and defers [request] to
+     * [microphonePermissionLauncher].
+     *
+     * @param canRecordAudio whether AnkiDroid holds [Manifest.permission.RECORD_AUDIO]
+     */
+    private fun askToAllowTemplateAudioRecording(
+        request: PermissionRequest,
+        canRecordAudio: Boolean,
+    ) {
+        AlertDialog.Builder(requireContext()).show {
+            message(R.string.template_is_trying_to_record_audio)
+            positiveButton(R.string.dialog_allow) {
+                if (canRecordAudio) {
+                    Prefs.allowTemplatesToRecordAudio = true
+                    request.grantAudioCapture()
+                } else {
+                    pendingWebViewPermissionRequest = request
+                    microphonePermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                }
+            }
+            negativeButton(R.string.dialog_cancel) { request.deny() }
+        }
+    }
 
     @CallSuper
     override fun onViewCreated(
@@ -372,28 +398,13 @@ abstract class CardViewerFragment(
                 return
             }
 
-            fun grantRequest() = request.grant(arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE))
-
             val canRecordAudio = Permissions.canRecordAudio(requireContext())
             if (canRecordAudio && Prefs.allowTemplatesToRecordAudio) {
-                Timber.i("Granting audio capture permission to WebView")
-                grantRequest()
+                request.grantAudioCapture()
                 return
             }
 
-            AlertDialog.Builder(requireContext()).show {
-                message(R.string.template_is_trying_to_record_audio)
-                positiveButton(R.string.dialog_allow) {
-                    if (canRecordAudio) {
-                        Prefs.allowTemplatesToRecordAudio = true
-                        grantRequest()
-                    } else {
-                        pendingWebViewPermissionRequest = request
-                        microphonePermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
-                    }
-                }
-                negativeButton(R.string.dialog_cancel) { request.deny() }
-            }
+            askToAllowTemplateAudioRecording(request, canRecordAudio)
         }
     }
 
@@ -402,4 +413,10 @@ abstract class CardViewerFragment(
             setAction(R.string.help) { openUrl(R.string.link_faq_missing_media) }
         }
     }
+}
+
+/** Allows the WebView to capture audio */
+private fun PermissionRequest.grantAudioCapture() {
+    Timber.i("Granting audio capture permission to WebView")
+    grant(arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE))
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
@@ -129,6 +129,7 @@ abstract class CardViewerFragment(
                 }
             }
             negativeButton(R.string.dialog_cancel) { request.deny() }
+            setOnCancelListener { request.deny() }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
@@ -77,33 +77,41 @@ abstract class CardViewerFragment(
 
     private val appPermission by lazy { AppPermissions(requireContext()) { showSnackbar(it) } }
 
-    private var pendingWebViewPermissionRequest: PermissionRequest? = null
+    /** The [PermissionRequest] being asked about via the opt-in dialog or [microphonePermissionLauncher] */
+    private var activeRequest: PermissionRequest? = null
+
+    /** Whether the user declined the opt-in: further requests are denied without a prompt */
+    private var userDeclinedRecording = false
 
     private val microphonePermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
             Prefs.allowTemplatesToRecordAudio = isGranted
 
             if (isGranted) {
-                pendingWebViewPermissionRequest?.grantAudioCapture()
+                activeRequest?.grantAudioCapture()
             } else {
                 Timber.i("Denying audio capture permission to WebView")
-                pendingWebViewPermissionRequest?.deny()
-
-                // Only ask to go to app settings if the permission dialog
-                // is no longer shown after repeated denials
-                if (ActivityCompat.shouldShowRequestPermissionRationale(requireActivity(), Manifest.permission.RECORD_AUDIO)) {
-                    return@registerForActivityResult
-                }
-
-                AlertDialog.Builder(requireContext()).show {
-                    title(R.string.permission_denied)
-                    message(R.string.microphone_permission_denied_message)
-                    positiveButton(R.string.dialog_ok) { openAppSettingsScreen() }
-                    negativeButton(R.string.dialog_cancel)
-                }
+                activeRequest?.deny()
+                onMicrophonePermissionDenied()
             }
-            pendingWebViewPermissionRequest = null
+            activeRequest = null
         }
+
+    /**
+     * Offers to open the app settings, so the user may grant the microphone permission there.
+     *
+     * Only done if the system dialog is no longer shown after repeated denials.
+     */
+    private fun onMicrophonePermissionDenied() {
+        if (ActivityCompat.shouldShowRequestPermissionRationale(requireActivity(), Manifest.permission.RECORD_AUDIO)) return
+
+        AlertDialog.Builder(requireContext()).show {
+            title(R.string.permission_denied)
+            message(R.string.microphone_permission_denied_message)
+            positiveButton(R.string.dialog_ok) { openAppSettingsScreen() }
+            negativeButton(R.string.dialog_cancel)
+        }
+    }
 
     /**
      * Asks whether the card template may record audio, granting [request] if the user allows it.
@@ -117,19 +125,27 @@ abstract class CardViewerFragment(
         request: PermissionRequest,
         canRecordAudio: Boolean,
     ) {
+        fun decline() {
+            userDeclinedRecording = true
+            activeRequest = null
+            request.deny()
+        }
+
+        activeRequest = request
         AlertDialog.Builder(requireContext()).show {
             message(R.string.template_is_trying_to_record_audio)
             positiveButton(R.string.dialog_allow) {
                 if (canRecordAudio) {
+                    activeRequest = null
                     Prefs.allowTemplatesToRecordAudio = true
                     request.grantAudioCapture()
                 } else {
-                    pendingWebViewPermissionRequest = request
+                    // the request is active until microphonePermissionLauncher handles it
                     microphonePermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
                 }
             }
-            negativeButton(R.string.dialog_cancel) { request.deny() }
-            setOnCancelListener { request.deny() }
+            negativeButton(R.string.dialog_cancel) { decline() }
+            setOnCancelListener { decline() }
         }
     }
 
@@ -402,6 +418,14 @@ abstract class CardViewerFragment(
             val canRecordAudio = Permissions.canRecordAudio(requireContext())
             if (canRecordAudio && Prefs.allowTemplatesToRecordAudio) {
                 request.grantAudioCapture()
+                return
+            }
+
+            // Prompt at most once at a time, and not again once declined: otherwise a template
+            // could spam requests, pressuring a user into consenting
+            if (activeRequest != null || userDeclinedRecording) {
+                Timber.i("Denying audio capture permission to WebView without prompting")
+                request.deny()
                 return
             }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
@@ -77,8 +77,11 @@ abstract class CardViewerFragment(
 
     private val appPermission by lazy { AppPermissions(requireContext()) { showSnackbar(it) } }
 
-    /** The [PermissionRequest] being asked about via the opt-in dialog or [microphonePermissionLauncher] */
+    /** The [PermissionRequest] being asked about via [optInDialog] or [microphonePermissionLauncher] */
     private var activeRequest: PermissionRequest? = null
+
+    /** The dialog asking the user to allow [activeRequest]. `null` if not shown */
+    private var optInDialog: AlertDialog? = null
 
     /** Whether the user declined the opt-in: further requests are denied without a prompt */
     private var userDeclinedRecording = false
@@ -132,21 +135,23 @@ abstract class CardViewerFragment(
         }
 
         activeRequest = request
-        AlertDialog.Builder(requireContext()).show {
-            message(R.string.template_is_trying_to_record_audio)
-            positiveButton(R.string.dialog_allow) {
-                if (canRecordAudio) {
-                    activeRequest = null
-                    Prefs.allowTemplatesToRecordAudio = true
-                    request.grantAudioCapture()
-                } else {
-                    // the request is active until microphonePermissionLauncher handles it
-                    microphonePermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+        optInDialog =
+            AlertDialog.Builder(requireContext()).show {
+                message(R.string.template_is_trying_to_record_audio)
+                positiveButton(R.string.dialog_allow) {
+                    if (canRecordAudio) {
+                        activeRequest = null
+                        Prefs.allowTemplatesToRecordAudio = true
+                        request.grantAudioCapture()
+                    } else {
+                        // the request stays active until microphonePermissionLauncher handles it
+                        microphonePermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                    }
                 }
+                negativeButton(R.string.dialog_cancel) { decline() }
+                setOnCancelListener { decline() }
+                setOnDismissListener { optInDialog = null }
             }
-            negativeButton(R.string.dialog_cancel) { decline() }
-            setOnCancelListener { decline() }
-        }
     }
 
     @CallSuper
@@ -430,6 +435,17 @@ abstract class CardViewerFragment(
             }
 
             askToAllowTemplateAudioRecording(request, canRecordAudio)
+        }
+
+        /**
+         * Forgets [request] after the WebView invalidated it (e.g. on navigating away), closing
+         * the opt-in dialog: granting or denying a cancelled request has no effect.
+         */
+        override fun onPermissionRequestCanceled(request: PermissionRequest) {
+            if (request != activeRequest) return
+            Timber.i("WebView cancelled its audio capture request")
+            activeRequest = null
+            optInDialog?.dismiss()
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/previewer/CardViewerFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/previewer/CardViewerFragmentTest.kt
@@ -27,6 +27,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.shadows.ShadowDialog
 
 @SdkSuppress(minSdkVersion = Build.VERSION_CODES.O) // WebChromeClient
@@ -83,6 +84,27 @@ class CardViewerFragmentTest : RobolectricTest() {
 
             verify(second).deny()
             assertThat("the user is not prompted again", ShadowDialog.getShownDialogs().size, equalTo(dialogCount))
+        }
+    }
+
+    @Test
+    fun `cancelled audio capture requests close the opt-in dialog`() {
+        grantRecordAudioPermission()
+        Prefs.allowTemplatesToRecordAudio = false
+        val request = audioCaptureRequest()
+
+        withCardViewerChromeClient { chromeClient ->
+            chromeClient.onPermissionRequest(request)
+            chromeClient.onPermissionRequestCanceled(request)
+            advanceRobolectricLooper()
+
+            assertThat(
+                "the opt-in dialog is dismissed with its request",
+                shadowOf(ShadowDialog.getLatestDialog()).hasBeenDismissed(),
+                equalTo(true),
+            )
+            verify(request, never()).grant(any())
+            assertThat("no opt-in is recorded", Prefs.allowTemplatesToRecordAudio, equalTo(false))
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/previewer/CardViewerFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/previewer/CardViewerFragmentTest.kt
@@ -2,6 +2,7 @@
 
 package com.ichi2.anki.previewer
 
+import android.content.DialogInterface
 import android.os.Build
 import android.view.ViewGroup
 import android.webkit.PermissionRequest
@@ -16,6 +17,8 @@ import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.browser.IdsFile
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.testutils.createTransientDirectory
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
 import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -42,6 +45,44 @@ class CardViewerFragmentTest : RobolectricTest() {
 
             verify(request).deny()
             verify(request, never()).grant(any())
+        }
+    }
+
+    @Test
+    fun `audio capture requests are denied while an opt-in dialog is open`() {
+        grantRecordAudioPermission()
+        Prefs.allowTemplatesToRecordAudio = false
+        val first = audioCaptureRequest()
+        val second = audioCaptureRequest()
+
+        withCardViewerChromeClient { chromeClient ->
+            chromeClient.onPermissionRequest(first)
+            chromeClient.onPermissionRequest(second)
+
+            verify(second).deny()
+            clickAlertDialogButton(DialogInterface.BUTTON_POSITIVE, true)
+            verify(first).grant(arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE))
+            verify(second, never()).grant(any())
+        }
+    }
+
+    @Test
+    fun `declining the opt-in denies later requests without re-prompting`() {
+        grantRecordAudioPermission()
+        Prefs.allowTemplatesToRecordAudio = false
+        val first = audioCaptureRequest()
+        val second = audioCaptureRequest()
+
+        withCardViewerChromeClient { chromeClient ->
+            chromeClient.onPermissionRequest(first)
+            clickAlertDialogButton(DialogInterface.BUTTON_NEGATIVE, true)
+            verify(first).deny()
+
+            val dialogCount = ShadowDialog.getShownDialogs().size
+            chromeClient.onPermissionRequest(second)
+
+            verify(second).deny()
+            assertThat("the user is not prompted again", ShadowDialog.getShownDialogs().size, equalTo(dialogCount))
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/previewer/CardViewerFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/previewer/CardViewerFragmentTest.kt
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.previewer
+
+import android.os.Build
+import android.view.ViewGroup
+import android.webkit.PermissionRequest
+import android.webkit.WebChromeClient
+import android.webkit.WebView
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SdkSuppress
+import com.ichi2.anki.R
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.browser.IdsFile
+import com.ichi2.anki.settings.Prefs
+import com.ichi2.testutils.createTransientDirectory
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.shadows.ShadowDialog
+
+@SdkSuppress(minSdkVersion = Build.VERSION_CODES.O) // WebChromeClient
+@RunWith(AndroidJUnit4::class)
+class CardViewerFragmentTest : RobolectricTest() {
+    @Test
+    fun `dismissing the opt-in dialog denies the audio capture request`() {
+        grantRecordAudioPermission()
+        Prefs.allowTemplatesToRecordAudio = false
+        val request = audioCaptureRequest()
+
+        withCardViewerChromeClient { chromeClient ->
+            chromeClient.onPermissionRequest(request)
+            ShadowDialog.getLatestDialog().cancel()
+            advanceRobolectricLooper()
+
+            verify(request).deny()
+            verify(request, never()).grant(any())
+        }
+    }
+
+    private fun audioCaptureRequest(): PermissionRequest =
+        mock(PermissionRequest::class.java).also {
+            whenever(it.resources).thenReturn(arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE))
+        }
+
+    /** Runs [block] on the [WebChromeClient] attached to an open previewer's WebView */
+    private fun withCardViewerChromeClient(block: (WebChromeClient) -> Unit) {
+        val note = addBasicAndReversedNote()
+        val intent =
+            PreviewerFragment.getIntent(
+                targetContext,
+                idsFile = IdsFile(createTransientDirectory(), note.cardIds(col)),
+                currentIndex = 0,
+            )
+
+        ActivityScenario.launch<CardViewerActivity>(intent).use { scenario ->
+            scenario.moveToState(Lifecycle.State.RESUMED)
+            scenario.onActivity { activity ->
+                val webViewLayout = activity.findViewById<ViewGroup>(R.id.web_view_layout)
+                val webView =
+                    (0 until webViewLayout.childCount)
+                        .map { webViewLayout.getChildAt(it) }
+                        .filterIsInstance<WebView>()
+                        .single()
+                block(requireNotNull(webView.webChromeClient) { "no WebChromeClient attached" })
+            }
+        }
+    }
+
+    /** [Prefs.allowTemplatesToRecordAudio] is process-wide state: reset it between tests */
+    @After
+    fun resetTemplateAudioOptIn() {
+        Prefs.allowTemplatesToRecordAudio = false
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

## Purpose / Description
Additional issues:

* `dismiss` didn't resolve to a result
* Hardened the API around decision fatigue
* If the WebView goes, so should the prompt

## Approach
See the commits

## How Has This Been Tested?
All unit tested


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)