### PR TITLE
fix(reviewer): preserve mark state updates without reloading the card

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -121,7 +121,7 @@ class PreviewerViewModel(
         launchCatchingIO {
             val card = currentCard.await()
             val note = withCol { card.note(this@withCol) }
-            NoteService.toggleMark(note)
+            NoteService.toggleMark(note, handler = this@PreviewerViewModel)
             isMarked.emit(NoteService.isMarked(note))
         }
     }
@@ -251,6 +251,8 @@ class PreviewerViewModel(
         handler: Any?,
     ) {
         launchCatchingIO {
+            if (handler == this@PreviewerViewModel) return@launchCatchingIO
+
             when {
                 changes.noteText -> {
                     val card = currentCard.await()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -233,7 +233,7 @@ class ReviewerViewModel(
         Timber.v("ReviewerViewModel::toggleMark")
         val card = currentCard.await()
         val note = withCol { card.note(this@withCol) }
-        NoteService.toggleMark(note)
+        NoteService.toggleMark(note, handler = this@ReviewerViewModel)
         isMarkedFlow.emit(NoteService.isMarked(note))
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerViewModelTest.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.previewer
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
 import com.ichi2.anki.Flag
 import com.ichi2.anki.browser.IdsFile
 import com.ichi2.anki.servicelayer.NoteService
@@ -177,6 +178,26 @@ class PreviewerViewModelTest : JvmTest() {
     fun `toggle mark`() =
         runTest {
             viewModel.toggleMark()
+            assertTrue(viewModel.isMarked.value)
+
+            val note = viewModel.currentCard.await().note()
+            assertTrue(NoteService.isMarked(note))
+        }
+
+    @Test
+    fun `mark does not rerender the current card`() =
+        runTest {
+            viewModel.eval.test {
+                viewModel.onPageFinished(false)
+                advanceUntilIdle()
+                awaitItem()
+
+                viewModel.toggleMark()
+                advanceUntilIdle()
+
+                expectNoEvents()
+            }
+
             assertTrue(viewModel.isMarked.value)
 
             val note = viewModel.currentCard.await().note()


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

<!---
Uncomment this section if AI tools were used. New contributors may not use AI tools. See:
https://github.com/ankidroid/Anki-Android/blob/main/AI_POLICY.md
> [!NOTE]
> Assisted-by: ___
--->

## Purpose / Description
Marking or Unmarking a note resets the option selected (MCQ Addon Model) in new study screen

## Fixes
* Fixes #21601

## Approach
Update mark toggles to call `NoteService.toggleMark(note, handler = this)`

## How Has This Been Tested?

Small Tablet API 35
[mark_note.webm](https://github.com/user-attachments/assets/9e011e07-f28b-4a81-803d-05734b52a05f)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->