### PR TITLE
fix(progress): show dialog after restart mid-delay [DEV]

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/progress/ProgressObserver.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/progress/ProgressObserver.kt
@@ -28,12 +28,13 @@ fun AnkiActivity.observeProgress(
 ) {
     var dialogVisible =
         supportFragmentManager.findFragmentByTag(LoadingDialogFragment.TAG) != null
-    // Pending "show after delay" job survives subsequent Active emissions so the
-    // anti-flash delay isn't restarted on every progress update.
-    var pendingShow: Job? = null
 
     lifecycleScope.launch {
         repeatOnLifecycle(Lifecycle.State.STARTED) {
+            // Pending "show after delay" job survives subsequent Active emissions so the
+            // anti-flash delay isn't restarted on every progress update. Kept inside the
+            // block: a job cancelled on stop must not linger into the next start.
+            var pendingShow: Job? = null
             viewModel.progressManager.progress.collect { state ->
                 when (state) {
                     is ViewModelProgress.Idle -> {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/progress/ProgressObserverTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/progress/ProgressObserverTest.kt
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2026 Ashish Yadav <mailtoashish693@gmail.com>
+package com.ichi2.anki.progress
+
+import android.os.Looper
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.dialogs.LoadingDialogFragment
+import com.ichi2.testutils.EmptyAnkiActivity
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.android.controller.ActivityController
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.toJavaDuration
+
+@RunWith(AndroidJUnit4::class)
+class ProgressObserverTest : RobolectricTest() {
+    private val progressManager = ProgressManager()
+    private val viewModel =
+        object : HasProgress {
+            override val progressManager = this@ProgressObserverTest.progressManager
+        }
+
+    @Test
+    fun `dialog appears after the delay and is dismissed when the op ends`() {
+        val controller = startActivity()
+        val activity = controller.get()
+        activity.observeProgress(viewModel, delayMillis = SHOW_DELAY)
+
+        val gate = CompletableDeferred<Unit>()
+        val op = launchOp(gate)
+        idleMainLooper(SHOW_DELAY / 2)
+        assertNull(activity.loadingDialog(), "dialog must not show before the delay elapses")
+
+        idleMainLooper(SHOW_DELAY)
+        assertNotNull(activity.loadingDialog(), "dialog must show once the delay elapses")
+
+        gate.complete(Unit)
+        idleMainLooper(SHOW_DELAY)
+        assertNull(activity.loadingDialog(), "dialog must be dismissed once the op ends")
+        op.cancel()
+    }
+
+    @Test
+    fun `dialog is not shown for an op that ends within the delay`() {
+        val controller = startActivity()
+        val activity = controller.get()
+        activity.observeProgress(viewModel, delayMillis = SHOW_DELAY)
+
+        val gate = CompletableDeferred<Unit>()
+        val op = launchOp(gate)
+        idleMainLooper(SHOW_DELAY / 2)
+        gate.complete(Unit)
+
+        idleMainLooper(SHOW_DELAY * 2)
+        assertNull(activity.loadingDialog(), "a quick op must not flash a dialog")
+        op.cancel()
+    }
+
+    @Test
+    fun `dialog is shown when the activity is stopped and restarted during the show delay`() {
+        val controller = startActivity()
+        val activity = controller.get()
+        activity.observeProgress(viewModel, delayMillis = SHOW_DELAY)
+
+        val gate = CompletableDeferred<Unit>()
+        val op = launchOp(gate)
+        idleMainLooper(SHOW_DELAY / 2)
+        assertNull(activity.loadingDialog(), "dialog must not show before the delay elapses")
+
+        // stopping cancels the pending show; the op is still running when the activity comes back
+        controller.pause().stop()
+        controller.start().resume()
+        idleMainLooper(SHOW_DELAY * 2)
+
+        assertNotNull(activity.loadingDialog(), "dialog must show after the activity restarts mid-op")
+
+        gate.complete(Unit)
+        idleMainLooper(SHOW_DELAY)
+        assertNull(activity.loadingDialog(), "dialog must be dismissed once the op ends")
+        op.cancel()
+    }
+
+    private fun launchOp(gate: CompletableDeferred<Unit>) =
+        CoroutineScope(Dispatchers.Unconfined).launch {
+            progressManager.withProgress(message = "op") { gate.await() }
+        }
+
+    private fun startActivity(): ActivityController<EmptyAnkiActivity> =
+        Robolectric
+            .buildActivity(EmptyAnkiActivity::class.java)
+            .setup()
+            .also { saveControllerForCleanup(it) }
+
+    private fun EmptyAnkiActivity.loadingDialog() = supportFragmentManager.findFragmentByTag(LoadingDialogFragment.TAG)
+
+    private fun idleMainLooper(duration: Duration) = shadowOf(Looper.getMainLooper()).idleFor(duration.toJavaDuration())
+
+    companion object {
+        private val SHOW_DELAY = 600.milliseconds
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

<!---
Uncomment this section if AI tools were used. New contributors may not use AI tools. See:
https://github.com/ankidroid/Anki-Android/blob/main/AI_POLICY.md
> [!NOTE]
> Assisted-by: ___
--->

## Purpose / Description
- Follow-up to #20729. `observeProgress` could permanently miss showing the loading dialog: if the activity was stopped and restarted while the initial show delay was still pending (e.g. the user briefly switches apps right after starting an operation), the dialog never appeared for that operation.

## Fixes
* Part of #19460

## Approach
`pendingShow` was declared outside `repeatOnLifecycle`, so a stop during the show delay cancelled the job but kept the stale reference. On the next start the Active state was ignored and the dialog never appeared for that operation.

Declare it inside the block so its lifetime matches the job's.

## How Has This Been Tested?
Added unit tests

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->