### PR TITLE
feat: progress support @StringRes messages [DEV]

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/progress/BackendProgressExt.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/progress/BackendProgressExt.kt
@@ -26,7 +26,7 @@ suspend fun <T> ProgressScope.withBackendProgress(
         extractProgress = extractProgress,
         updateUi = {
             updateProgress(
-                message = text,
+                message = text?.let(ProgressText::Raw),
                 amount = amount,
             )
         },

--- a/AnkiDroid/src/main/java/com/ichi2/anki/progress/ProgressManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/progress/ProgressManager.kt
@@ -32,7 +32,7 @@ class ProgressManager {
      * is re-inserted (to move it to the "latest" position).
      */
     private class Op(
-        var message: String?,
+        var message: ProgressText?,
         var amount: ProgressContext.Amount?,
         val onCancel: (() -> Unit)?,
         val formatAmount: (ProgressContext.Amount) -> String,
@@ -53,7 +53,7 @@ class ProgressManager {
      *  dedicated API instead of overloading [updateProgress].
      */
     suspend fun <T> withProgress(
-        message: String? = null,
+        message: ProgressText? = null,
         onCancel: (() -> Unit)? = null,
         formatAmount: (ProgressContext.Amount) -> String =
             { (current, max) -> "$current/$max" },
@@ -93,12 +93,12 @@ class ProgressManager {
      */
     internal fun updateOp(
         opId: Long,
-        message: String?,
+        message: ProgressText?,
         amount: ProgressContext.Amount?,
     ) {
         synchronized(lock) {
             val op = activeOps[opId] ?: return
-            op.message = message
+            message?.let { op.message = it }
             op.amount = amount
             // Only the displayed op (last-started) drives the published state.
             if (activeOps.entries.last().key == opId) {
@@ -136,8 +136,9 @@ class ProgressScope internal constructor(
     private val manager: ProgressManager,
     private val opId: Long,
 ) {
+    /** A null [message] keeps the current one. */
     fun updateProgress(
-        message: String? = null,
+        message: ProgressText? = null,
         amount: ProgressContext.Amount? = null,
     ) {
         manager.updateOp(opId, message = message, amount = amount)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/progress/ProgressObserver.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/progress/ProgressObserver.kt
@@ -3,6 +3,7 @@
 
 package com.ichi2.anki.progress
 
+import android.content.Context
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -46,7 +47,7 @@ fun AnkiActivity.observeProgress(
                     is ViewModelProgress.Active -> {
                         if (dialogVisible) {
                             showLoadingDialog(
-                                message = state.formatMessage(),
+                                message = formatMessage(state),
                                 cancellable = state.cancellable,
                             )
                             if (state.cancellable) wireCancelListener(viewModel)
@@ -58,7 +59,7 @@ fun AnkiActivity.observeProgress(
                                     if (latest is ViewModelProgress.Active) {
                                         dialogVisible = true
                                         showLoadingDialog(
-                                            message = latest.formatMessage(),
+                                            message = formatMessage(latest),
                                             cancellable = latest.cancellable,
                                         )
                                         if (latest.cancellable) wireCancelListener(viewModel)
@@ -109,11 +110,12 @@ fun Fragment.observeProgress(
     activity.observeProgress(viewModel, delayMillis)
 }
 
-private fun ViewModelProgress.Active.formatMessage(): String? {
-    val amount = amount ?: return message
-    val formattedAmount = formatAmount(amount)
+private fun Context.formatMessage(state: ViewModelProgress.Active): String? {
+    val text = state.message?.resolve(this)
+    val amount = state.amount ?: return text
+    val formattedAmount = state.formatAmount(amount)
     return when {
-        message.isNullOrEmpty() -> formattedAmount
-        else -> "$message$separator$formattedAmount"
+        text.isNullOrEmpty() -> formattedAmount
+        else -> "$text${state.separator}$formattedAmount"
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/progress/ProgressText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/progress/ProgressText.kt
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2026 Ashish Yadav <mailtoashish693@gmail.com>
+
+package com.ichi2.anki.progress
+
+import android.content.Context
+import androidx.annotation.StringRes
+
+/** A progress message, resolved to a [String] by the UI. */
+sealed interface ProgressText {
+    data class Raw(
+        val text: String,
+    ) : ProgressText
+
+    data class Res(
+        @StringRes val resId: Int,
+        val args: List<Any> = emptyList(),
+    ) : ProgressText
+
+    fun resolve(context: Context): String =
+        when (this) {
+            is Raw -> text
+            is Res -> context.getString(resId, *args.toTypedArray())
+        }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/progress/ViewModelProgress.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/progress/ViewModelProgress.kt
@@ -10,7 +10,7 @@ sealed interface ViewModelProgress {
     data object Idle : ViewModelProgress
 
     data class Active(
-        val message: String? = null,
+        val message: ProgressText? = null,
         val amount: ProgressContext.Amount? = null,
         val cancellable: Boolean = false,
         val formatAmount: (ProgressContext.Amount) -> String =

--- a/AnkiDroid/src/test/java/com/ichi2/anki/progress/ProgressManagerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/progress/ProgressManagerTest.kt
@@ -4,6 +4,7 @@
 package com.ichi2.anki.progress
 
 import com.ichi2.anki.ProgressContext
+import com.ichi2.anki.R
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -25,10 +26,10 @@ class ProgressManagerTest {
         runTest {
             val manager = ProgressManager()
 
-            manager.withProgress(message = "Loading...") {
+            manager.withProgress(message = ProgressText.Raw("Loading...")) {
                 val state = manager.progress.value
                 assertIs<ViewModelProgress.Active>(state)
-                assertEquals("Loading...", state.message)
+                assertEquals(ProgressText.Raw("Loading..."), state.message)
             }
 
             assertIs<ViewModelProgress.Idle>(manager.progress.value)
@@ -68,14 +69,14 @@ class ProgressManagerTest {
 
             val job1 =
                 launch(UnconfinedTestDispatcher(testScheduler)) {
-                    manager.withProgress(message = "Op 1") {
+                    manager.withProgress(message = ProgressText.Raw("Op 1")) {
                         deferred1.await()
                     }
                 }
 
             val job2 =
                 launch(UnconfinedTestDispatcher(testScheduler)) {
-                    manager.withProgress(message = "Op 2") {
+                    manager.withProgress(message = ProgressText.Raw("Op 2")) {
                         deferred2.await()
                     }
                 }
@@ -99,18 +100,50 @@ class ProgressManagerTest {
         runTest {
             val manager = ProgressManager()
 
-            manager.withProgress(message = "Starting") {
+            manager.withProgress(message = ProgressText.Raw("Starting")) {
                 val initialState = manager.progress.value
                 assertIs<ViewModelProgress.Active>(initialState)
-                assertEquals("Starting", initialState.message)
+                assertEquals(ProgressText.Raw("Starting"), initialState.message)
 
                 val testAmount = ProgressContext.Amount(current = 5, max = 10)
-                updateProgress(message = "Step 2", amount = testAmount)
+                updateProgress(message = ProgressText.Raw("Step 2"), amount = testAmount)
 
                 val updatedState = manager.progress.value
                 assertIs<ViewModelProgress.Active>(updatedState)
-                assertEquals("Step 2", updatedState.message)
+                assertEquals(ProgressText.Raw("Step 2"), updatedState.message)
                 assertEquals(testAmount, updatedState.amount)
+            }
+        }
+
+    @Test
+    fun `withProgress publishes a resource message`() =
+        runTest {
+            val manager = ProgressManager()
+            val message = ProgressText.Res(R.string.dialog_processing)
+
+            manager.withProgress(message = message) {
+                val state = manager.progress.value
+                assertIs<ViewModelProgress.Active>(state)
+                assertEquals(message, state.message)
+            }
+
+            assertIs<ViewModelProgress.Idle>(manager.progress.value)
+        }
+
+    @Test
+    fun `updateProgress without a message keeps the current one`() =
+        runTest {
+            val manager = ProgressManager()
+            val message = ProgressText.Res(R.string.dialog_processing)
+
+            manager.withProgress(message = message) {
+                val amount = ProgressContext.Amount(current = 1, max = 2)
+                updateProgress(amount = amount)
+
+                val state = manager.progress.value
+                assertIs<ViewModelProgress.Active>(state)
+                assertEquals(message, state.message)
+                assertEquals(amount, state.amount)
             }
         }
 
@@ -259,13 +292,13 @@ class ProgressManagerTest {
             val nonCancellableJob =
                 launch(UnconfinedTestDispatcher(testScheduler)) {
                     manager.withProgress {
-                        updateProgress(message = "mid-update")
+                        updateProgress(message = ProgressText.Raw("mid-update"))
                         nonCancellableDone.await()
                     }
                 }
 
             val state = manager.progress.value as ViewModelProgress.Active
-            assertEquals("mid-update", state.message)
+            assertEquals(ProgressText.Raw("mid-update"), state.message)
             assertEquals(true, state.cancellable)
 
             cancellableDone.complete(Unit)
@@ -283,15 +316,15 @@ class ProgressManagerTest {
 
             val jobA =
                 launch(UnconfinedTestDispatcher(testScheduler)) {
-                    manager.withProgress(message = "A") { aDone.await() }
+                    manager.withProgress(message = ProgressText.Raw("A")) { aDone.await() }
                 }
             val jobB =
                 launch(UnconfinedTestDispatcher(testScheduler)) {
-                    manager.withProgress(message = "B") { bDone.await() }
+                    manager.withProgress(message = ProgressText.Raw("B")) { bDone.await() }
                 }
 
             val state = manager.progress.value as ViewModelProgress.Active
-            assertEquals("B", state.message, "newest op wins")
+            assertEquals(ProgressText.Raw("B"), state.message, "newest op wins")
 
             aDone.complete(Unit)
             bDone.complete(Unit)
@@ -308,18 +341,18 @@ class ProgressManagerTest {
 
             val jobA =
                 launch(UnconfinedTestDispatcher(testScheduler)) {
-                    manager.withProgress(message = "A") { aDone.await() }
+                    manager.withProgress(message = ProgressText.Raw("A")) { aDone.await() }
                 }
             val jobB =
                 launch(UnconfinedTestDispatcher(testScheduler)) {
-                    manager.withProgress(message = "B") { bDone.await() }
+                    manager.withProgress(message = ProgressText.Raw("B")) { bDone.await() }
                 }
 
-            assertEquals("B", (manager.progress.value as ViewModelProgress.Active).message)
+            assertEquals(ProgressText.Raw("B"), (manager.progress.value as ViewModelProgress.Active).message)
 
             bDone.complete(Unit)
             jobB.join()
-            assertEquals("A", (manager.progress.value as ViewModelProgress.Active).message)
+            assertEquals(ProgressText.Raw("A"), (manager.progress.value as ViewModelProgress.Active).message)
 
             aDone.complete(Unit)
             jobA.join()
@@ -336,24 +369,24 @@ class ProgressManagerTest {
 
             val jobA =
                 launch(UnconfinedTestDispatcher(testScheduler)) {
-                    manager.withProgress(message = "A") {
+                    manager.withProgress(message = ProgressText.Raw("A")) {
                         aUpdated.await()
-                        updateProgress(message = "A-updated")
+                        updateProgress(message = ProgressText.Raw("A-updated"))
                         aDone.await()
                     }
                 }
             val jobB =
                 launch(UnconfinedTestDispatcher(testScheduler)) {
-                    manager.withProgress(message = "B") { bDone.await() }
+                    manager.withProgress(message = ProgressText.Raw("B")) { bDone.await() }
                 }
 
             // B is the displayed op (latest-started).
-            assertEquals("B", (manager.progress.value as ViewModelProgress.Active).message)
+            assertEquals(ProgressText.Raw("B"), (manager.progress.value as ViewModelProgress.Active).message)
 
             // A updates while B is still displayed — displayed message must NOT flicker to A's.
             aUpdated.complete(Unit)
             assertEquals(
-                "B",
+                ProgressText.Raw("B"),
                 (manager.progress.value as ViewModelProgress.Active).message,
                 "non-displayed op's update must not steal the dialog",
             )
@@ -362,7 +395,7 @@ class ProgressManagerTest {
             bDone.complete(Unit)
             jobB.join()
             assertEquals(
-                "A-updated",
+                ProgressText.Raw("A-updated"),
                 (manager.progress.value as ViewModelProgress.Active).message,
                 "A's held update should surface once it becomes the displayed op",
             )
@@ -454,12 +487,12 @@ class ProgressManagerTest {
 
             val opJob =
                 launch(UnconfinedTestDispatcher(testScheduler)) {
-                    manager.withProgress(message = "start") {
+                    manager.withProgress(message = ProgressText.Raw("start")) {
                         // Stream of updates every 100ms would defeat the delay
                         // under the old collectLatest pattern.
                         repeat(10) { i ->
                             kotlinx.coroutines.delay(100)
-                            updateProgress(message = "step $i")
+                            updateProgress(message = ProgressText.Raw("step $i"))
                         }
                         done.await()
                     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/progress/ProgressObserverTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/progress/ProgressObserverTest.kt
@@ -3,7 +3,10 @@
 package com.ichi2.anki.progress
 
 import android.os.Looper
+import android.widget.TextView
+import androidx.fragment.app.DialogFragment
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.dialogs.LoadingDialogFragment
 import com.ichi2.testutils.EmptyAnkiActivity
@@ -16,6 +19,7 @@ import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.android.controller.ActivityController
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.time.Duration
@@ -90,10 +94,29 @@ class ProgressObserverTest : RobolectricTest() {
         op.cancel()
     }
 
-    private fun launchOp(gate: CompletableDeferred<Unit>) =
-        CoroutineScope(Dispatchers.Unconfined).launch {
-            progressManager.withProgress(message = "op") { gate.await() }
-        }
+    @Test
+    fun `a resource message is resolved into the dialog text`() {
+        val controller = startActivity()
+        val activity = controller.get()
+        activity.observeProgress(viewModel, delayMillis = SHOW_DELAY)
+
+        val gate = CompletableDeferred<Unit>()
+        val message = ProgressText.Res(R.string.progress_amount_bytes, listOf("1 MB", "2 MB"))
+        val op = launchOp(gate, message)
+        idleMainLooper(SHOW_DELAY * 2)
+
+        assertEquals("1 MB/2 MB", activity.loadingDialogText())
+
+        gate.complete(Unit)
+        op.cancel()
+    }
+
+    private fun launchOp(
+        gate: CompletableDeferred<Unit>,
+        message: ProgressText = ProgressText.Raw("op"),
+    ) = CoroutineScope(Dispatchers.Unconfined).launch {
+        progressManager.withProgress(message = message) { gate.await() }
+    }
 
     private fun startActivity(): ActivityController<EmptyAnkiActivity> =
         Robolectric
@@ -102,6 +125,13 @@ class ProgressObserverTest : RobolectricTest() {
             .also { saveControllerForCleanup(it) }
 
     private fun EmptyAnkiActivity.loadingDialog() = supportFragmentManager.findFragmentByTag(LoadingDialogFragment.TAG)
+
+    private fun EmptyAnkiActivity.loadingDialogText() =
+        (loadingDialog() as? DialogFragment)
+            ?.dialog
+            ?.findViewById<TextView>(R.id.text)
+            ?.text
+            ?.toString()
 
     private fun idleMainLooper(duration: Duration) = shadowOf(Looper.getMainLooper()).idleFor(duration.toJavaDuration())
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/progress/ProgressTextTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/progress/ProgressTextTest.kt
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2026 Ashish Yadav <mailtoashish693@gmail.com>
+
+package com.ichi2.anki.progress
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.R
+import com.ichi2.anki.RobolectricTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class ProgressTextTest : RobolectricTest() {
+    @Test
+    fun `Raw resolves to its text`() {
+        assertEquals("Loading", ProgressText.Raw("Loading").resolve(targetContext))
+    }
+
+    @Test
+    fun `Res resolves the resource without arguments`() {
+        val expected = targetContext.getString(R.string.dialog_processing)
+        assertEquals(expected, ProgressText.Res(R.string.dialog_processing).resolve(targetContext))
+    }
+
+    @Test
+    fun `Res resolves the resource with its arguments`() {
+        val text = ProgressText.Res(R.string.progress_amount_bytes, listOf("1 MB", "2 MB")).resolve(targetContext)
+        assertEquals("1 MB/2 MB", text)
+    }
+}


### PR DESCRIPTION


<!--- Please fill the necessary details below -->

<!---
Uncomment this section if AI tools were used. New contributors may not use AI tools. See:
https://github.com/ankidroid/Anki-Android/blob/main/AI_POLICY.md
> [!NOTE]
> Assisted-by: ___
--->

## Purpose / Description
ViewModels don't resolve `R.string` themselves, and many progress messages have no Fluent equivalent so add the param in method

## Fixes
* Part of #19460

## Approach
Simply add the string res param

## How Has This Been Tested?
Added test

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->