### PR TITLE
fix(tests): Prefs contamination

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesScreenshotTest.kt
@@ -8,11 +8,19 @@ import com.ichi2.anki.R
 import com.ichi2.anki.ScreenshotTest
 import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.settings.Prefs
+import com.ichi2.testutils.ext.clear
+import org.junit.After
 import org.junit.Test
 
 class PreferencesScreenshotTest : ScreenshotTest() {
     init {
         Prefs.isNewStudyScreenEnabled = true
+    }
+
+    @After
+    override fun tearDown() {
+        super.tearDown()
+        Prefs.clear()
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/StudyScreenScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/StudyScreenScreenshotTest.kt
@@ -10,9 +10,17 @@ import com.ichi2.anki.previewer.CardViewerActivity
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.settings.enums.FrameStyle
 import com.ichi2.anki.settings.enums.ToolbarPosition
+import com.ichi2.testutils.ext.clear
+import org.junit.After
 import org.junit.Test
 
 class StudyScreenScreenshotTest : ScreenshotTest() {
+    @After
+    override fun tearDown() {
+        super.tearDown()
+        Prefs.clear()
+    }
+
     @Test
     fun captureScreenshot(
         @TestParameter toolbarPosition: ToolbarPosition,

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/ext/Prefs.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/ext/Prefs.kt
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2026 Brayan Oliveira <69634269+brayandso@users.noreply.github.com>
+package com.ichi2.testutils.ext
+
+import androidx.core.content.edit
+import com.ichi2.anki.settings.Prefs
+
+fun Prefs.clear() {
+    sharedPrefs.edit { clear() }
+}


### PR DESCRIPTION
## Fixes
* Fixes #21081

## Approach

Checked for the places that set the value of `Prefs.isNewStudyScreenEnabled` then cleared the shared preferences there

## How Has This Been Tested?

CI

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->