### PR TITLE
feat: remove 'Donate' links from 'play' variant 

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -88,6 +88,8 @@ android {
         buildConfigField "Boolean", "ENABLE_LEAK_CANARY", "false"
         buildConfigField "String", "GIT_COMMIT_HASH", "\"${gitCommitHash.get()}\""
         buildConfigField "long", "BUILD_TIME", buildTimeMillis.get()
+        // whether UI elements linking to external donation pages are shown ('play' hides them)
+        buildConfigField "Boolean", "SHOW_DONATE_LINKS", "true"
         resValue "string", "app_name", "AnkiDroid"
 
         // The version number is of the form:
@@ -233,6 +235,9 @@ android {
         create('play') {
             getIsDefault().set(true)
             dimension "appStore"
+            // Google Play no longer considers Open Collective to be acceptable for
+            // a 'tax-exempt' link. Temporarily remove our links
+            buildConfigField "Boolean", "SHOW_DONATE_LINKS", "false"
         }
         create('amazon') {
             dimension "appStore"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
@@ -142,6 +142,14 @@ class Info :
                             }
                             document.body.style.setProperty("background", "$background");""",
                     )
+                    if (!BuildConfig.SHOW_DONATE_LINKS) {
+                        // remove donation links, keeping the text
+                        binding.webView.evaluateJavascript(
+                            """document.querySelectorAll('a[href*="opencollective.com"]')
+                                .forEach((a) => a.replaceWith(...a.childNodes));""",
+                            null,
+                        )
+                    }
                 }
 
                 override fun shouldOverrideUrlLoading(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
@@ -19,6 +19,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat.Type.displayCutout
 import androidx.core.view.WindowInsetsCompat.Type.systemBars
+import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.utils.android.getColorFromAttr
@@ -62,7 +63,11 @@ class Info :
         setViewBinding(binding)
         enableToolbar()
         applyInsets()
-        binding.donate.setOnClickListener { openUrl(R.string.link_opencollective_donate) }
+        if (BuildConfig.SHOW_DONATE_LINKS) {
+            binding.donate.setOnClickListener { openUrl(R.string.link_opencollective_donate) }
+        } else {
+            binding.donate.isVisible = false
+        }
         title = "$appName v$pkgVersionName"
         binding.webView.webChromeClient =
             object : WebChromeClient() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MoreFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MoreFragment.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.annotation.StringRes
 import androidx.core.net.toUri
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import com.ichi2.anki.common.analytics.Analytics
 import com.ichi2.anki.common.analytics.AnalyticsEvent.LinkClicked
@@ -93,6 +94,10 @@ class MoreFragment : Fragment(R.layout.fragment_more) {
         // Hide rate if Play Store not available
         if (!IntentUtil.canOpenIntent(requireContext(), marketIntent)) {
             binding.moreSupportRate.visibility = View.GONE
+        }
+
+        if (!BuildConfig.SHOW_DONATE_LINKS) {
+            binding.moreSupportDonate.isVisible = false
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/help/HelpDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/help/HelpDialog.kt
@@ -13,6 +13,7 @@ import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.BuildConfig
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.ankiActivity
@@ -139,7 +140,10 @@ class HelpDialog : AnalyticsDialogFragment() {
          */
         fun newSupportInstance(canRateApp: Boolean): HelpDialog {
             Analytics.send(LinkClicked(LinkAction.OPENED_SUPPORT_ANKIDROID))
-            val actualMenuItems = supportMenuItems.filterNot { it.action is Rate && !canRateApp }
+            val actualMenuItems =
+                supportMenuItems
+                    .filterNot { it.action is Rate && !canRateApp }
+                    .filterNot { it.analyticsId == LinkAction.OPENED_DONATE && !BuildConfig.SHOW_DONATE_LINKS }
             return HelpDialog().apply {
                 arguments =
                     Bundle().apply {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
@@ -11,6 +11,7 @@ import android.view.View
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.core.text.parseAsHtml
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.BuildConfig
@@ -85,10 +86,15 @@ class AboutFragment : Fragment(R.layout.fragment_about) {
         }
 
         // Donate text
-        val donateLink = getString(R.string.link_opencollective_donate)
-        binding.donateDescription.apply {
-            text = getString(R.string.donate_description, donateLink).parseAsHtml()
-            movementMethod = LinkMovementMethod.getInstance()
+        if (BuildConfig.SHOW_DONATE_LINKS) {
+            val donateLink = getString(R.string.link_opencollective_donate)
+            binding.donateDescription.apply {
+                text = getString(R.string.donate_description, donateLink).parseAsHtml()
+                movementMethod = LinkMovementMethod.getInstance()
+            }
+        } else {
+            binding.aboutDonateTitle.isVisible = false
+            binding.donateDescription.isVisible = false
         }
 
         binding.rateAnkiDroid.setOnClickListener {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/help/HelpDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/help/HelpDialogTest.kt
@@ -14,6 +14,7 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.BuildConfig
 import com.ichi2.anki.R
 import com.ichi2.anki.dialogs.help.HelpItem.Action.Rate
 import io.mockk.mockk
@@ -54,8 +55,8 @@ class HelpDialogTest {
     fun `Help contains the expected items at start`() {
         // checking the support menu
         val expectedSupportItems =
-            listOf(
-                R.string.help_item_support_opencollective_donate,
+            listOfNotNull(
+                R.string.help_item_support_opencollective_donate.takeIf { BuildConfig.SHOW_DONATE_LINKS },
                 R.string.multimedia_editor_trans_translate,
                 R.string.help_item_support_develop_ankidroid,
                 R.string.help_item_support_rate_ankidroid,


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

## Purpose / Description
Google Play hasn't provided any explanation for why Open Source Collective [501(c)(6)] isn't tax-exempt, and we'll be removed from the Play Store on September 11 if we don't remove Donation links.

Realistically, we have until August 31 [SDK 36], so let's get this in now

## Fixes
* Part of #21656

## Approach
* Disable elements wich link to the donate screen
* For `changelog.html`, replace `<a>` tags with their content

## How Has This Been Tested?
<img width="310" height="693" alt="Screenshot 2026-08-30 at 01 11 33" src="https://github.com/user-attachments/assets/a3ce1623-a35a-4b7b-9527-18bdcb669e19" />


<img width="301" height="295" alt="Screenshot 2026-08-30 at 01 13 08" src="https://github.com/user-attachments/assets/12c35811-f56a-468e-b9fa-2a7c2a0b9775" />

<img width="191" height="321" alt="Screenshot 2026-08-30 at 01 14 02" src="https://github.com/user-attachments/assets/daea1604-ea05-4e8c-9208-89f17cda6570" />

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)