### PR TITLE
Enable edge to edge for CardTemplateEditor activity

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -7,6 +7,7 @@ package com.ichi2.anki
 import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
+import android.graphics.Color
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -19,8 +20,12 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.widget.FrameLayout
 import android.widget.LinearLayout
+import android.widget.ScrollView
 import androidx.activity.OnBackPressedCallback
+import androidx.activity.SystemBarStyle
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.CheckResult
@@ -31,10 +36,15 @@ import androidx.core.view.MenuHost
 import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsCompat.Type.displayCutout
+import androidx.core.view.WindowInsetsCompat.Type.ime
+import androidx.core.view.WindowInsetsCompat.Type.systemBars
 import androidx.core.view.isVisible
 import androidx.core.view.size
+import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentContainerView
 import androidx.fragment.app.commitNow
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -188,6 +198,7 @@ open class CardTemplateEditor : AnkiActivity(R.layout.activity_card_template_edi
         if (!ensureStorageIsReady()) {
             return
         }
+        setupEdgeToEdge()
         // Load the args either from the intent or savedInstanceState bundle
         if (savedInstanceState == null) {
             // get note type id
@@ -242,6 +253,30 @@ open class CardTemplateEditor : AnkiActivity(R.layout.activity_card_template_edi
         }
 
         registerDeckSelectedHandler(action = ::onDeckSelected)
+    }
+
+    private fun setupEdgeToEdge() {
+        enableEdgeToEdge(statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT))
+        ViewCompat.setOnApplyWindowInsetsListener(binding.templateEditorTop.root) { _, insets ->
+            val constraints = insets.getInsets(systemBars() or displayCutout())
+            findViewById<LinearLayout>(
+                R.id.template_editor_top,
+            )?.updatePadding(left = constraints.left, top = constraints.top, right = constraints.right)
+            insets
+        }
+        ViewCompat.setOnApplyWindowInsetsListener(binding.rootLayout) { _, insets ->
+            val constraints = insets.getInsets(systemBars() or displayCutout() or ime())
+            if (fragmented) {
+                findViewById<LinearLayout>(R.id.template_editor)?.updatePadding(left = constraints.left)
+                findViewById<FragmentContainerView>(R.id.fragment_container)?.updatePadding(right = constraints.right)
+            } else {
+                findViewById<FrameLayout>(
+                    R.id.bottom_navigation_container,
+                )?.updatePadding(left = constraints.left, right = constraints.right)
+                findViewById<ScrollView>(R.id.scroll_view)?.updatePadding(left = constraints.left, right = constraints.right)
+            }
+            insets
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/res/layout-sw600dp/activity_card_template_editor.xml
+++ b/AnkiDroid/src/main/res/layout-sw600dp/activity_card_template_editor.xml
@@ -19,7 +19,8 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
-            android:orientation="horizontal">
+            android:orientation="horizontal"
+            android:background="?attr/alternativeBackgroundColor">
 
             <include layout="@layout/include_card_template_editor_main"
                 android:id="@+id/template_editor"

--- a/AnkiDroid/src/main/res/layout/fragment_card_template_editor_template.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_card_template_editor_template.xml
@@ -35,14 +35,20 @@
         </LinearLayout>
     </ScrollView>
 
-    <com.google.android.material.bottomnavigation.BottomNavigationView
-        android:id="@+id/bottom_navigation"
+    <FrameLayout
+        android:id="@+id/bottom_navigation_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="bottom"
-        style="@style/BottomNavigationViewStyle"
-        android:background="?attr/alternativeBackgroundColor"
-        app:menu="@menu/card_template_editor_navigation_bar_menu"
-        />
+        android:background="?attr/alternativeBackgroundColor">
 
+        <com.google.android.material.bottomnavigation.BottomNavigationView
+            android:id="@+id/bottom_navigation"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            style="@style/BottomNavigationViewStyle"
+            android:background="?attr/alternativeBackgroundColor"
+            app:menu="@menu/card_template_editor_navigation_bar_menu"
+            />
+    </FrameLayout>
 </LinearLayout>

--- a/AnkiDroid/src/main/res/layout/include_card_template_editor_top.xml
+++ b/AnkiDroid/src/main/res/layout/include_card_template_editor_top.xml
@@ -2,9 +2,11 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/toolbar_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:background="?attr/appBarColor">
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar"


### PR DESCRIPTION
## Purpose / Description

Enable edge to edge for CardTemplateEditor. Had to add extra views or specifiy background to fix some visual issue with the gesture bar when the cutout was on the sides. I used the views directly without the binding as I needed to access the views from the inner fragment and the ui structure in that activity is a mess.

API 36 phone, light theme:
<img width="270" height="600" alt="Screenshot_20260830_124830" src="https://github.com/user-attachments/assets/6fbb9ca5-16c8-4620-ab9c-9f8148a96228" /><img width="270" height="600" alt="Screenshot_20260830_124852" src="https://github.com/user-attachments/assets/48e35a22-195d-4422-8b1f-99a7258d2c04" />
<img width="600" height="270" alt="Screenshot_20260830_124842" src="https://github.com/user-attachments/assets/3a066d01-7f9b-4db0-b523-70d4e76ffc15" />
<img width="600" height="270" alt="Screenshot_20260830_124906" src="https://github.com/user-attachments/assets/9daa6a8f-a3af-4624-8785-4f57d8aada69" />

API 36 phone, dark theme:

<img width="270" height="600" alt="Screenshot_20260830_124954" src="https://github.com/user-attachments/assets/04783222-3e6a-43a4-9e32-41534e215a65" />
<img width="600" height="270" alt="Screenshot_20260830_125005" src="https://github.com/user-attachments/assets/48b2dc7c-942b-400a-9b43-41a2d5e2b680" />

API 36 tablet(the camera cutout is mostly on the bottom bar):
<img width="480" height="300" alt="Screenshot_20260830_125054" src="https://github.com/user-attachments/assets/92c982ef-f65d-4d80-80f3-aa052b4b0f85" />
<img width="300" height="480" alt="Screenshot_20260830_125105" src="https://github.com/user-attachments/assets/fd81b99c-18b5-4e34-96fc-dde9a31039ac" />
<img width="480" height="300" alt="Screenshot_20260830_125117" src="https://github.com/user-attachments/assets/417ea93c-32f9-457a-bbc4-7f71aed04fc4" />
<img width="300" height="480" alt="Screenshot_20260830_125125" src="https://github.com/user-attachments/assets/7c66dccb-3615-409c-9396-eb21e8b77c59" />

API 36 phone with the gesture bar:
<img width="270" height="600" alt="Screenshot_20260830_125739" src="https://github.com/user-attachments/assets/7c589434-66fd-46c3-b86f-b00c1d68b38e" />
<img width="600" height="270" alt="Screenshot_20260830_125749" src="https://github.com/user-attachments/assets/c10658a9-f86e-4e8f-b1aa-8cc9f2da13c0" />

API 28:

<img width="308" height="662" alt="Screenshot_20260830_125217" src="https://github.com/user-attachments/assets/1350a7f1-6c65-44c8-bfd6-446938698d66" />
<img width="662" height="309" alt="Screenshot_20260830_125243" src="https://github.com/user-attachments/assets/135d0147-348f-4e1e-b9bc-eff8631adb1c" />
<img width="661" height="308" alt="Screenshot_20260830_125259" src="https://github.com/user-attachments/assets/b9545b0a-3339-4e30-b825-bec15e9c8e79" />


## Fixes
* Fixes #21510

## How Has This Been Tested?

Manually on two emulators: API 28(big notch + navigation bar) and API 36 phone & table(punch hole + navigation bar/gesture bar). No lower API level tablet or emulator tablet but should work.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
