### PR TITLE
refactor(navigation): migrate the small widget to a destination

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/LauncherDestination.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/LauncherDestination.kt
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki
+
+import android.content.Context
+import android.content.Intent
+import com.ichi2.anki.common.destinations.LauncherDestination
+
+/** Builds the [Intent] that opens AnkiDroid's launcher entry point. */
+fun LauncherDestination.toIntent(context: Context): Intent =
+    Intent(context, IntentHandler::class.java).apply {
+        // matches the launcher <intent-filter>, so this behaves like tapping the app icon
+        action = Intent.ACTION_MAIN
+        addCategory(Intent.CATEGORY_LAUNCHER)
+    }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/navigation/AnkiDroidNavigator.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/navigation/AnkiDroidNavigator.kt
@@ -11,6 +11,7 @@ import com.ichi2.anki.common.destinations.ChangelogDestination
 import com.ichi2.anki.common.destinations.CsvImporterDestination
 import com.ichi2.anki.common.destinations.DeckOptionsDestination
 import com.ichi2.anki.common.destinations.Destination
+import com.ichi2.anki.common.destinations.LauncherDestination
 import com.ichi2.anki.common.destinations.Navigator
 import com.ichi2.anki.common.destinations.PreferencesDestination
 import com.ichi2.anki.common.destinations.ReviewDeckDestination
@@ -35,6 +36,7 @@ object AnkiDroidNavigator : Navigator {
             is CsvImporterDestination -> destination.toIntent(navContext)
             is DeckOptionsDestination -> destination.toIntent(navContext)
             is ChangelogDestination -> destination.toIntent(navContext)
+            is LauncherDestination -> destination.toIntent(navContext)
             is PreferencesDestination -> destination.toIntent(navContext)
             is ReviewDeckDestination -> destination.toIntent(navContext)
             is StatisticsDestination -> destination.toIntent(navContext)

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
@@ -20,9 +20,11 @@ import androidx.annotation.LayoutRes
 import androidx.core.app.PendingIntentCompat
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
-import com.ichi2.anki.IntentHandler
 import com.ichi2.anki.R
 import com.ichi2.anki.common.android.appContext
+import com.ichi2.anki.common.destinations.DeferredNavigation
+import com.ichi2.anki.common.destinations.LauncherDestination
+import com.ichi2.anki.common.destinations.toIntent
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.utils.android.SdCard
 import com.ichi2.anki.compat.CompatHelper.Companion.registerReceiverCompat
@@ -164,9 +166,7 @@ class AnkiDroidWidgetSmall : AnalyticsWidgetProvider() {
 
             // Add a click listener to open Anki from the icon.
             // This should be always there, whether there are due cards or not.
-            val ankiDroidIntent = Intent(context, IntentHandler::class.java)
-            ankiDroidIntent.action = Intent.ACTION_MAIN
-            ankiDroidIntent.addCategory(Intent.CATEGORY_LAUNCHER)
+            val ankiDroidIntent = with(DeferredNavigation) { LauncherDestination.toIntent() }
             val pendingAnkiDroidIntent =
                 PendingIntentCompat.getActivity(
                     context,

--- a/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/LauncherDestination.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/common/destinations/LauncherDestination.kt
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.common.destinations
+
+/** Opens AnkiDroid at its launcher entry point, as if the app icon had been tapped. */
+data object LauncherDestination : Destination()


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
> [!NOTE]
> Assisted-by: Claude Opus 5

## Purpose / Description
`AnkiDroidWidgetSmall` built its "open AnkiDroid" click intent by referencing `IntentHandler` directly. That was the widget's last dependency on `:AnkiDroid` other than `R` and `:compat`. (@david-allison I hope it ok here me pushing this)

## Fixes
- Part of #20737

## Approach
See commit

## How Has This Been Tested?
Locally added the widget and launced the app

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->