### PR TITLE
Security fixes for main (from 2.24.1 release)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ViewerResourceHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ViewerResourceHandler.kt
@@ -22,6 +22,7 @@ import android.webkit.WebResourceResponse
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.utils.AssetHelper.guessMimeType
+import com.ichi2.utils.withFileNameSafe
 import timber.log.Timber
 import java.io.ByteArrayInputStream
 import java.io.File
@@ -61,12 +62,7 @@ class ViewerResourceHandler(
                 return WebResourceResponse(guessMimeType(path), null, inputStream)
             }
 
-            val file = File(mediaDir, path)
-            if (!file.canonicalPath.startsWith(mediaDir.canonicalPath + File.separator)) {
-                Timber.w("Path traversal attempt blocked")
-                Timber.d("Path: %s", path)
-                return null
-            }
+            val file = mediaDir.withFileNameSafe(path)
             if (!file.exists()) {
                 return null
             }
@@ -76,6 +72,9 @@ class ViewerResourceHandler(
             val inputStream = FileInputStream(file)
             val mimeType = guessMimeType(path)
             return WebResourceResponse(mimeType, null, inputStream)
+        } catch (e: SecurityException) {
+            Timber.w("Path traversal attempt blocked")
+            return null
         } catch (e: Exception) {
             Timber.d("File not found")
             return null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/TgzPackageExtract.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/TgzPackageExtract.kt
@@ -347,16 +347,29 @@ class TgzPackageExtract(
      * @param outputFile output file
      * @param destDirectory destination directory
      */
-    @Throws(ArchiveException::class, IOException::class)
+    @Throws(ArchiveException::class)
     private fun zipPathSafety(
         outputFile: File,
         destDirectory: File,
     ) {
-        val destDirCanonicalPath = destDirectory.canonicalPath
-        val outputFileCanonicalPath = outputFile.canonicalPath
-
-        if (!outputFileCanonicalPath.startsWith(destDirCanonicalPath)) {
-            throw ArchiveException(context.getString(R.string.malicious_archive_entry_outside, outputFileCanonicalPath))
+        val destCanonical =
+            try {
+                destDirectory.canonicalPath
+            } catch (_: IOException) {
+                // Path may contain PII; removing the %s param would churn translations — use a placeholder.
+                throw ArchiveException(context.getString(R.string.malicious_archive_entry_outside, ARCHIVE_ENTRY_PATH_OMITTED))
+            }
+        val childCanonical =
+            try {
+                outputFile.canonicalPath
+            } catch (_: IOException) {
+                throw ArchiveException(context.getString(R.string.malicious_archive_entry_outside, ARCHIVE_ENTRY_PATH_OMITTED))
+            }
+        val destPrefix = destCanonical + File.separator
+        // Allow the destination directory itself (e.g. `./` entries). Reject anything else
+        // that is not dest and not under dest + separator (sibling-prefix safe).
+        if (childCanonical != destCanonical && !childCanonical.startsWith(destPrefix)) {
+            throw ArchiveException(context.getString(R.string.malicious_archive_entry_outside, ARCHIVE_ENTRY_PATH_OMITTED))
         }
     }
 
@@ -432,5 +445,8 @@ class TgzPackageExtract(
         private const val BUFFER = 512
         private const val TOO_BIG_SIZE: Long = 0x6400000 // max size of unzipped data, 100MB
         private const val TOO_MANY_FILES = 1024 // max number of files
+
+        /** Placeholder for [R.string.malicious_archive_entry_outside]; do not pass real archive paths. */
+        private const val ARCHIVE_ENTRY_PATH_OMITTED = "archive entry"
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorMultimediaController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorMultimediaController.kt
@@ -145,7 +145,8 @@ internal class NoteEditorMultimediaController(
             val canonicalDestFile = destFile.canonicalFile
 
             if (!canonicalDestFile.path.startsWith(canonicalCacheDir.path)) {
-                Timber.w("Rejected path due to directory traversal risk: $fileName")
+                // Do not log the name: it is attacker-controlled and warn logs are reported to ACRA.
+                Timber.w("Rejected path due to directory traversal risk")
                 return null
             }
 

--- a/AnkiDroid/src/main/java/com/ichi2/ui/CollectionMediaImageGetter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/CollectionMediaImageGetter.kt
@@ -93,8 +93,13 @@ class CollectionMediaImageGetter(
                 } else {
                     null
                 }
+            } catch (e: SecurityException) {
+                Timber.w("Path traversal attempt blocked")
+                Timber.d(e, "Path: %s", source)
+                null
             } catch (e: Throwable) {
-                Timber.w(e, "Failed to load deck description image: %s", source)
+                Timber.w("Failed to load deck description image")
+                Timber.d(e, "Failed to load deck description image: %s", source)
                 null
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/ui/CollectionMediaImageGetter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/CollectionMediaImageGetter.kt
@@ -25,6 +25,7 @@ import android.widget.TextView
 import androidx.annotation.CheckResult
 import androidx.core.graphics.drawable.toDrawable
 import com.ichi2.utils.BitmapUtil.decodeSampledBitmap
+import com.ichi2.utils.withFileNameSafe
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -81,13 +82,7 @@ class CollectionMediaImageGetter(
                     return@withContext null
                 }
 
-                val localFile = File(mediaDir, source)
-
-                // Prevent path traversal to ensure file is inside media directory
-                if (!localFile.canonicalPath.startsWith(mediaDir.canonicalPath + File.separator)) {
-                    Timber.w("CollectionMediaImageGetter: Path traversal attempt detected: %s", source)
-                    return@withContext null
-                }
+                val localFile = mediaDir.withFileNameSafe(source)
 
                 if (localFile.exists()) {
                     // Use view width or fallback to screen width

--- a/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.kt
@@ -220,10 +220,12 @@ fun File.withFileNameSafe(childName: String): File {
         val canonicalChild = child.canonicalPath
 
         if (!canonicalChild.startsWith(canonicalParent + File.separator)) {
-            throw SecurityException("Invalid path: $childName traversal attempt detected")
+            // Do not put attacker-controlled paths in exception messages (they are reported to ACRA).
+            throw SecurityException("Path traversal detected")
         }
     } catch (e: IOException) {
-        throw IllegalArgumentException("Unable to resolve canonical path for $childName", e)
+        // Do not put attacker-controlled paths in exception messages (they are reported to ACRA).
+        throw IllegalArgumentException("Unable to resolve canonical path", e)
     }
     return child
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
@@ -169,7 +169,18 @@ object ImportUtils {
             uri: Uri,
         ): String? {
             val filename = validateFileName(getFileNameFromContentProvider(context, uri) ?: return null)
-            val tempFile = File(context.cacheDir, filename)
+            val tempFile =
+                try {
+                    context.cacheDir.withFileNameSafe(filename)
+                } catch (_: SecurityException) {
+                    // Do not log the exception: it may interpolate attacker-controlled paths (PII).
+                    Timber.e("Path traversal detected in getFileCachedCopy")
+                    return null
+                } catch (_: IllegalArgumentException) {
+                    // Do not log the exception: it may interpolate attacker-controlled paths (PII).
+                    Timber.e("Path traversal detected in getFileCachedCopy")
+                    return null
+                }
             return when (val result = copyFileToCache(context, uri, tempFile.absolutePath)) {
                 is CacheFileResult.Success -> result.path
                 else -> null
@@ -239,7 +250,19 @@ object ImportUtils {
 
             // Copy to temporary file
             filename = validateFileName(filename)
-            val tempOutDir: String = Uri.fromFile(File(context.cacheDir, filename)).encodedPath!!
+            val checkFile =
+                try {
+                    context.cacheDir.withFileNameSafe(filename)
+                } catch (_: SecurityException) {
+                    // Do not log the exception: it may interpolate attacker-controlled paths (PII).
+                    Timber.e("Path traversal detected in handleContentProviderFile")
+                    return ImportResult.Failure(context.getString(R.string.import_error_handle_exception, "Invalid path"))
+                } catch (_: IllegalArgumentException) {
+                    // Do not log the exception: it may interpolate attacker-controlled paths (PII).
+                    Timber.e("Path traversal detected in handleContentProviderFile")
+                    return ImportResult.Failure(context.getString(R.string.import_error_handle_exception, "Invalid path"))
+                }
+            val tempOutDir: String = checkFile.absolutePath
 
             copyFileToCache(context, importPathUri, tempOutDir).asErrorDetails()?.let { details ->
                 CrashReportService.sendExceptionReport(details.exceptionForReport, "ImportUtils")
@@ -268,26 +291,42 @@ object ImportUtils {
 
         private fun isAnkiDatabase(filename: String?): Boolean = filename != null && hasExtension(filename, "anki2")
 
+        /**
+         * Uses the last path segment ([File.name]) so directory components cannot escape the
+         * destination. Empty names, `.`, and `..` become `unnamed_file`. Leading dots on a real
+         * filename are preserved (e.g. `.hidden.apkg`, `..apkg`).
+         */
+        @CheckResult
+        private fun sanitizeFileName(fileName: String): String {
+            val sanitized = File(fileName).name
+            return if (sanitized.isEmpty() || sanitized == "." || sanitized == "..") {
+                "unnamed_file"
+            } else {
+                sanitized
+            }
+        }
+
         @NeedsTest("Add test for the fallback, ensure the fallback filename \"file_<timestamp>.<ext>\" is produced when decoding fails")
         private fun validateFileName(fileName: String): String {
             // #6137 - filenames can be too long when URLEncoded
+            val sanitized = sanitizeFileName(fileName)
             return try {
-                val encoded = URLEncoder.encode(fileName, "UTF-8")
+                val encoded = URLEncoder.encode(sanitized, "UTF-8")
                 if (encoded.length <= FILE_NAME_SHORTENING_THRESHOLD) {
                     Timber.d("No filename truncation necessary")
-                    fileName
+                    sanitized
                 } else {
                     Timber.d("Filename was longer than %d, shortening", FILE_NAME_SHORTENING_THRESHOLD)
                     // take 90 instead of 100 so we don't get the extension
                     val substringLength = FILE_NAME_SHORTENING_THRESHOLD - 10
                     val shortenedFileName = encoded.take(substringLength) + "..." + getExtension(fileName)
-                    Timber.d("Shortened filename '%s' to '%s'", fileName, shortenedFileName)
+                    Timber.d("Shortened filename")
                     // if we don't decode, % is double-encoded
-                    URLDecoder.decode(shortenedFileName, "UTF-8")
+                    sanitizeFileName(URLDecoder.decode(shortenedFileName, "UTF-8"))
                 }
             } catch (e: Exception) {
-                Timber.w(e, "Failed to shorten file: %s", fileName)
-                "file_${TimeManager.time.intTimeMS()}.${getExtension(fileName)}"
+                Timber.w(e, "Failed to shorten file")
+                sanitizeFileName("file_${TimeManager.time.intTimeMS()}.${getExtension(fileName)}")
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
@@ -262,7 +262,7 @@ object ImportUtils {
                     Timber.e("Path traversal detected in handleContentProviderFile")
                     return ImportResult.Failure(context.getString(R.string.import_error_handle_exception, "Invalid path"))
                 }
-            val tempOutDir: String = checkFile.absolutePath
+            val tempOutDir: String = Uri.fromFile(checkFile).encodedPath!!
 
             copyFileToCache(context, importPathUri, tempOutDir).asErrorDetails()?.let { details ->
                 CrashReportService.sendExceptionReport(details.exceptionForReport, "ImportUtils")

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ViewerResourceHandlerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ViewerResourceHandlerTest.kt
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki
+
+import android.webkit.WebResourceRequest
+import androidx.core.net.toUri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.common.storage.CollectionHelper
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@RunWith(AndroidJUnit4::class)
+class ViewerResourceHandlerTest : RobolectricTest() {
+    private val mediaDir: File
+        get() = CollectionHelper.getMediaDirectory(targetContext).apply { mkdirs() }
+
+    @Test
+    fun `file in the media directory is served`() {
+        File(mediaDir, "hello.txt").writeText("hello")
+
+        val response = ViewerResourceHandler(targetContext).shouldInterceptRequest(request("/hello.txt"))
+
+        assertEquals("hello", assertNotNull(response).data.reader().readText())
+    }
+
+    @Test
+    fun `path traversal outside the media directory is blocked`() {
+        File(mediaDir.parentFile, "outside.txt").writeText("secret")
+
+        val response = ViewerResourceHandler(targetContext).shouldInterceptRequest(request("/../outside.txt"))
+
+        assertNull(response, "a request escaping the media directory must not be served")
+    }
+
+    private fun request(path: String): WebResourceRequest =
+        mock {
+            on { url } doReturn "http://127.0.0.1$path".toUri()
+            on { method } doReturn "GET"
+            on { requestHeaders } doReturn emptyMap()
+        }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.kt
@@ -20,14 +20,18 @@ import org.acra.util.IOUtils.writeStringToFile
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsEqual.equalTo
+import org.junit.Assume.assumeTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
 import java.io.IOException
+import java.nio.file.FileSystems
+import java.nio.file.Files
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.test.fail
 
 class FileUtilTest {
     @get:Rule
@@ -155,4 +159,108 @@ class FileUtilTest {
      * Destructuring doesn't work on a `FileNameAndExtension?`
      * */
     private fun getValidFileNameAndExtension(input: String) = assertNotNull(FileNameAndExtension.fromString(input))
+
+    @Test
+    @Throws(Exception::class)
+    fun `withFileNameSafe - valid child file returns File`() {
+        val parentDir = temporaryDirectory.newFolder("parent")
+        val result = parentDir.withFileNameSafe("child.txt")
+        assertEquals(File(parentDir, "child.txt"), result)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun `withFileNameSafe - nested valid child returns File`() {
+        val parentDir = temporaryDirectory.newFolder("parent")
+        val result = parentDir.withFileNameSafe("subdir/nested/file.txt")
+        assertEquals(File(parentDir, "subdir/nested/file.txt"), result)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun `withFileNameSafe path traversal with dotdot throws SecurityException`() {
+        val parentDir = temporaryDirectory.newFolder("parent")
+        try {
+            parentDir.withFileNameSafe("../outside.txt")
+            fail("Expected SecurityException for path traversal")
+        } catch (e: SecurityException) {
+            assertTrue(e.message!!.contains("traversal"))
+        }
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun `withFileNameSafe double dotdot traversal throws SecurityException`() {
+        val parentDir = temporaryDirectory.newFolder("parent")
+        try {
+            parentDir.withFileNameSafe("../foo/../../outside.txt")
+            fail("Expected SecurityException for path traversal")
+        } catch (e: SecurityException) {
+            assertTrue(e.message!!.contains("traversal"))
+        }
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun `withFileNameSafe child named same as parent in different location throws SecurityException`() {
+        val parentDir = temporaryDirectory.newFolder("parent")
+        val siblingDir = temporaryDirectory.newFolder("sibling_parent")
+        // Create a file at sibling_dir/parent to test the boundary case
+        File(siblingDir, "parent").mkdirs()
+        try {
+            parentDir.withFileNameSafe("../sibling_parent/parent/file.txt")
+            fail("Expected SecurityException for same-name traversal")
+        } catch (e: SecurityException) {
+            assertTrue(e.message!!.contains("traversal"))
+        }
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun `withFileNameSafe - file named like parent but not traversing stays in place`() {
+        val parentDir = temporaryDirectory.newFolder("parent")
+        // A file literally named "parent" inside the directory should be valid
+        val result = parentDir.withFileNameSafe("parent")
+        assertEquals(File(parentDir, "parent"), result)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun `withFileNameSafe sibling prefix parentfoo is rejected`() {
+        val root = temporaryDirectory.root
+        val parentDir = File(root, "parent").apply { mkdirs() }
+        File(root, "parentfoo").mkdirs()
+        try {
+            parentDir.withFileNameSafe("../parentfoo/evil.txt")
+            fail("Expected SecurityException for sibling-prefix traversal")
+        } catch (e: SecurityException) {
+            assertTrue(e.message!!.contains("traversal"))
+        }
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun `withFileNameSafe symlink escape throws SecurityException`() {
+        assumeTrue(
+            "Symlink test requires POSIX file attributes",
+            FileSystems.getDefault().supportedFileAttributeViews().contains("posix"),
+        )
+        val parentDir = temporaryDirectory.newFolder("symlinkParent")
+        val outsideDir = temporaryDirectory.newFolder("symlinkOutside")
+        val target = File(outsideDir, "secret.txt").apply { writeText("secret") }
+        val link = File(parentDir, "link").toPath()
+        try {
+            Files.createSymbolicLink(link, target.toPath())
+        } catch (e: UnsupportedOperationException) {
+            assumeTrue("Could not create symlink: ${e.message}", false)
+        } catch (e: IOException) {
+            assumeTrue("Could not create symlink: ${e.message}", false)
+        }
+        try {
+            parentDir.withFileNameSafe("link")
+            fail("Expected SecurityException for symlink escape")
+        } catch (e: SecurityException) {
+            assertTrue(e.message!!.contains("traversal"))
+        }
+    }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.kt
@@ -30,7 +30,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.endsWith
 import org.hamcrest.Matchers.lessThanOrEqualTo
-import org.hamcrest.Matchers.startsWith
+import org.hamcrest.Matchers.not
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -44,19 +44,17 @@ import java.io.File
 @RunWith(AndroidJUnit4::class)
 class ImportUtilsTest : RobolectricTest() {
     @Test
-    fun cjkNamesAreImportedUnderCacheDir() {
-        // Regression for filenames that previously crashed when building cache paths.
+    fun cjkNamesAreConvertedToUnicode() {
+        // NOTE: I don't know whether this still needs to exist, but it was added as this previously crashes
+        // and I would have added a regression without checking the history.
         // https://github.com/ankidroid/Anki-Android/commit/ed06954c8c678024e2fce25c19bd6cdaf0120260#diff-8eefa7f7b20c936f007c934965238520R58
+
         val inputFileName = "好.apkg"
-        val cachePrefix = targetContext.cacheDir.canonicalPath + File.separator
 
         val actualFilePath = importValidFile(inputFileName)
 
-        assertThat(
-            File(actualFilePath).canonicalPath,
-            startsWith(cachePrefix),
-        )
-        assertThat(actualFilePath, endsWith("${File.separator}好.apkg"))
+        assertThat("Unicode character should be stripped", actualFilePath, not(containsString("好")))
+        assertThat("Unicode character should be urlencoded", actualFilePath, endsWith("%E5%A5%BD.apkg"))
     }
 
     @Test
@@ -69,8 +67,9 @@ class ImportUtilsTest : RobolectricTest() {
 
         assertThat(actualFilePath, endsWith(".apkg"))
         assertThat(actualFilePath, containsString("..."))
-        val fileName = File(actualFilePath).name
-        assertThat(fileName, containsString("好"))
+        // Obtain the filename from the path
+        assertThat(actualFilePath, containsString("%E5%A5%BD"))
+        val fileName = actualFilePath.substringAfter("%E5%A5%BD")
         assertThat(fileName.length, lessThanOrEqualTo(100))
     }
 
@@ -86,8 +85,7 @@ class ImportUtilsTest : RobolectricTest() {
     @Test
     fun pathTraversalInFileNameIsRejected() {
         // GHSA-q29p-h3pp-mh3v — Path traversal via import DISPLAY_NAME should be blocked
-        val cacheDir = targetContext.cacheDir
-        val cachePrefix = cacheDir.canonicalPath + File.separator
+        val cacheDir = targetContext.cacheDir.canonicalFile
         val maliciousFilenames =
             listOf(
                 "../etc/passwd.apkg",
@@ -103,10 +101,12 @@ class ImportUtilsTest : RobolectricTest() {
             val result = testFileImporter.handleFileImport(targetContext, intent)
             assertTrue("Import should succeed after basename sanitization: $maliciousFilename", result is ImportResult.Success)
 
-            val cachedCanonical = File(testFileImporter.cacheFileName).canonicalPath
-            assertTrue(
-                "Cached file must remain under cacheDir ($cachePrefix): $maliciousFilename -> $cachedCanonical",
-                cachedCanonical.startsWith(cachePrefix),
+            // the cached path is Uri-encoded (see handleContentProviderFile): decode it before resolving it on disk
+            val cachedFile = File(Uri.decode(testFileImporter.cacheFileName)).canonicalFile
+            assertEquals(
+                "Cached file must be a direct child of cacheDir: $maliciousFilename -> $cachedFile",
+                cacheDir,
+                cachedFile.parentFile,
             )
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.kt
@@ -30,7 +30,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.endsWith
 import org.hamcrest.Matchers.lessThanOrEqualTo
-import org.hamcrest.Matchers.not
+import org.hamcrest.Matchers.startsWith
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -44,17 +44,19 @@ import java.io.File
 @RunWith(AndroidJUnit4::class)
 class ImportUtilsTest : RobolectricTest() {
     @Test
-    fun cjkNamesAreConvertedToUnicode() {
-        // NOTE: I don't know whether this still needs to exist, but it was added as this previously crashes
-        // and I would have added a regression without checking the history.
+    fun cjkNamesAreImportedUnderCacheDir() {
+        // Regression for filenames that previously crashed when building cache paths.
         // https://github.com/ankidroid/Anki-Android/commit/ed06954c8c678024e2fce25c19bd6cdaf0120260#diff-8eefa7f7b20c936f007c934965238520R58
-
         val inputFileName = "好.apkg"
+        val cachePrefix = targetContext.cacheDir.canonicalPath + File.separator
 
         val actualFilePath = importValidFile(inputFileName)
 
-        assertThat("Unicode character should be stripped", actualFilePath, not(containsString("好")))
-        assertThat("Unicode character should be urlencoded", actualFilePath, endsWith("%E5%A5%BD.apkg"))
+        assertThat(
+            File(actualFilePath).canonicalPath,
+            startsWith(cachePrefix),
+        )
+        assertThat(actualFilePath, endsWith("${File.separator}好.apkg"))
     }
 
     @Test
@@ -67,9 +69,8 @@ class ImportUtilsTest : RobolectricTest() {
 
         assertThat(actualFilePath, endsWith(".apkg"))
         assertThat(actualFilePath, containsString("..."))
-        // Obtain the filename from the path
-        assertThat(actualFilePath, containsString("%E5%A5%BD"))
-        val fileName = actualFilePath.substringAfter("%E5%A5%BD")
+        val fileName = File(actualFilePath).name
+        assertThat(fileName, containsString("好"))
         assertThat(fileName.length, lessThanOrEqualTo(100))
     }
 
@@ -80,6 +81,34 @@ class ImportUtilsTest : RobolectricTest() {
 
         // COULD_BE_BETTER: Strip off the file path
         return testFileImporter.cacheFileName
+    }
+
+    @Test
+    fun pathTraversalInFileNameIsRejected() {
+        // GHSA-q29p-h3pp-mh3v — Path traversal via import DISPLAY_NAME should be blocked
+        val cacheDir = targetContext.cacheDir
+        val cachePrefix = cacheDir.canonicalPath + File.separator
+        val maliciousFilenames =
+            listOf(
+                "../etc/passwd.apkg",
+                "..\\windows\\system32\\config.sam.apkg",
+                "../../../../../../../../../etc/passwd.apkg",
+                "..\\..\\..\\passwd.apkg",
+                "normal.apkg",
+            )
+
+        for (maliciousFilename in maliciousFilenames) {
+            val testFileImporter = TestFileImporter(maliciousFilename)
+            val intent = getValidClipDataUri(maliciousFilename)
+            val result = testFileImporter.handleFileImport(targetContext, intent)
+            assertTrue("Import should succeed after basename sanitization: $maliciousFilename", result is ImportResult.Success)
+
+            val cachedCanonical = File(testFileImporter.cacheFileName).canonicalPath
+            assertTrue(
+                "Cached file must remain under cacheDir ($cachePrefix): $maliciousFilename -> $cachedCanonical",
+                cachedCanonical.startsWith(cachePrefix),
+            )
+        }
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.kt
@@ -92,6 +92,8 @@ class ImportUtilsTest : RobolectricTest() {
                 "..\\windows\\system32\\config.sam.apkg",
                 "../../../../../../../../../etc/passwd.apkg",
                 "..\\..\\..\\passwd.apkg",
+                "%2e%2e%2fetc%2fpasswd.apkg", // percent-encoded traversal: File does not decode it
+                "....apkg",
                 "normal.apkg",
             )
 
@@ -108,6 +110,22 @@ class ImportUtilsTest : RobolectricTest() {
                 cacheDir,
                 cachedFile.parentFile,
             )
+        }
+    }
+
+    @Test
+    fun leadingDotFilenamesAreNotStripped() {
+        for (fileName in listOf(".hidden.apkg", "..apkg")) {
+            val actualFilePath = importValidFile(fileName)
+            assertEquals(fileName, File(Uri.decode(actualFilePath)).name)
+        }
+    }
+
+    @Test
+    fun getFileCachedCopyUsesUnnamedFileForEmptyDotAndDotDot() {
+        for (fileName in listOf("", ".", "..")) {
+            val actualFilepath = TestFileImporter(fileName).getFileCachedCopy(targetContext, "dummy".toUri())
+            assertEquals(File(targetContext.cacheDir, "unnamed_file").absolutePath, actualFilepath)
         }
     }
 


### PR DESCRIPTION
## Summary

Backport two security fixes already released in 2.24.1 (and on the 2.16/2.19 release lines) to `main`:

- **Import path traversal** — sanitize filenames when copying shared content into the app cache (`GHSA-q29p-h3pp-mh3v`)
- **Path traversal hardening** — centralize safe filename handling at remaining sinks; block media traversal without logging paths

## Notes

- No Play `retain.artifacts` changes: 2.16.6 / 2.19.6 APKs were not formally published and cannot be retained on the current track.
- `main` already retains the previously published 2.16.3 / 2.19.5 ABI splits.

## Test plan

- [ ] CI green
- [ ] `ViewerResourceHandlerPathTraversalTest` and import path traversal tests pass