### PR TITLE
fix(note-editor): edge to edge - lower toolbar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -155,7 +155,7 @@ import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.ui.setupNoteTypeSpinner
 import com.ichi2.anki.utils.RunOnlyOnce
-import com.ichi2.anki.utils.bottomCornerClearance
+import com.ichi2.anki.utils.bottomCornerSideClearance
 import com.ichi2.anki.utils.doOnApplyWindowInsets
 import com.ichi2.anki.utils.ext.requireLong
 import com.ichi2.anki.utils.ext.sharedPrefs
@@ -2225,10 +2225,16 @@ class NoteEditorFragment :
     }
 
     private fun setupEdgeToEdge() {
-        ViewCompat.setOnApplyWindowInsetsListener(binding.rootLayout) { root, insets ->
+        ViewCompat.setOnApplyWindowInsetsListener(binding.rootLayout) { _, insets ->
             val bars = insets.paneInsets()
-            bottomInsetPx = maxOf(bars.bottom, insets.bottomCornerClearance(root))
+            bottomInsetPx = bars.bottom
             toolbar.updatePadding(left = bars.left, right = bars.right)
+            // move the toolbar as low as possible, without being impacted by rounded corners
+            val corners = insets.bottomCornerSideClearance(bars.bottom)
+            toolbar.setSideClearance(
+                left = if (inCardBrowserActivity) 0 else (corners.left - bars.left).coerceAtLeast(0),
+                right = if (noteEditorActivity?.fragmented == true) 0 else (corners.right - bars.right).coerceAtLeast(0),
+            )
             applyBottomInset()
             insets
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -23,6 +23,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.WindowInsets
 import android.widget.FrameLayout
+import android.widget.HorizontalScrollView
 import android.widget.LinearLayout
 import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
@@ -33,6 +34,7 @@ import androidx.core.graphics.createBitmap
 import androidx.core.graphics.drawable.toDrawable
 import androidx.core.view.children
 import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import com.ichi2.anki.NoteEditorFragment
 import com.ichi2.anki.R
@@ -66,6 +68,7 @@ class Toolbar : FrameLayout {
     var formatListener: TextFormatListener? = null
     private val toolbar: LinearLayout
     private val toolbarLayout: LinearLayout
+    private val scrollView: HorizontalScrollView
 
     /** A list of buttons, typically user-defined which modify text + selection */
     private val customButtons: MutableList<View> = ArrayList()
@@ -93,7 +96,19 @@ class Toolbar : FrameLayout {
             }
         toolbar = findViewById(R.id.editor_toolbar_internal)
         toolbarLayout = findViewById(R.id.toolbar_layout)
+        scrollView = findViewById(R.id.toolbar_scrollview)
         setupDefaultButtons()
+    }
+
+    /**
+     * Insets the ends of the button row, keeping buttons which rest there clear of the bottom
+     *  rounded display corners; buttons scroll beneath the clearance.
+     */
+    fun setSideClearance(
+        left: Int,
+        right: Int,
+    ) {
+        scrollView.updatePadding(left = left, right = right)
     }
 
     /** Sets up the "standard" buttons to insert bold, italics etc... */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/Insets.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/Insets.kt
@@ -11,6 +11,8 @@ import androidx.core.view.marginBottom
 import androidx.core.view.marginLeft
 import androidx.core.view.marginRight
 import androidx.core.view.marginTop
+import kotlin.math.ceil
+import kotlin.math.sqrt
 
 /** [Insets.of], with named arguments */
 fun insetsOf(
@@ -47,6 +49,30 @@ fun WindowInsetsCompat.bottomCornerClearance(view: View): Int {
     // `r - sqrt(r² - (r - d)²)` of vertical clearance, and `r - d` is never less (a chord vs the
     // arc), so the content never dips into the corner.
     return (bottomRoundedCornerRadius - endInset).coerceAtLeast(0)
+}
+
+/**
+ * The horizontal clearance, per side, which keeps the ends of a bottom-anchored row clear of the
+ *  bottom rounded display corners.
+ *
+ * A row resting [bottomInset] above the screen bottom ends `r - bottomInset` below where a
+ *  corner's arc begins, and there the arc reaches `r - sqrt(r² - (r - bottomInset)²)` in from the
+ *  screen edge. Content at least that far inboard clears the arc at every height it occupies.
+ *
+ * The clearance is measured from the screen edge: subtract any side inset already applied to
+ *  the row.
+ */
+fun WindowInsetsCompat.bottomCornerSideClearance(bottomInset: Int): Insets {
+    fun clearance(position: Int): Int {
+        val radius = getRoundedCorner(position)?.radius ?: 0
+        val depth = radius - bottomInset
+        if (depth <= 0) return 0
+        return ceil(radius - sqrt((radius.toDouble() * radius) - (depth.toDouble() * depth))).toInt()
+    }
+    return insetsOf(
+        left = clearance(RoundedCornerCompat.POSITION_BOTTOM_LEFT),
+        right = clearance(RoundedCornerCompat.POSITION_BOTTOM_RIGHT),
+    )
 }
 
 /**

--- a/AnkiDroid/src/main/res/layout/view_note_editor_toolbar.xml
+++ b/AnkiDroid/src/main/res/layout/view_note_editor_toolbar.xml
@@ -7,6 +7,7 @@
     android:id="@+id/toolbar_scrollview"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:clipToPadding="false"
     android:scrollbarStyle="insideOverlay"
     android:scrollbars="horizontal">
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorInsetsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorInsetsTest.kt
@@ -5,6 +5,7 @@ package com.ichi2.anki
 import android.os.Build
 import android.view.View
 import android.view.ViewGroup.MarginLayoutParams
+import android.widget.HorizontalScrollView
 import androidx.core.content.edit
 import androidx.core.view.RoundedCornerCompat
 import androidx.core.view.ViewCompat
@@ -143,19 +144,68 @@ class NoteEditorInsetsTest : RobolectricTest() {
     }
 
     @Test
-    fun `the formatting toolbar clears rounded display corners larger than the navigation bar`() =
+    fun `rounded corners inset the button row's ends, not the toolbar's height`() =
         withNoteEditor { activity ->
-            activity.dispatchInsets(navBarBottom = 24.dp, bottomCornerRadius = 48.dp)
+            activity.dispatchInsets(navBarBottom = 20.dp, bottomCornerRadius = 50.dp)
 
-            assertThat(activity.formattingToolbar.paddingBottom, equalTo(48.dp.toPx(targetContext)))
+            assertThat(
+                "the toolbar rests on the navigation bar, not above the corners",
+                activity.formattingToolbar.paddingBottom,
+                equalTo(20.dp.toPx(targetContext)),
+            )
+            // the arc reaches r - √(r² - (r - inset)²) = 50 - √(50² - 30²) = 10dp into the row
+            assertThat(activity.formattingToolbarRow.paddingLeft, equalTo(10.dp.toPx(targetContext)))
+            assertThat(activity.formattingToolbarRow.paddingRight, equalTo(10.dp.toPx(targetContext)))
+            assertThat(
+                "buttons scroll beneath the clearance, only resting clear of the corners",
+                activity.formattingToolbarRow.clipToPadding,
+                equalTo(false),
+            )
         }
 
     @Test
-    fun `a side navigation bar clearing the corner removes the bottom buffer`() =
+    fun `a side navigation bar clearing the corner takes the place of the row's clearance`() =
         withNoteEditor { activity ->
             activity.dispatchInsets(navBarRight = 48.dp, bottomCornerRadius = 34.dp)
 
             assertThat(activity.formattingToolbar.paddingBottom, equalTo(0))
+            assertThat(
+                "at the screen bottom the arc spans its full radius, all on the bare side",
+                activity.formattingToolbarRow.paddingLeft,
+                equalTo(34.dp.toPx(targetContext)),
+            )
+            assertThat(
+                "the navigation bar already pushes the row past the corner",
+                activity.formattingToolbarRow.paddingRight,
+                equalTo(0),
+            )
+        }
+
+    @Test
+    fun `the keyboard lifts the button row clear of the corners`() =
+        withNoteEditor { activity ->
+            activity.dispatchInsets(navBarBottom = 24.dp, bottomCornerRadius = 48.dp, imeBottom = 300.dp)
+
+            assertThat(activity.formattingToolbar.paddingBottom, equalTo(300.dp.toPx(targetContext)))
+            assertThat(activity.formattingToolbarRow.paddingLeft, equalTo(0))
+            assertThat(activity.formattingToolbarRow.paddingRight, equalTo(0))
+        }
+
+    @Test
+    fun `the two-pane editor only clears the corner on its outer edge`() =
+        withTabletNoteEditor { activity ->
+            activity.dispatchInsets(cutoutLeft = 32.dp, bottomCornerRadius = 48.dp)
+
+            assertThat(
+                "the cutout inset already covers part of the full-radius arc",
+                activity.formattingToolbarRow.paddingLeft,
+                equalTo((48 - 32).dp.toPx(targetContext)),
+            )
+            assertThat(
+                "the divider side borders no corner",
+                activity.formattingToolbarRow.paddingRight,
+                equalTo(0),
+            )
         }
 
     @Test
@@ -212,6 +262,9 @@ class NoteEditorInsetsTest : RobolectricTest() {
 
     private val NoteEditorActivity.formattingToolbar: View get() = findViewById(R.id.editor_toolbar)
 
+    /** The scrolling row of buttons inside [formattingToolbar] */
+    private val NoteEditorActivity.formattingToolbarRow: HorizontalScrollView get() = findViewById(R.id.toolbar_scrollview)
+
     private val NoteEditorActivity.editorFields: View get() = findViewById(R.id.note_editor_layout)
 
     private val NoteEditorActivity.fragmentRoot: View get() = getNoteEditorFragment().requireView()
@@ -233,12 +286,13 @@ class NoteEditorInsetsTest : RobolectricTest() {
                     .setInsets(displayCutout(), insetsOf(left = cutoutLeft))
                     .setInsets(ime(), insetsOf(bottom = imeBottom))
                     .apply {
+                        // Robolectric's WindowInsets.Builder leaks rounded corners between tests
                         val radius = bottomCornerRadius.toPx(targetContext)
-                        if (radius > 0) {
-                            setRoundedCorner(
-                                RoundedCornerCompat.POSITION_BOTTOM_LEFT,
-                                RoundedCornerCompat(RoundedCornerCompat.POSITION_BOTTOM_LEFT, radius, radius, radius),
-                            )
+                        for (position in intArrayOf(
+                            RoundedCornerCompat.POSITION_BOTTOM_LEFT,
+                            RoundedCornerCompat.POSITION_BOTTOM_RIGHT,
+                        )) {
+                            setRoundedCorner(position, RoundedCornerCompat(position, radius, radius, radius))
                         }
                     }.build()
             }


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Assisted-by: Claude Fable 5

## Purpose / Description
After 7a0baf7de789c9cd82116b5e5fb8a7d8f9e08309 the toolbar was higher when using gesture navigation.

## Fixes
* Fixup of https://github.com/ankidroid/Anki-Android/pull/21596
* Fixes https://github.com/ankidroid/Anki-Android/issues/21503
* Part of https://github.com/ankidroid/Anki-Android/issues/17334

## Approach
Use a more accurate function and focus on horizontal clearance, rather than vertically clearing the rounded corners.

## How Has This Been Tested?
My Pixel 9 Pro, API 37

🚧 Screenshot tests should do the work here.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)