### PR TITLE
build(ci): screenshots - retry Gradle network fetches

### DIFF
--- a/.github/workflows/screenshot_compare.yml
+++ b/.github/workflows/screenshot_compare.yml
@@ -56,6 +56,15 @@ jobs:
           cache-provider: basic
           gradle-version: wrapper
 
+      - name: Warm Gradle Cache
+        # This makes sure we fetch gradle network resources with a retry
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 10
+          retry_wait_seconds: 60
+          max_attempts: 3
+          command: ./gradlew robolectricSdkDownload :AnkiDroid:compilePlayDebugUnitTestKotlin -Pscreenshot --daemon
+
       - name: Download base branch screenshots
         uses: dawidd6/action-download-artifact@d63b86af1b34672e53c440b1b83979861906bad7 # v24
         continue-on-error: true

--- a/.github/workflows/screenshot_store.yml
+++ b/.github/workflows/screenshot_store.yml
@@ -69,6 +69,16 @@ jobs:
           cache-provider: basic
           gradle-version: wrapper
 
+      - name: Warm Gradle Cache
+        # This makes sure we fetch gradle network resources with a retry
+        # TODO: --rerun-tasks in 'Record screenshots' discards the compilation performed here
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 10
+          retry_wait_seconds: 60
+          max_attempts: 3
+          command: ./gradlew robolectricSdkDownload :AnkiDroid:compilePlayDebugUnitTestKotlin -Pscreenshot --daemon
+
       - name: Record screenshots
         id: record-test
         run: |


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

## Fixes
* Fixes https://github.com/ankidroid/Anki-Android/issues/21682


## Approach
Mirrors the 'Warm Gradle Cache' pattern from tests_emulator.yml.

## How Has This Been Tested?
⚠️ CI will tell

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)