### PR TITLE
fix(card-browser): don't lose search state on cancelled emit

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -70,6 +70,7 @@ import com.ichi2.anki.utils.ext.setUserFlagForCards
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -142,7 +143,11 @@ class CardBrowserViewModel(
 
     val cards = BrowserRowCollection(CARDS, mutableListOf())
 
-    val flowOfSearchState = MutableSharedFlow<SearchState>()
+    val flowOfSearchState =
+        MutableSharedFlow<SearchState>(
+            extraBufferCapacity = 1,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
 
     /**
      * Commands to drive the note editor either in a fragment or a standalone activity

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -78,13 +78,21 @@ import com.ichi2.testutils.ensureOpWithHandler
 import com.ichi2.testutils.ensureOpsExecuted
 import com.ichi2.testutils.ext.reopenWithLanguage
 import com.ichi2.testutils.mockIt
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.containsInAnyOrder
 import org.hamcrest.Matchers.empty
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.greaterThanOrEqualTo
+import org.hamcrest.Matchers.hasItem
 import org.hamcrest.Matchers.hasSize
 import org.hamcrest.Matchers.instanceOf
 import org.hamcrest.Matchers.lessThan
@@ -1820,6 +1828,41 @@ class CardBrowserViewModelTest : JvmTest() {
 
                 expectMostRecentItem()
             }
+        }
+
+    @Test
+    fun `search state is not lost when a cancelled search emits`() =
+        runViewModelTest {
+            // launchSearchForCards cancels the previous search job, which may emit its
+            // search state after cancellation. On a zero-capacity SharedFlow this corrupts
+            // the flow and later emissions are lost (kotlinx.coroutines#4681).
+            val scheduler = TestCoroutineScheduler()
+            val scope = CoroutineScope(StandardTestDispatcher(scheduler))
+            val received = mutableListOf<SearchState>()
+            val collector = scope.launch { flowOfSearchState.collect { received += it } }
+            scheduler.runCurrent()
+
+            val cancelledSearch =
+                scope.launch {
+                    try {
+                        awaitCancellation()
+                    } catch (e: CancellationException) {
+                        flowOfSearchState.emit(SearchState.Searching)
+                        throw e
+                    }
+                }
+            scheduler.runCurrent()
+            cancelledSearch.cancel()
+
+            val liveState = SearchState.Error("from the next search")
+            val liveSearch = scope.launch { flowOfSearchState.emit(liveState) }
+            scheduler.runCurrent()
+
+            assertThat("state from an active search reaches collectors", received, hasItem(liveState))
+
+            liveSearch.cancel()
+            collector.cancel()
+            scope.cancel()
         }
 
     @Test


### PR DESCRIPTION


> [!NOTE]
> Assisted-by: Assisted-by: Claude Fable 5 (test)

## Purpose / Description
The Card Browser's search status sometimes stops updating, and `CardBrowserInsetsTest` flakes in CI with an `AssertionError` from deep inside `SharedFlowImpl`.
- an upstream coroutines bug, [Kotlin/kotlinx.coroutines#4681](https://github.com/Kotlin/kotlinx.coroutines/issues/4681)

## Fixes
* Fixes #21661

## Approach
refer commit

## How Has This Been Tested?
Unit testing

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->