### PR TITLE
 Avoid eager materialization of /cards search results

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -379,6 +379,118 @@ class ContentProviderTest : InstrumentedTest() {
     }
 
     @Test
+    fun testSearchCards_fillWindowCopiesAllRows() {
+        val note = addTempClozeNote("{{c1::A}} {{c2::B}}")
+        assertThat("sanity check", note.numberOfCards(col), greaterThan(1))
+
+        val cursor =
+            contentResolver.query(
+                FlashCardsContract.Card.CONTENT_URI,
+                null,
+                "nid:${note.id}",
+                null,
+                null,
+            )
+
+        assertNotNull(cursor)
+        cursor.use {
+            val window = CursorWindow("test")
+            val initialPosition = it.position
+            cursorFillWindow(it, 0, window)
+            assertThat("position should not change", it.position, equalTo(initialPosition))
+            assertThat("Count should be copied", window.numRows, equalTo(it.count))
+        }
+    }
+
+    @Test
+    fun testSearchCards_randomAccessIsStable() {
+        val note = addTempClozeNote("{{c1::A}} {{c2::B}}")
+        assertThat("sanity check", note.numberOfCards(col), greaterThan(1))
+
+        val cursor =
+            contentResolver.query(
+                FlashCardsContract.Card.CONTENT_URI,
+                null,
+                "nid:${note.id}",
+                null,
+                null,
+            )
+
+        assertNotNull(cursor)
+        cursor.use {
+            fun rowAt(position: Int): List<String?> {
+                assertTrue("move to $position", it.moveToPosition(position))
+                return (0 until it.columnCount).map { column -> it.getString(column) }
+            }
+
+            val forwards = (0 until it.count).map { position -> rowAt(position) }
+            assertThat("sanity check", forwards.size, greaterThan(1))
+
+            for (position in it.count - 1 downTo 0) {
+                assertEquals("row $position read backwards", forwards[position], rowAt(position))
+            }
+            assertEquals("row 0 re-read", forwards[0], rowAt(0))
+            assertEquals("row 0 read twice in a row", forwards[0], rowAt(0))
+        }
+    }
+
+    @Test
+    fun testSearchCards_rowOfCardDeletedAfterQueryIsNull() {
+        val note = addTempClozeNote("{{c1::A}} {{c2::B}}")
+        assertThat("sanity check", note.numberOfCards(col), greaterThan(1))
+
+        val cursor =
+            contentResolver.query(
+                FlashCardsContract.Card.CONTENT_URI,
+                null,
+                "nid:${note.id}",
+                null,
+                null,
+            )
+
+        assertNotNull(cursor)
+        cursor.use {
+            val cardIds = mutableListOf<Long>()
+            val idColumn = it.getColumnIndexOrThrow(FlashCardsContract.Card._ID)
+            while (it.moveToNext()) {
+                cardIds.add(it.getLong(idColumn))
+            }
+            assertThat("sanity check", cardIds.size, greaterThan(1))
+
+            col.removeNotes(noteIds = listOf(note.id))
+
+            for (position in cardIds.indices) {
+                assertTrue("move to $position", it.moveToPosition(position))
+                assertEquals("_id of a deleted card", cardIds[position], it.getLong(idColumn))
+                for (column in 0 until it.columnCount) {
+                    if (column == idColumn) continue
+                    assertTrue(
+                        "column ${it.getColumnName(column)} of a deleted card is null",
+                        it.isNull(column),
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    @Suppress("Recycle")
+    fun testSearchCards_unknownColumnThrowsFromQuery() {
+        val exception =
+            assertThrows<UnsupportedOperationException> {
+                contentResolver.query(
+                    FlashCardsContract.Card.CONTENT_URI,
+                    arrayOf(FlashCardsContract.Card._ID, "not_a_column"),
+                    null,
+                    null,
+                    null,
+                )
+            }
+
+        assertThat(exception.message, containsString("not_a_column"))
+    }
+
+    @Test
     fun testQueryCardById() {
         val card = getFirstCardFromScheduler(col)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -65,6 +65,7 @@ import com.ichi2.utils.FileUtil.internalizeUri
 import com.ichi2.utils.Permissions.arePermissionsDefinedInManifest
 import net.ankiweb.rsdroid.BackendException
 import net.ankiweb.rsdroid.exceptions.BackendDeckIsFilteredException
+import net.ankiweb.rsdroid.exceptions.BackendNotFoundException
 import org.json.JSONArray
 import org.json.JSONException
 import timber.log.Timber
@@ -97,9 +98,6 @@ import java.io.IOException
  *
  */
 
-// TODO: Consider streaming Cursor results instead of materializing all rows
-//  to avoid potential OOM for large queries.
-//  Tracked in: https://github.com/ankidroid/Anki-Android/issues/20253
 class CardContentProvider : ContentProvider() {
     companion object {
         // URI types
@@ -133,6 +131,49 @@ class CardContentProvider : ContentProvider() {
          * applied to more columns. "MID", "USN", "MOD" are not really user friendly.
          */
         private val sDefaultNoteProjectionDBAccess = FlashCardsContract.Note.DEFAULT_PROJECTION.clone()
+
+        private val CARD_COLUMNS: Map<String, (Card, Collection) -> Any?> =
+            mapOf(
+                FlashCardsContract.Card._ID to { card, _ -> card.id },
+                FlashCardsContract.Card.NOTE_ID to { card, _ -> card.nid },
+                FlashCardsContract.Card.CARD_ORD to { card, _ -> card.ord },
+                FlashCardsContract.Card.CARD_NAME to { card, col -> cardName(card, col) },
+                FlashCardsContract.Card.DECK_ID to { card, _ -> card.did },
+                FlashCardsContract.Card.REPS to { card, _ -> card.reps },
+                FlashCardsContract.Card.LAPSES to { card, _ -> card.lapses },
+                FlashCardsContract.Card.TYPE to { card, _ -> card.type.code },
+                FlashCardsContract.Card.ORIGINAL_DECK_ID to { card, _ -> card.oDid },
+                FlashCardsContract.Card.QUESTION to { card, col -> card.renderOutput(col).questionWithFixedSoundTags() },
+                FlashCardsContract.Card.ANSWER to { card, col -> card.renderOutput(col).answerWithFixedSoundTags() },
+                FlashCardsContract.Card.QUESTION_SIMPLE to { card, col -> card.renderOutput(col).questionText },
+                FlashCardsContract.Card.ANSWER_SIMPLE to { card, col -> card.renderOutput(col, false).answerText },
+                FlashCardsContract.Card.ANSWER_PURE to { card, col -> card.pureAnswer(col) },
+                FlashCardsContract.Card.RAW_QUEUE to { card, _ -> card.queue.code },
+                FlashCardsContract.Card.RAW_DUE to { card, _ -> card.due },
+                FlashCardsContract.Card.RAW_ORIGINAL_DUE to { card, _ -> card.oDue },
+                FlashCardsContract.Card.INTERVAL to { card, _ -> card.ivl },
+                FlashCardsContract.Card.RAW_SM2_FACTOR to { card, _ -> card.factor },
+                FlashCardsContract.Card.RAW_LEFT to { card, _ -> card.left },
+                FlashCardsContract.Card.ORIGINAL_POSITION to { card, _ -> card.originalPosition },
+                FlashCardsContract.Card.RAW_CUSTOM_DATA to { card, _ -> card.customData },
+                FlashCardsContract.Card.FSRS_STABILITY to { card, _ -> card.memoryStateStability },
+                FlashCardsContract.Card.FSRS_DIFFICULTY to { card, _ -> card.memoryStateDifficulty },
+                FlashCardsContract.Card.FSRS_DESIRED_RETENTION to { card, _ -> card.fsrsDesiredRetention },
+                FlashCardsContract.Card.FSRS_DECAY to { card, _ -> card.decay },
+                FlashCardsContract.Card.LAST_REVIEW_TIME_SECONDS to { card, _ -> card.lastReviewTimeSecs },
+                // return only 3 first bits
+                FlashCardsContract.Card.FLAGS to { card, _ -> card.flags and 7 },
+            )
+
+        private fun cardName(
+            currentCard: Card,
+            col: Collection,
+        ): String =
+            try {
+                currentCard.template(col).name
+            } catch (je: JSONException) {
+                throw IllegalArgumentException("Card is using an invalid template", je)
+            }
 
         private fun sanitizeNoteProjection(projection: Array<String>?): Array<String> {
             if (projection.isNullOrEmpty()) {
@@ -441,6 +482,8 @@ class CardContentProvider : ContentProvider() {
                 val columns = projection ?: FlashCardsContract.Card.DEFAULT_PROJECTION
                 val query = selection ?: ""
 
+                validateCardProjection(columns)
+
                 val cardIds =
                     try {
                         col.findCards(query)
@@ -456,19 +499,18 @@ class CardContentProvider : ContentProvider() {
 
                 if (onlyRequestingId) {
                     // Return IDs without fetching card objects
-                    val rv = MatrixCursor(columns, cardIds.size)
-                    for (cardId in cardIds) {
-                        rv.newRow().add(cardId)
-                    }
-                    rv
+                    LazyRowCursor(columns, cardIds.size) { position -> arrayOf(cardIds[position]) }
                 } else {
-                    // Get all requested fields
-                    val rv = MatrixCursor(columns, cardIds.size)
-                    for (cardId in cardIds) {
-                        val card = col.getCard(cardId)
-                        addCardToCursor(card, rv, col, columns)
+                    LazyRowCursor(columns, cardIds.size) { position ->
+                        val cardId = cardIds[position]
+                        val currentCol = getColUnsafe()
+                        try {
+                            cardColumnValues(currentCol.getCard(cardId), currentCol, columns)
+                        } catch (e: BackendNotFoundException) {
+                            Timber.d(e, "card %d was deleted after the query returned", cardId)
+                            deletedCardColumnValues(cardId, columns)
+                        }
                     }
-                    rv
                 }
             }
             CARD_ID -> {
@@ -1211,46 +1253,35 @@ class CardContentProvider : ContentProvider() {
         col: Collection,
         columns: Array<String>,
     ) {
-        val cardName: String =
-            try {
-                currentCard.template(col).name
-            } catch (je: JSONException) {
-                throw IllegalArgumentException("Card is using an invalid template", je)
-            }
-        val question = currentCard.renderOutput(col).questionWithFixedSoundTags()
-        val answer = currentCard.renderOutput(col).answerWithFixedSoundTags()
         val rb = rv.newRow()
+        for (value in cardColumnValues(currentCard, col, columns)) {
+            rb.add(value)
+        }
+    }
+
+    private fun cardColumnValues(
+        currentCard: Card,
+        col: Collection,
+        columns: Array<String>,
+    ): Array<Any?> =
+        Array(columns.size) { index ->
+            val column = columns[index]
+            val accessor = CARD_COLUMNS[column] ?: throw UnsupportedOperationException("Column \"$column\" is unknown")
+            accessor(currentCard, col)
+        }
+
+    private fun deletedCardColumnValues(
+        cardId: CardId,
+        columns: Array<String>,
+    ): Array<Any?> =
+        Array(columns.size) { index ->
+            if (columns[index] == FlashCardsContract.Card._ID) cardId else null
+        }
+
+    private fun validateCardProjection(columns: Array<String>) {
         for (column in columns) {
-            when (column) {
-                FlashCardsContract.Card._ID -> rb.add(currentCard.id)
-                FlashCardsContract.Card.NOTE_ID -> rb.add(currentCard.nid)
-                FlashCardsContract.Card.CARD_ORD -> rb.add(currentCard.ord)
-                FlashCardsContract.Card.CARD_NAME -> rb.add(cardName)
-                FlashCardsContract.Card.DECK_ID -> rb.add(currentCard.did)
-                FlashCardsContract.Card.REPS -> rb.add(currentCard.reps)
-                FlashCardsContract.Card.LAPSES -> rb.add(currentCard.lapses)
-                FlashCardsContract.Card.TYPE -> rb.add(currentCard.type.code)
-                FlashCardsContract.Card.ORIGINAL_DECK_ID -> rb.add(currentCard.oDid)
-                FlashCardsContract.Card.QUESTION -> rb.add(question)
-                FlashCardsContract.Card.ANSWER -> rb.add(answer)
-                FlashCardsContract.Card.QUESTION_SIMPLE -> rb.add(currentCard.renderOutput(col).questionText)
-                FlashCardsContract.Card.ANSWER_SIMPLE -> rb.add(currentCard.renderOutput(col, false).answerText)
-                FlashCardsContract.Card.ANSWER_PURE -> rb.add(currentCard.pureAnswer(col))
-                FlashCardsContract.Card.RAW_QUEUE -> rb.add(currentCard.queue.code)
-                FlashCardsContract.Card.RAW_DUE -> rb.add(currentCard.due)
-                FlashCardsContract.Card.RAW_ORIGINAL_DUE -> rb.add(currentCard.oDue)
-                FlashCardsContract.Card.INTERVAL -> rb.add(currentCard.ivl)
-                FlashCardsContract.Card.RAW_SM2_FACTOR -> rb.add(currentCard.factor)
-                FlashCardsContract.Card.RAW_LEFT -> rb.add(currentCard.left)
-                FlashCardsContract.Card.ORIGINAL_POSITION -> rb.add(currentCard.originalPosition)
-                FlashCardsContract.Card.RAW_CUSTOM_DATA -> rb.add(currentCard.customData)
-                FlashCardsContract.Card.FSRS_STABILITY -> rb.add(currentCard.memoryStateStability)
-                FlashCardsContract.Card.FSRS_DIFFICULTY -> rb.add(currentCard.memoryStateDifficulty)
-                FlashCardsContract.Card.FSRS_DESIRED_RETENTION -> rb.add(currentCard.fsrsDesiredRetention)
-                FlashCardsContract.Card.FSRS_DECAY -> rb.add(currentCard.decay)
-                FlashCardsContract.Card.LAST_REVIEW_TIME_SECONDS -> rb.add(currentCard.lastReviewTimeSecs)
-                FlashCardsContract.Card.FLAGS -> rb.add(currentCard.flags and 7) // return only 3 first bits
-                else -> throw UnsupportedOperationException("Queue \"$column\" is unknown")
+            if (column !in CARD_COLUMNS) {
+                throw UnsupportedOperationException("Column \"$column\" is unknown")
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/LazyRowCursor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/LazyRowCursor.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.provider
+
+import android.database.AbstractCursor
+import android.database.Cursor
+
+/**
+ * A [Cursor] which builds a row only when it is read, keeping at most one row in memory. Use it
+ * over `MatrixCursor` when rows are expensive to build, such as rendering card HTML.
+ *
+ * @param columns the column names, in the order [rowProvider] returns their values
+ * @param rowCount the number of rows, known before any row is built
+ * @param rowProvider builds one row of `MatrixCursor`-typed values. May run on a binder thread
+ * after `query()` returns, and more than once per position, so it must not outlive the query.
+ */
+class LazyRowCursor(
+    private val columns: Array<String>,
+    private val rowCount: Int,
+    private val rowProvider: (position: Int) -> Array<Any?>,
+) : AbstractCursor() {
+    private var cachedPosition = -1
+    private var cachedRow: Array<Any?>? = null
+
+    override fun getCount(): Int = rowCount
+
+    override fun getColumnNames(): Array<String> = columns
+
+    private fun valueAt(column: Int): Any? {
+        checkPosition()
+        val row =
+            cachedRow.takeIf { cachedPosition == position } ?: rowProvider(position).also {
+                cachedRow = it
+                cachedPosition = position
+            }
+        return row[column]
+    }
+
+    override fun getString(column: Int): String? = valueAt(column)?.toString()
+
+    override fun getShort(column: Int): Short = (valueAt(column) as? Number)?.toShort() ?: 0
+
+    override fun getInt(column: Int): Int = (valueAt(column) as? Number)?.toInt() ?: 0
+
+    override fun getLong(column: Int): Long = (valueAt(column) as? Number)?.toLong() ?: 0
+
+    override fun getFloat(column: Int): Float = (valueAt(column) as? Number)?.toFloat() ?: 0f
+
+    override fun getDouble(column: Int): Double = (valueAt(column) as? Number)?.toDouble() ?: 0.0
+
+    override fun getBlob(column: Int): ByteArray? = valueAt(column) as? ByteArray
+
+    override fun isNull(column: Int): Boolean = valueAt(column) == null
+
+    override fun getType(column: Int): Int =
+        when (valueAt(column)) {
+            null -> Cursor.FIELD_TYPE_NULL
+            is ByteArray -> Cursor.FIELD_TYPE_BLOB
+            is Float, is Double -> Cursor.FIELD_TYPE_FLOAT
+            is Number -> Cursor.FIELD_TYPE_INTEGER
+            else -> Cursor.FIELD_TYPE_STRING
+        }
+
+    override fun close() {
+        cachedRow = null
+        cachedPosition = -1
+        super.close()
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/provider/LazyRowCursorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/provider/LazyRowCursorTest.kt
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.provider
+
+import android.database.Cursor
+import android.database.CursorIndexOutOfBoundsException
+import android.database.CursorWindow
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.testutils.EmptyApplication
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.contains
+import org.hamcrest.Matchers.empty
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import kotlin.test.assertFailsWith
+
+/** Tests for [LazyRowCursor] */
+@RunWith(AndroidJUnit4::class)
+@Config(application = EmptyApplication::class)
+class LazyRowCursorTest {
+    private val columns = arrayOf("_id", "name", "weight")
+    private val built = mutableListOf<Int>()
+
+    private fun cursor(rowCount: Int = 3) =
+        LazyRowCursor(columns, rowCount) { position ->
+            built.add(position)
+            arrayOf(position.toLong(), "row $position", if (position == 1) null else position * 0.5)
+        }
+
+    @Test
+    fun `no row is built until one is read`() {
+        val cursor = cursor()
+
+        assertThat("count is known without building rows", cursor.count, equalTo(3))
+        assertThat("column names are known without building rows", cursor.columnNames.size, equalTo(3))
+        cursor.moveToFirst()
+
+        assertThat("moving does not build a row", built, empty())
+    }
+
+    @Test
+    fun `reading a row builds only that row`() {
+        val cursor = cursor()
+
+        cursor.moveToPosition(2)
+        assertThat(cursor.getString(1), equalTo("row 2"))
+
+        assertThat("rows 0 and 1 are never built", built, contains(2))
+    }
+
+    @Test
+    fun `all columns of a row share a single build`() {
+        val cursor = cursor()
+
+        cursor.moveToFirst()
+        cursor.getLong(0)
+        cursor.getString(1)
+        cursor.getDouble(2)
+        cursor.getType(2)
+
+        assertThat("the row is built once, not once per column", built, contains(0))
+    }
+
+    @Test
+    fun `re-reading a row rebuilds it rather than retaining it`() {
+        val cursor = cursor()
+
+        cursor.moveToPosition(0)
+        cursor.getLong(0)
+        cursor.moveToPosition(1)
+        cursor.getLong(0)
+        cursor.moveToPosition(0)
+        assertThat("the value is unchanged", cursor.getString(1), equalTo("row 0"))
+
+        assertThat("only one row is cached at a time", built, contains(0, 1, 0))
+    }
+
+    @Test
+    fun `values are typed as MatrixCursor types them`() {
+        val cursor = cursor()
+
+        cursor.moveToFirst()
+        assertThat(cursor.getLong(0), equalTo(0L))
+        assertThat(cursor.getString(1), equalTo("row 0"))
+        assertThat(cursor.getDouble(2), equalTo(0.0))
+        assertThat(cursor.getType(0), equalTo(Cursor.FIELD_TYPE_INTEGER))
+        assertThat(cursor.getType(1), equalTo(Cursor.FIELD_TYPE_STRING))
+        assertThat(cursor.getType(2), equalTo(Cursor.FIELD_TYPE_FLOAT))
+
+        cursor.moveToNext()
+        assertThat("a null value is reported as null", cursor.isNull(2), equalTo(true))
+        assertThat(cursor.getType(2), equalTo(Cursor.FIELD_TYPE_NULL))
+        assertThat("a null value reads as zero", cursor.getDouble(2), equalTo(0.0))
+        assertThat("a null value has no string", cursor.getString(2), equalTo(null))
+    }
+
+    @Test
+    fun `a non-numeric value is typed and read as a string`() {
+        val cursor = LazyRowCursor(arrayOf("flag"), 1) { arrayOf(true) }
+
+        cursor.moveToFirst()
+        assertThat(cursor.getType(0), equalTo(Cursor.FIELD_TYPE_STRING))
+        assertThat(cursor.getString(0), equalTo("true"))
+    }
+
+    @Test
+    fun `reading outside the result set throws instead of building a row`() {
+        val cursor = cursor()
+
+        assertFailsWith<CursorIndexOutOfBoundsException> { cursor.getLong(0) }
+        cursor.moveToPosition(3)
+        assertFailsWith<CursorIndexOutOfBoundsException> { cursor.getLong(0) }
+
+        assertThat("no row is built for an invalid position", built, empty())
+    }
+
+    @Test
+    fun `an empty result set builds nothing`() {
+        val cursor = cursor(rowCount = 0)
+
+        assertThat(cursor.count, equalTo(0))
+        assertThat("there is no first row", cursor.moveToFirst(), equalTo(false))
+        assertThat(built, empty())
+    }
+
+    @Test
+    fun `filling a window builds each row once`() {
+        val cursor = cursor()
+        val window = CursorWindow("test")
+
+        fillWindow(cursor, window)
+
+        assertThat("every row reaches the window", window.numRows, equalTo(3))
+        assertThat("each row is built exactly once", built, contains(0, 1, 2))
+        assertThat(window.getString(0, 1), equalTo("row 0"))
+        assertThat("the null value survives the window", window.getString(1, 2), equalTo(null))
+    }
+
+    private fun fillWindow(
+        cursor: Cursor,
+        window: CursorWindow,
+    ) {
+        window.setNumColumns(cursor.columnCount)
+        cursor.moveToPosition(-1)
+        while (cursor.moveToNext()) {
+            check(window.allocRow())
+            for (column in 0 until cursor.columnCount) {
+                val row = cursor.position
+                val put =
+                    when (cursor.getType(column)) {
+                        Cursor.FIELD_TYPE_NULL -> window.putNull(row, column)
+                        Cursor.FIELD_TYPE_INTEGER -> window.putLong(cursor.getLong(column), row, column)
+                        Cursor.FIELD_TYPE_FLOAT -> window.putDouble(cursor.getDouble(column), row, column)
+                        Cursor.FIELD_TYPE_BLOB -> window.putBlob(cursor.getBlob(column), row, column)
+                        else -> window.putString(cursor.getString(column), row, column)
+                    }
+                check(put)
+            }
+        }
+        cursor.moveToPosition(-1)
+    }
+}


### PR DESCRIPTION

## Purpose / Description
cards searches rendered and materialized every matching card before query() returned, risking OOM on broad searches.

## Fixes
* Fixes #20253 

## Approach
Adds LazyRowCursor, an AbstractCursor holding only the card ids that builds each row on read, so peak memory is bounded by the CursorWindow.

## How Has This Been Tested?
8 new JVM tests asserting laziness plus the full 84-test ContentProviderTest green on a physical device (API 36).

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->