### PR TITLE
fix(card-browser): tinting of 'mark' icon

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/MenuUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/MenuUtils.kt
@@ -21,7 +21,6 @@ import android.view.MenuItem
 import androidx.annotation.DrawableRes
 import androidx.appcompat.view.menu.MenuBuilder
 import androidx.appcompat.view.menu.MenuItemImpl
-import androidx.core.content.ContextCompat
 import androidx.core.view.forEach
 import com.google.android.material.color.MaterialColors
 import com.ichi2.anki.R
@@ -65,14 +64,18 @@ private fun Context.increaseHorizontalPaddingOfMenuIcons(
     }
 }
 
+/**
+ * Sets [drawableResId] as the icon, with [horizontalPaddingDp] of padding on each side.
+ */
 fun MenuItem.setPaddedIcon(
     context: Context,
     @DrawableRes drawableResId: Int,
     horizontalPaddingDp: Float = DEFAULT_HORIZONTAL_PADDING,
 ) {
     val padding = horizontalPaddingDp.dp.toPx(context)
-    val drawable = ContextCompat.getDrawable(context, drawableResId)
-    icon = InsetDrawable(drawable, padding, 0, padding, 0)
+    // #21688 use the Menu's context to resolve the drawable
+    setIcon(drawableResId)
+    icon = InsetDrawable(icon, padding, 0, padding, 0)
 }
 
 /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserScreenshotTest.kt
@@ -108,6 +108,16 @@ class CardBrowserScreenshotTest : ScreenshotTest() {
         }
     }
 
+    @Test
+    fun multiselect() =
+        runTest {
+            val browser = getBrowserWithNotes(noteCount = 1)
+            browser.longClickRowAtPosition(0).join()
+            advanceRobolectricLooper()
+
+            captureScreen("multiselect")
+        }
+
     /**
      * Robolectric reports zero system-bar insets by default. Inject realistic ones so the app's
      * edge-to-edge layout responds as it would on a real device, and overlay a translucent band


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5.1

## Fixes
* Fixes #21688

## Approach
Use the right `Context`

## How Has This Been Tested?
Screenshot test added

## Learning (optional, can help others)
Broken in 01cd6fbf05 - wrong `Context` was used

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)