### PR TITLE
fix(deck-options): match 'double tap interval' accessibility setting

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/pages/DeckOptionsTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/pages/DeckOptionsTest.kt
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.pages
+
+import androidx.core.content.edit
+import androidx.core.view.isVisible
+import androidx.test.core.app.ActivityScenario
+import androidx.test.platform.app.InstrumentationRegistry
+import com.ichi2.anki.R
+import com.ichi2.anki.SingleFragmentActivity
+import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.libanki.Consts
+import com.ichi2.anki.tests.InstrumentedTest
+import com.ichi2.anki.testutil.waitUntil
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+class DeckOptionsTest : InstrumentedTest() {
+    private val doubleTapIntervalKey get() = testContext.getString(R.string.double_tap_timeout_pref_key)
+    private var fsrsWasEnabled = false
+
+    @Before
+    fun enableFsrs() {
+        // the parameters are only displayed when FSRS is enabled
+        fsrsWasEnabled = col.config.get<Boolean>("fsrs") ?: false
+        col.config.set("fsrs", true)
+    }
+
+    @After
+    fun restoreState() {
+        col.config.set("fsrs", fsrsWasEnabled)
+        testContext.sharedPrefs().edit { remove(doubleTapIntervalKey) }
+    }
+
+    @Test
+    fun pageExposesParameterUnlockClickTimeout() {
+        withDeckOptions {
+            assertEquals("\"function\"", evaluateJavascript("typeof anki.setParameterUnlockClickTimeoutMs"))
+            assertEquals("\"number\"", evaluateJavascript("typeof anki.defaultParameterUnlockClickTimeoutMs"))
+        }
+    }
+
+    @Test
+    fun raisedDoubleTapIntervalUnlocksParametersWithSlowerTaps() {
+        testContext.sharedPrefs().edit { putInt(doubleTapIntervalKey, 1000) }
+        withDeckOptions {
+            assertTrue(tapParametersThreeTimes(gapMs = 750), "parameters unlocked")
+        }
+    }
+
+    @Test
+    fun defaultDoubleTapIntervalKeepsPageTimeout() {
+        withDeckOptions {
+            assertFalse(tapParametersThreeTimes(gapMs = 750), "parameters remain locked")
+        }
+    }
+
+    private fun withDeckOptions(block: DeckOptions.() -> Unit) {
+        val intent = DeckOptions.getIntent(testContext, Consts.DEFAULT_DECK_ID)
+        ActivityScenario.launch<SingleFragmentActivity>(intent).use { scenario ->
+            lateinit var fragment: DeckOptions
+            scenario.onActivity { fragment = it.fragment as DeckOptions }
+            // the WebView is shown once the page reports it is ready, which also sets the timeout
+            waitUntil(timeout = 30.seconds, message = { "deck options did not become ready" }) {
+                var ready = false
+                scenario.onActivity { ready = fragment.webViewLayout.isVisible }
+                ready
+            }
+            block(fragment)
+        }
+    }
+
+    /**
+     * Taps the FSRS parameters three times, [gapMs] apart
+     *
+     * @return whether the parameters were unlocked
+     */
+    private fun DeckOptions.tapParametersThreeTimes(gapMs: Int): Boolean {
+        evaluateJavascript(
+            """
+            globalThis.ankidroidTest = undefined;
+            (async () => {
+                try {
+                    const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+                    const parameters = document.querySelector('[aria-label="FSRS Parameters"]');
+                    const textarea = parameters.querySelector("textarea");
+                    for (let tap = 0; tap < 3; tap++) {
+                        if (tap > 0) await sleep($gapMs);
+                        parameters.click();
+                    }
+                    await sleep(100); // allow the DOM to update
+                    globalThis.ankidroidTest = { unlocked: !textarea.disabled };
+                } catch (e) {
+                    globalThis.ankidroidTest = { error: String(e) };
+                }
+            })();
+            """.trimIndent(),
+        )
+        waitUntil(message = { "tap sequence did not complete" }) {
+            evaluateJavascript("globalThis.ankidroidTest !== undefined") == "true"
+        }
+        assertEquals("null", evaluateJavascript("globalThis.ankidroidTest.error ?? null"), "tap sequence failed")
+        return evaluateJavascript("globalThis.ankidroidTest.unlocked") == "true"
+    }
+
+    /** Evaluates [script] in the WebView, returning the JSON-encoded result */
+    private fun DeckOptions.evaluateJavascript(script: String): String {
+        val result = CompletableDeferred<String>()
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            webViewLayout.evaluateJavascript(script) { result.complete(it) }
+        }
+        return runBlocking { withTimeout(10.seconds) { result.await() } }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
@@ -39,6 +39,7 @@ import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.updateDeckConfigsRaw
 import com.ichi2.anki.observability.undoableOp
+import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.utils.openUrl
 import com.ichi2.anki.withProgress
 import kotlinx.coroutines.Dispatchers
@@ -247,6 +248,43 @@ class DeckOptions : PageFragment() {
         webViewIsReady = true
         webViewLayout.isVisible = true
         pageLoadingIndicator.isVisible = false
+        setParameterUnlockClickTimeout()
+    }
+
+    /**
+     * The FSRS parameters are locked until they are tapped three times in quick succession.
+     *
+     * Use [Prefs.doubleTapInterval] for this.
+     *
+     * See: https://github.com/ankitects/anki/blob/d036c2ade428b65d47c677bf3887a7402312c5c5/ts/routes/deck-options/ParamsInput.svelte
+     */
+    private fun setParameterUnlockClickTimeout() {
+        val minimumTimeoutMs = Prefs.doubleTapInterval
+        // The setter and default are only defined while `ParamsInput` is mounted, which requires
+        // FSRS to be enabled, and are reassigned each time it mounts.
+        // Intercept the assignments so this functionality works the first time someone enables
+        // FSRS.
+        webViewLayout.evaluateJavascript(
+            """
+            (() => {
+                globalThis.anki ||= {};
+                let setter = globalThis.anki.setParameterUnlockClickTimeoutMs;
+                const apply = () => {
+                    const defaultMs = globalThis.anki.defaultParameterUnlockClickTimeoutMs;
+                    if (setter === undefined || defaultMs === undefined) return;
+                    setter(Math.max(defaultMs, $minimumTimeoutMs));
+                };
+                Object.defineProperty(globalThis.anki, "setParameterUnlockClickTimeoutMs", {
+                    configurable: true,
+                    enumerable: true,
+                    get: () => setter,
+                    // the default is assigned after the setter: defer until both are defined
+                    set: (value) => { setter = value; queueMicrotask(apply); },
+                });
+                apply();
+            })();
+            """.trimIndent(),
+        )
     }
 
     companion object {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/pages/DeckOptionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/pages/DeckOptionsTest.kt
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.pages
+
+import android.webkit.WebView
+import androidx.core.view.children
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.R
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.SingleFragmentActivity
+import com.ichi2.anki.libanki.Consts
+import com.ichi2.anki.settings.Prefs
+import com.ichi2.testutils.ext.clear
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsString
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+
+/** Test for [DeckOptions] */
+@RunWith(AndroidJUnit4::class)
+class DeckOptionsTest : RobolectricTest() {
+    @After
+    override fun tearDown() {
+        super.tearDown()
+        Prefs.clear()
+    }
+
+    @Test
+    fun `double tap interval is sent to the page when it is ready`() {
+        Prefs.putInt(R.string.double_tap_timeout_pref_key, 800)
+
+        withDeckOptions {
+            onWebViewReady()
+
+            assertThat(lastEvaluatedJavascript, containsString("setParameterUnlockClickTimeoutMs"))
+            assertThat(lastEvaluatedJavascript, containsString("800"))
+        }
+    }
+
+    private fun withDeckOptions(block: DeckOptions.() -> Unit) {
+        val activity =
+            startActivityNormallyOpenCollectionWithIntent(
+                SingleFragmentActivity::class.java,
+                DeckOptions.getIntent(targetContext, Consts.DEFAULT_DECK_ID),
+            )
+        advanceRobolectricLooper()
+        block(activity.fragment as DeckOptions)
+    }
+
+    /** The last JavaScript evaluated by the WebView of [DeckOptions] */
+    private val DeckOptions.lastEvaluatedJavascript: String?
+        get() =
+            webViewLayout.children
+                .filterIsInstance<WebView>()
+                .single()
+                .let { shadowOf(it).lastEvaluatedJavascript }
+}


### PR DESCRIPTION

> [!NOTE]
> Assisted-by: Claude Fable 5.1

## Purpose / Description
* See https://github.com/ankitects/anki/pull/4810

FSRS parameters now require two taps to unlock.
This now takes 'double tap interval' into account if it's larger than 500ms.

## Fixes
* Fixes #21683
* Fixes #21016

## Approach
Implement `setParameterUnlockClickTimeoutMs` 

## How Has This Been Tested?
Unit tested; instrumented regression test added

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)