### PR TITLE
fix(card-template-editor): insets apply to all templates

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -47,6 +47,7 @@ import androidx.fragment.app.commitNow
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.adapter.FragmentStateAdapter
+import androidx.viewpager2.widget.ViewPager2
 import anki.notetypes.StockNotetype
 import anki.notetypes.StockNotetype.OriginalStockKind.ORIGINAL_STOCK_KIND_UNKNOWN_VALUE
 import anki.notetypes.notetypeId
@@ -249,6 +250,16 @@ open class CardTemplateEditor : AnkiActivity(R.layout.activity_card_template_edi
             Timber.i("selected card index: %s", tab.position)
             loadTemplatePreviewerFragmentIfFragmented(tab.position)
         }
+
+        // ViewPager2 clears focus when a page is selected, so focus can't stay on an offscreen page.
+        // Move it to the selected page instead: see CardTemplateFragment.isCurrentPage
+        mainBinding.cardTemplateEditorPager.registerOnPageChangeCallback(
+            object : ViewPager2.OnPageChangeCallback() {
+                override fun onPageSelected(position: Int) {
+                    templateFragment(position)?.binding?.editText?.requestFocus()
+                }
+            },
+        )
 
         registerDeckSelectedHandler(action = ::onDeckSelected)
     }
@@ -505,6 +516,12 @@ open class CardTemplateEditor : AnkiActivity(R.layout.activity_card_template_edi
         return true
     }
 
+    /** The page for a card, if the pager has created it */
+    private fun templateFragment(position: Int): CardTemplateFragment? {
+        val adapter = mainBinding.cardTemplateEditorPager.adapter ?: return null
+        return supportFragmentManager.findFragmentByTag("f${adapter.getItemId(position)}") as? CardTemplateFragment
+    }
+
     @get:VisibleForTesting
     val currentFragment: CardTemplateFragment?
         get() =
@@ -576,6 +593,10 @@ open class CardTemplateEditor : AnkiActivity(R.layout.activity_card_template_edi
         // Index of this card template fragment in ViewPager
         private val cardIndex
             get() = requireArguments().getInt(CARD_INDEX)
+
+        /** Whether this is the page shown by the pager. */
+        private val isCurrentPage: Boolean
+            get() = templateEditor.mainBinding.cardTemplateEditorPager.currentItem == cardIndex
 
         private val templateName
             get() = tempModel.notetype.templates[cardIndex].name
@@ -763,8 +784,10 @@ open class CardTemplateEditor : AnkiActivity(R.layout.activity_card_template_edi
              * show the keyboard. This is intentional - the keyboard should only appear
              * when the user taps on the edit field, not every time the fragment loads.
              */
-            binding.editText.post {
-                binding.editText.requestFocus()
+            if (isCurrentPage) {
+                binding.editText.post {
+                    binding.editText.requestFocus()
+                }
             }
 
             parentFragmentManager.setFragmentResultListener(insertFieldRequestKey, viewLifecycleOwner) { key, bundle ->
@@ -936,7 +959,9 @@ open class CardTemplateEditor : AnkiActivity(R.layout.activity_card_template_edi
             )
             currentEditorViewId = viewId
             binding.editText.setText(editorContent)
-            binding.editText.requestFocus()
+            if (isCurrentPage) {
+                binding.editText.requestFocus()
+            }
             binding.editText.setSelection(
                 templateEditor.tabToCursorPositions[cardId]?.get(
                     currentEditorViewId,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -20,9 +20,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import android.widget.FrameLayout
 import android.widget.LinearLayout
-import android.widget.ScrollView
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
@@ -35,10 +33,10 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.view.MenuHost
 import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsCompat.Type.displayCutout
 import androidx.core.view.WindowInsetsCompat.Type.ime
 import androidx.core.view.WindowInsetsCompat.Type.systemBars
+import androidx.core.view.doOnAttach
 import androidx.core.view.isVisible
 import androidx.core.view.size
 import androidx.core.view.updatePadding
@@ -264,16 +262,13 @@ open class CardTemplateEditor : AnkiActivity(R.layout.activity_card_template_edi
             )?.updatePadding(left = constraints.left, top = constraints.top, right = constraints.right)
             insets
         }
+        // When not fragmented, each CardTemplateFragment insets its own template: the fragments
+        // are created after the first insets are dispatched, so they can't be reached from here
         ViewCompat.setOnApplyWindowInsetsListener(binding.rootLayout) { _, insets ->
             val constraints = insets.getInsets(systemBars() or displayCutout() or ime())
             if (fragmented) {
                 findViewById<LinearLayout>(R.id.template_editor)?.updatePadding(left = constraints.left)
                 findViewById<FragmentContainerView>(R.id.fragment_container)?.updatePadding(right = constraints.right)
-            } else {
-                findViewById<FrameLayout>(
-                    R.id.bottom_navigation_container,
-                )?.updatePadding(left = constraints.left, right = constraints.right)
-                findViewById<ScrollView>(R.id.scroll_view)?.updatePadding(left = constraints.left, right = constraints.right)
             }
             insets
         }
@@ -748,12 +743,20 @@ open class CardTemplateEditor : AnkiActivity(R.layout.activity_card_template_edi
                 }
             binding.editText.addTextChangedListener(templateEditorWatcher)
 
-            /* When keyboard is visible, hide the bottom navigation bar to allow viewing
-            of all template text when resize happens */
             ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, insets ->
-                binding.bottomNavigation.isVisible = !insets.isVisible(WindowInsetsCompat.Type.ime())
+                /* When keyboard is visible, hide the bottom navigation bar to allow viewing
+                of all template text when resize happens */
+                binding.bottomNavigation.isVisible = !insets.isVisible(ime())
+                // When fragmented, the activity insets the editor pane instead.
+                // The bottom navigation insets itself, so it is not padded here.
+                if (!templateEditor.fragmented) {
+                    val bars = insets.getInsets(systemBars() or displayCutout())
+                    binding.scrollView.updatePadding(left = bars.left, right = bars.right)
+                }
                 insets
             }
+            // the view is added to the pager after the insets were dispatched, so request them again
+            binding.root.doOnAttach { ViewCompat.requestApplyInsets(it) }
 
             /*
              * We focus on the editText to indicate it's editable, but we don't automatically

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorScreenshotTest.kt
@@ -2,9 +2,28 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 package com.ichi2.anki
 
+import android.annotation.SuppressLint
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsCompat.Type.displayCutout
+import androidx.core.view.WindowInsetsCompat.Type.navigationBars
+import androidx.core.view.WindowInsetsCompat.Type.statusBars
 import androidx.test.core.app.ActivityScenario
+import com.ichi2.testutils.insetsOf
+import com.ichi2.utils.Dp
+import com.ichi2.utils.dp
 import org.junit.Test
+import org.robolectric.RuntimeEnvironment
 
+/**
+ * Screenshot tests for [CardTemplateEditor]
+ *
+ * `./gradlew :AnkiDroid:recordRoborazziPlayDebug -Pscreenshot --tests "com.ichi2.anki.CardTemplateEditorScreenshotTest"`
+ */
 class CardTemplateEditorScreenshotTest : ScreenshotTest() {
     @Test
     fun basic() {
@@ -16,5 +35,47 @@ class CardTemplateEditorScreenshotTest : ScreenshotTest() {
                 captureScreen("basic")
             }
         }
+    }
+
+    /**
+     * Landscape with 3-button navigation showing the second card.
+     */
+    @Test
+    fun landscape() {
+        RuntimeEnvironment.setQualifiers("+land")
+        withCardTemplateEditor(noteType = getCurrentDatabaseNoteTypeCopy("Basic (and reversed card)")) {
+            mainBinding.cardTemplateEditorPager.setCurrentItem(1, false)
+            advanceRobolectricLooper()
+            simulateSideNavigationBar()
+            captureScreen("landscape")
+        }
+    }
+
+    @SuppressLint("RtlHardcoded") // insets and cutouts are physical: not layout-direction relative
+    private fun CardTemplateEditor.simulateSideNavigationBar() {
+        val navBarWidth = 48.dp
+        val cutoutWidth = 32.dp
+        val insets =
+            with(targetContext) {
+                WindowInsetsCompat
+                    .Builder()
+                    .setInsets(statusBars(), insetsOf(top = 24.dp))
+                    .setInsets(navigationBars(), insetsOf(left = navBarWidth))
+                    .setInsets(displayCutout(), insetsOf(right = cutoutWidth))
+                    .build()
+            }
+        ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
+        advanceRobolectricLooper()
+        addOverlay(navBarWidth, Gravity.LEFT)
+        addOverlay(cutoutWidth, Gravity.RIGHT)
+    }
+
+    private fun CardTemplateEditor.addOverlay(
+        width: Dp,
+        gravity: Int,
+    ) {
+        val decor = window.decorView as ViewGroup
+        val overlay = View(this).apply { setBackgroundColor(0x80000000.toInt()) }
+        decor.addView(overlay, FrameLayout.LayoutParams(width.toPx(targetContext), FrameLayout.LayoutParams.MATCH_PARENT, gravity))
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
@@ -24,6 +24,7 @@ import android.os.Looper
 import android.view.View
 import android.widget.EditText
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.CardTemplateEditor.CardTemplateFragment
 import com.ichi2.anki.CardTemplateEditor.CardTemplateFragment.CardTemplate
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.dialogs.InsertFieldDialog
@@ -942,6 +943,24 @@ class CardTemplateEditorTest : RobolectricTest() {
                 assertThat(previewer.ord, equalTo(1))
             }
         }
+
+    @Test
+    fun `the current card is focused`() {
+        withCardTemplateEditor(noteType = getCurrentDatabaseNoteTypeCopy("Basic (and reversed card)")) {
+            advanceRobolectricLooper()
+            assertThat("card 1 is focused on open", window.decorView.findFocus(), equalTo(templateFragment(0).binding.editText))
+
+            selectTab(1)
+            advanceRobolectricLooper()
+            assertThat("card 2 is focused once selected", window.decorView.findFocus(), equalTo(templateFragment(1).binding.editText))
+
+            selectTab(0)
+            advanceRobolectricLooper()
+            assertThat("card 1 is focused again", window.decorView.findFocus(), equalTo(templateFragment(0).binding.editText))
+        }
+    }
+
+    private fun CardTemplateEditor.templateFragment(ord: Int) = supportFragmentManager.findFragmentByTag("f$ord") as CardTemplateFragment
 
     private fun addCardType(
         testEditor: CardTemplateEditor,


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5.1

## Purpose / Description
When switching to another template, in landscape mode, the card content rendered in the cutout on my Pixel 9 Pro API 37 (if the displayed template was not the initial template).

<img width="2142" height="960" alt="image" src="https://github.com/user-attachments/assets/75358275-58a4-408f-ab38-1303be66c454" />


## Fixes
* Fixes #21510

## Approach
* Reapply the insets on attach

## How Has This Been Tested?
Screenshot tests, physical test on an API 37 Pixel 9 Pro

I found an unrelate flake, which I fix in this PR: when in landscape mode, the ViewPager was showing 2 templates (half of each), with 1 inside the inset. 

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)