### PR TITLE
fix(deck-picker): restore deck selection highlight

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -555,9 +555,7 @@ open class DeckPicker :
                     viewModel.requestRightClickContextMenu(deckId, x, y)
                     Timber.d("Right Click on deck recorded!! %d, %f %f", deckId, x, y)
                 },
-            ).apply {
-                highlightSelected = fragmented
-            }
+            )
         deckPickerBinding.decks.adapter = deckListAdapter
         if (Prefs.devBottomNavEnabled) {
             deckPickerBinding.decks.addItemDecoration(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -102,12 +102,6 @@ class DeckAdapter(
             }
         }
 
-    /**
-     * Whether to highlight the selected deck. Usually true for fragmented (tablet) layouts
-     * where the deck contents are shown side-by-side, but false for phones.
-     */
-    var highlightSelected: Boolean = true
-
     class ViewHolder(
         val binding: ItemDeckBinding,
     ) : RecyclerView.ViewHolder(binding.root)
@@ -171,8 +165,7 @@ class DeckAdapter(
         }
         holder.binding.deckLayout.setBackgroundResource(rowCurrentDrawable)
         // set a different background color for the current selected deck
-        if (node.isSelected && highlightSelected) {
-            holder.binding.deckLayout.setBackgroundResource(rowCurrentDrawable)
+        if (node.isSelected) {
             if (activityHasBackground) {
                 val background =
                     holder.binding.deckLayout.background

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -25,6 +25,7 @@ import app.cash.turbine.test
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.time.TimeManager
+import com.ichi2.anki.common.utils.android.getResFromAttr
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.databinding.ActivityHomescreenBinding
 import com.ichi2.anki.deckpicker.DeckPickerViewModel
@@ -455,6 +456,14 @@ class DeckPickerTest : RobolectricTest() {
         }
     }
 
+    private fun DeckPicker.longPressDeck(name: String): View =
+        deckPickerBinding.decks.children
+            .single { it.findViewById<TextView>(R.id.deck_name).text == name }
+            .also {
+                it.performLongClick()
+                advanceRobolectricLooper()
+            }
+
     private fun keyDownEvent(
         keyCode: Int,
         modifiers: Int,
@@ -617,6 +626,23 @@ class DeckPickerTest : RobolectricTest() {
                 "No deck is being displayed",
                 hasAtLeastOneDeckBeingDisplayed(),
                 equalTo(false),
+            )
+        }
+    }
+
+    @Test
+    fun `long pressed deck is highlighted on phones`() {
+        val initiallySelectedDeck = addDeck("Initially selected")
+        addDeck("Long pressed")
+        col.decks.select(initiallySelectedDeck)
+
+        deckPicker {
+            assumeTrue("Not running on tablet", !fragmented)
+            val selectedDeck = longPressDeck("Long pressed")
+
+            assertThat(
+                shadowOf(selectedDeck.background).createdFromResId,
+                equalTo(getResFromAttr(this, R.attr.currentDeckBackground)),
             )
         }
     }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

<!---
Uncomment this section if AI tools were used. New contributors may not use AI tools. See:
https://github.com/ankidroid/Anki-Android/blob/main/AI_POLICY.md
> [!NOTE]
> Assisted-by: GPT-5.6 Sol for the regression test, verified by me
--->

## Purpose / Description
Deck selection was not highlighting due to a regression in #21373 

## Fixes
* Fixes #21639 

## Approach
Removes the code added in the mentioned PR that was removing deck highlighting as a whole.

## How Has This Been Tested?
Regression test added.
[Screen_recording_20260902_093042.webm](https://github.com/user-attachments/assets/fd3dd760-79a0-4b8b-abff-9ac683e3bdf1)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->