### PR TITLE
build(lint): make ThreadConstraint IDE only

### DIFF
--- a/lint-release.xml
+++ b/lint-release.xml
@@ -429,7 +429,9 @@
     <issue id="Range" severity="ignore" />
     <issue id="ResourceType" severity="ignore" />
     <issue id="RestrictedApi" severity="ignore" />
+    <!-- WrongThread & ThreadConstraint should be IDE-only, not breaking the build -->
     <issue id="WrongThread" severity="informational" />
+    <issue id="ThreadConstraint" severity="informational" />
     <issue id="VisibleForTests" severity="ignore" />
     <issue id="ProtectedPermissions" severity="ignore" />
     <issue id="TextViewEdits" severity="ignore" />

--- a/lint.gradle
+++ b/lint.gradle
@@ -16,6 +16,7 @@ android {
         if (System.getenv("CI") == "true") {
             // 14853: we want this to appear in the IDE, but it adds noise to CI
             disable += "WrongThread"
+            disable += "ThreadConstraint"
         }
     }
 }


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5.1

## Purpose / Description
* Prep for https://github.com/ankidroid/Anki-Android/pull/21698

ThreadConstraint is added in AGP 9.4.0 as a successor to WrongThread.

## Approach
Matches #14853: informational for the IDE, disabled on CI.

* #14853

## How Has This Been Tested?
Trusting Ci

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
