### PR TITLE
Issue: #13283: Test: closeDialogFlow test for ChangeNoteTypeViewModel

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeViewModel.kt
@@ -329,7 +329,6 @@ class ChangeNoteTypeViewModel(
      * @throws ConfirmModSchemaException if a one-way sync dialog needs to be accepted
      */
     @NeedsTest("one way sync")
-    @NeedsTest("closeDialogFlow")
     fun executeChangeNoteTypeAsync() =
         viewModelScope.async {
             Timber.d("Changing note type from '%s' to '%s'", inputNoteType.name, outputNoteType.name)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/ChangeNoteTypeViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/ChangeNoteTypeViewModelTest.kt
@@ -47,6 +47,23 @@ class ChangeNoteTypeViewModelTest : RobolectricTest() {
         }
 
     @Test
+    fun `closeDialogFlow emits unit on success`() =
+        viewModelTest {
+            val basicAndOptionalReversed = col.notetypes.byName("Basic (optional reversed card)")!!
+            setOutputNoteType(basicAndOptionalReversed)
+
+            closeDialogFlow.test {
+                // MutableStateFlow emits its initial value (null) immediately.
+                assertThat(awaitItem(), equalTo(null))
+
+                val changes = executeChangeNoteTypeAsync().await()
+                // assert that the flow emitted unit after execution
+                assertThat(awaitItem(), equalTo(Unit))
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
     fun `integration test - regular`() =
         viewModelTest {
             // A basic card mapped to '"Basic (optional reversed card)"'


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

<!---
Uncomment this section if AI tools were used. New contributors may not use AI tools. See:<!--- Please fill the necessary details below -->

<!---
Uncomment this section if AI tools were used. New contributors may not use AI tools. See:
https://github.com/ankidroid/Anki-Android/blob/main/AI_POLICY.md
> [!NOTE]
> Assisted-by: ___
--->

## Purpose / Description
Adding unit test coverage for `closeDialogFlow` in `ChangeNoteTypeViewModel` as requested by the @NeedsTest annotations.

## Fixes
Partially addresses #13283

## Approach
Added a new test case `closeDialogFlow emits unit on success` inside `ChangeNoteTypeViewModelTest.kt`.

## How Has This Been Tested?
Ran the test locally using JUnit testing.

## Learning (optional, can help others)

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->