### PR TITLE
refactor(tests): consolidate edge-to-edge methods

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserInsetsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserInsetsTest.kt
@@ -4,17 +4,10 @@ package com.ichi2.anki
 
 import android.view.View
 import android.view.View.MeasureSpec
-import androidx.core.view.RoundedCornerCompat
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsCompat.Type.displayCutout
-import androidx.core.view.WindowInsetsCompat.Type.navigationBars
-import androidx.core.view.WindowInsetsCompat.Type.statusBars
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.ui.RecyclerFastScroller
-import com.ichi2.testutils.insetsOf
-import com.ichi2.utils.Dp
+import com.ichi2.testutils.dispatchInsets
 import com.ichi2.utils.dp
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.allOf
@@ -248,34 +241,6 @@ class CardBrowserInsetsTest : RobolectricTest() {
 
     private val CardBrowser.fastScroller: RecyclerFastScroller
         get() = findViewById(R.id.browser_scroller)
-
-    /** Dispatches realistic system-bar insets, which Robolectric otherwise reports as zero. */
-    private fun CardBrowser.dispatchInsets(
-        navBarBottom: Dp = 0.dp,
-        navBarRight: Dp = 0.dp,
-        cutoutLeft: Dp = 0.dp,
-        bottomCornerRadius: Dp = 0.dp,
-    ) {
-        val insets =
-            with(targetContext) {
-                WindowInsetsCompat
-                    .Builder()
-                    .setInsets(statusBars(), insetsOf(top = 24.dp))
-                    .setInsets(navigationBars(), insetsOf(right = navBarRight, bottom = navBarBottom))
-                    .setInsets(displayCutout(), insetsOf(left = cutoutLeft))
-                    .apply {
-                        val radius = bottomCornerRadius.toPx(targetContext)
-                        if (radius > 0) {
-                            // only the radius is read by the implementation; the center is unused
-                            setRoundedCorner(
-                                RoundedCornerCompat.POSITION_BOTTOM_LEFT,
-                                RoundedCornerCompat(RoundedCornerCompat.POSITION_BOTTOM_LEFT, radius, radius, radius),
-                            )
-                        }
-                    }.build()
-            }
-        ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
-    }
 
     /** Forces a measure/layout pass so view bounds (not just padding/insets) can be asserted. */
     private fun CardBrowser.layoutForTest() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerInsetsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerInsetsTest.kt
@@ -7,17 +7,12 @@ import android.view.View
 import android.view.View.MeasureSpec
 import android.view.ViewGroup.MarginLayoutParams
 import androidx.core.content.edit
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsCompat.Type.navigationBars
-import androidx.core.view.WindowInsetsCompat.Type.statusBars
 import androidx.core.view.isVisible
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.android.view.locationInWindow
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.testutils.BackupManagerTestUtilities
-import com.ichi2.testutils.insetsOf
-import com.ichi2.utils.Dp
+import com.ichi2.testutils.dispatchInsets
 import com.ichi2.utils.dp
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -173,19 +168,6 @@ class DeckPickerInsetsTest : RobolectricTest() {
             val containerBottom = container.locationInWindow().y + container.height
             return containerBottom - fabBottom
         }
-
-    /** Dispatches realistic system-bar insets, which Robolectric otherwise reports as zero. */
-    private fun DeckPicker.dispatchInsets(navBarBottom: Dp) {
-        val insets =
-            with(targetContext) {
-                WindowInsetsCompat
-                    .Builder()
-                    .setInsets(statusBars(), insetsOf(top = 24.dp))
-                    .setInsets(navigationBars(), insetsOf(bottom = navBarBottom))
-                    .build()
-            }
-        ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
-    }
 
     /**
      * Forces measure/layout passes so view bounds can be asserted.

--- a/AnkiDroid/src/test/java/com/ichi2/anki/InfoInsetsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/InfoInsetsTest.kt
@@ -4,15 +4,8 @@ package com.ichi2.anki
 
 import android.content.Intent
 import android.view.View
-import androidx.core.view.RoundedCornerCompat
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsCompat.Type.displayCutout
-import androidx.core.view.WindowInsetsCompat.Type.navigationBars
-import androidx.core.view.WindowInsetsCompat.Type.statusBars
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.testutils.insetsOf
-import com.ichi2.utils.Dp
+import com.ichi2.testutils.dispatchInsets
 import com.ichi2.utils.dp
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -124,34 +117,6 @@ class InfoInsetsTest : RobolectricTest() {
 
     private val Info.content: View
         get() = findViewById(R.id.content)
-
-    /** Dispatches realistic system-bar insets, which Robolectric otherwise reports as zero. */
-    private fun Info.dispatchInsets(
-        navBarBottom: Dp = 0.dp,
-        navBarRight: Dp = 0.dp,
-        cutoutLeft: Dp = 0.dp,
-        bottomCornerRadius: Dp = 0.dp,
-    ) {
-        val insets =
-            with(targetContext) {
-                WindowInsetsCompat
-                    .Builder()
-                    .setInsets(statusBars(), insetsOf(top = 24.dp))
-                    .setInsets(navigationBars(), insetsOf(right = navBarRight, bottom = navBarBottom))
-                    .setInsets(displayCutout(), insetsOf(left = cutoutLeft))
-                    .apply {
-                        val radius = bottomCornerRadius.toPx(targetContext)
-                        if (radius > 0) {
-                            // only the radius is read by the implementation; the center is unused
-                            setRoundedCorner(
-                                RoundedCornerCompat.POSITION_BOTTOM_LEFT,
-                                RoundedCornerCompat(RoundedCornerCompat.POSITION_BOTTOM_LEFT, radius, radius, radius),
-                            )
-                        }
-                    }.build()
-            }
-        ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
-    }
 
     private fun withInfo(block: (Info) -> Unit) =
         block(

--- a/AnkiDroid/src/test/java/com/ichi2/anki/IntroductionInsetsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/IntroductionInsetsTest.kt
@@ -4,16 +4,9 @@ package com.ichi2.anki
 
 import android.content.Intent
 import android.view.View
-import androidx.core.view.RoundedCornerCompat
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsCompat.Type.displayCutout
-import androidx.core.view.WindowInsetsCompat.Type.navigationBars
-import androidx.core.view.WindowInsetsCompat.Type.statusBars
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.introduction.SetupCollectionFragment
-import com.ichi2.testutils.insetsOf
-import com.ichi2.utils.Dp
+import com.ichi2.testutils.dispatchInsets
 import com.ichi2.utils.dp
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -95,34 +88,6 @@ class IntroductionInsetsTest : RobolectricTest() {
     /** Everything except the gradient: the view taking the side insets */
     private val IntroductionActivity.content: View
         get() = findViewById(R.id.intro_content)
-
-    /** Dispatches realistic system-bar insets, which Robolectric otherwise reports as zero. */
-    private fun IntroductionActivity.dispatchInsets(
-        navBarBottom: Dp = 0.dp,
-        navBarRight: Dp = 0.dp,
-        cutoutLeft: Dp = 0.dp,
-        bottomCornerRadius: Dp = 0.dp,
-    ) {
-        val insets =
-            with(targetContext) {
-                WindowInsetsCompat
-                    .Builder()
-                    .setInsets(statusBars(), insetsOf(top = 24.dp))
-                    .setInsets(navigationBars(), insetsOf(right = navBarRight, bottom = navBarBottom))
-                    .setInsets(displayCutout(), insetsOf(left = cutoutLeft))
-                    .apply {
-                        val radius = bottomCornerRadius.toPx(targetContext)
-                        if (radius > 0) {
-                            // only the radius is read by the implementation; the center is unused
-                            setRoundedCorner(
-                                RoundedCornerCompat.POSITION_BOTTOM_LEFT,
-                                RoundedCornerCompat(RoundedCornerCompat.POSITION_BOTTOM_LEFT, radius, radius, radius),
-                            )
-                        }
-                    }.build()
-            }
-        ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
-    }
 
     private fun withIntroduction(block: (IntroductionActivity) -> Unit) =
         block(

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorInsetsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorInsetsTest.kt
@@ -7,21 +7,13 @@ import android.view.View
 import android.view.ViewGroup.MarginLayoutParams
 import android.widget.HorizontalScrollView
 import androidx.core.content.edit
-import androidx.core.view.RoundedCornerCompat
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsCompat.Type.displayCutout
-import androidx.core.view.WindowInsetsCompat.Type.ime
-import androidx.core.view.WindowInsetsCompat.Type.navigationBars
-import androidx.core.view.WindowInsetsCompat.Type.statusBars
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SdkSuppress
 import com.ichi2.anki.common.destinations.NoteEditorDestination
 import com.ichi2.anki.noteeditor.getNoteEditorFragment
 import com.ichi2.anki.noteeditor.toIntent
-import com.ichi2.testutils.insetsOf
+import com.ichi2.testutils.dispatchInsets
 import com.ichi2.testutils.withSplitPaneUi
-import com.ichi2.utils.Dp
 import com.ichi2.utils.dp
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -268,36 +260,6 @@ class NoteEditorInsetsTest : RobolectricTest() {
     private val NoteEditorActivity.editorFields: View get() = findViewById(R.id.note_editor_layout)
 
     private val NoteEditorActivity.fragmentRoot: View get() = getNoteEditorFragment().requireView()
-
-    /** Dispatches realistic system-bar insets, which Robolectric otherwise reports as zero. */
-    private fun NoteEditorActivity.dispatchInsets(
-        navBarBottom: Dp = 0.dp,
-        navBarRight: Dp = 0.dp,
-        cutoutLeft: Dp = 0.dp,
-        bottomCornerRadius: Dp = 0.dp,
-        imeBottom: Dp = 0.dp,
-    ) {
-        val insets =
-            with(targetContext) {
-                WindowInsetsCompat
-                    .Builder()
-                    .setInsets(statusBars(), insetsOf(top = 24.dp))
-                    .setInsets(navigationBars(), insetsOf(right = navBarRight, bottom = navBarBottom))
-                    .setInsets(displayCutout(), insetsOf(left = cutoutLeft))
-                    .setInsets(ime(), insetsOf(bottom = imeBottom))
-                    .apply {
-                        // Robolectric's WindowInsets.Builder leaks rounded corners between tests
-                        val radius = bottomCornerRadius.toPx(targetContext)
-                        for (position in intArrayOf(
-                            RoundedCornerCompat.POSITION_BOTTOM_LEFT,
-                            RoundedCornerCompat.POSITION_BOTTOM_RIGHT,
-                        )) {
-                            setRoundedCorner(position, RoundedCornerCompat(position, radius, radius, radius))
-                        }
-                    }.build()
-            }
-        ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
-    }
 
     private fun withNoteEditor(block: (NoteEditorActivity) -> Unit) {
         val activity =

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerInsetsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerInsetsTest.kt
@@ -8,19 +8,12 @@ import android.view.View
 import android.view.WindowInsets
 import android.view.WindowInsetsAnimation
 import androidx.core.content.edit
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsCompat.Type.displayCutout
-import androidx.core.view.WindowInsetsCompat.Type.ime
-import androidx.core.view.WindowInsetsCompat.Type.navigationBars
-import androidx.core.view.WindowInsetsCompat.Type.statusBars
 import androidx.core.view.marginBottom
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SdkSuppress
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.reviewer.FullScreenMode
-import com.ichi2.testutils.insetsOf
-import com.ichi2.utils.Dp
+import com.ichi2.testutils.dispatchInsets
 import com.ichi2.utils.dp
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -496,41 +489,6 @@ class ReviewerInsetsTest : RobolectricTest() {
 
     private val Reviewer.answerArea: View
         get() = findViewById(R.id.answer_options_layout)
-
-    /**
-     * Dispatches realistic system-bar insets, which Robolectric otherwise reports as zero.
-     *
-     * The 'stable' insets ([WindowInsetsCompat.getInsetsIgnoringVisibility]) report the bars'
-     * regions whether or not they are currently visible: [navBarStableBottom] stays reported
-     * while immersive mode hides the bars themselves.
-     */
-    private fun Reviewer.dispatchInsets(
-        navBarBottom: Dp = 0.dp,
-        navBarRight: Dp = 0.dp,
-        navBarStableBottom: Dp = navBarBottom,
-        cutoutLeft: Dp = 0.dp,
-        cutoutTop: Dp = 0.dp,
-        imeBottom: Dp = 0.dp,
-        barsVisible: Boolean = true,
-    ) {
-        val insets =
-            with(targetContext) {
-                WindowInsetsCompat
-                    .Builder()
-                    .setInsets(statusBars(), insetsOf(top = if (barsVisible) 24.dp else 0.dp))
-                    .setInsetsIgnoringVisibility(statusBars(), insetsOf(top = 24.dp))
-                    .setInsets(navigationBars(), insetsOf(right = navBarRight, bottom = navBarBottom))
-                    .setInsetsIgnoringVisibility(
-                        navigationBars(),
-                        insetsOf(right = navBarRight, bottom = navBarStableBottom),
-                    ).setInsets(displayCutout(), insetsOf(left = cutoutLeft, top = cutoutTop))
-                    .setInsetsIgnoringVisibility(displayCutout(), insetsOf(left = cutoutLeft, top = cutoutTop))
-                    .setInsets(ime(), insetsOf(bottom = imeBottom))
-                    .setVisible(statusBars() or navigationBars(), barsVisible)
-                    .build()
-            }
-        ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
-    }
 
     private fun withReviewer(
         answerButtonsPosition: String? = null,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/account/AccountInsetsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/account/AccountInsetsTest.kt
@@ -4,20 +4,12 @@ package com.ichi2.anki.account
 
 import android.view.View
 import android.widget.Button
-import androidx.core.view.RoundedCornerCompat
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsCompat.Type.displayCutout
-import androidx.core.view.WindowInsetsCompat.Type.ime
-import androidx.core.view.WindowInsetsCompat.Type.navigationBars
-import androidx.core.view.WindowInsetsCompat.Type.statusBars
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.databinding.FragmentPageBinding
 import com.ichi2.anki.settings.Prefs
-import com.ichi2.testutils.insetsOf
-import com.ichi2.utils.Dp
+import com.ichi2.testutils.dispatchInsets
 import com.ichi2.utils.dp
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -152,36 +144,6 @@ class AccountInsetsTest : RobolectricTest() {
     private val AccountActivity.toolbarContainer: View get() = findViewById(R.id.toolbar_container)
 
     private val AccountActivity.content: View get() = findViewById(R.id.account_content)
-
-    /** Dispatches realistic system-bar insets, which Robolectric otherwise reports as zero. */
-    private fun AccountActivity.dispatchInsets(
-        navBarBottom: Dp = 0.dp,
-        navBarRight: Dp = 0.dp,
-        cutoutLeft: Dp = 0.dp,
-        bottomCornerRadius: Dp = 0.dp,
-        imeBottom: Dp = 0.dp,
-    ) {
-        val insets =
-            with(targetContext) {
-                WindowInsetsCompat
-                    .Builder()
-                    .setInsets(statusBars(), insetsOf(top = 24.dp))
-                    .setInsets(navigationBars(), insetsOf(right = navBarRight, bottom = navBarBottom))
-                    .setInsets(displayCutout(), insetsOf(left = cutoutLeft))
-                    .setInsets(ime(), insetsOf(bottom = imeBottom))
-                    .apply {
-                        val radius = bottomCornerRadius.toPx(targetContext)
-                        if (radius > 0) {
-                            // only the radius is read by the implementation; the center is unused
-                            setRoundedCorner(
-                                RoundedCornerCompat.POSITION_BOTTOM_LEFT,
-                                RoundedCornerCompat(RoundedCornerCompat.POSITION_BOTTOM_LEFT, radius, radius, radius),
-                            )
-                        }
-                    }.build()
-            }
-        ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
-    }
 
     private fun withLoginScreen(block: (AccountActivity) -> Unit) {
         Prefs.hkey = ""

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimedia/MultimediaInsetsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimedia/MultimediaInsetsTest.kt
@@ -4,12 +4,6 @@ package com.ichi2.anki.multimedia
 
 import android.Manifest.permission.RECORD_AUDIO
 import android.view.View
-import androidx.core.view.RoundedCornerCompat
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsCompat.Type.displayCutout
-import androidx.core.view.WindowInsetsCompat.Type.navigationBars
-import androidx.core.view.WindowInsetsCompat.Type.statusBars
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
@@ -17,9 +11,8 @@ import com.ichi2.anki.databinding.ActivityMultimediaBinding
 import com.ichi2.anki.multimediacard.fields.AudioRecordingField
 import com.ichi2.anki.multimediacard.fields.TextField
 import com.ichi2.anki.multimediacard.impl.MultimediaEditableNote
+import com.ichi2.testutils.dispatchInsets
 import com.ichi2.testutils.grantPermissions
-import com.ichi2.testutils.insetsOf
-import com.ichi2.utils.Dp
 import com.ichi2.utils.dp
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -97,34 +90,6 @@ class MultimediaInsetsTest : RobolectricTest() {
     /** The hosted fragment's own root, which [MultimediaFragment] insets */
     private val MultimediaActivity.fragmentRoot: View
         get() = supportFragmentManager.findFragmentById(R.id.fragment_container)!!.requireView()
-
-    /** Dispatches realistic system-bar insets, which Robolectric otherwise reports as zero. */
-    private fun MultimediaActivity.dispatchInsets(
-        navBarBottom: Dp = 0.dp,
-        navBarRight: Dp = 0.dp,
-        cutoutLeft: Dp = 0.dp,
-        bottomCornerRadius: Dp = 0.dp,
-    ) {
-        val insets =
-            with(targetContext) {
-                WindowInsetsCompat
-                    .Builder()
-                    .setInsets(statusBars(), insetsOf(top = 24.dp))
-                    .setInsets(navigationBars(), insetsOf(right = navBarRight, bottom = navBarBottom))
-                    .setInsets(displayCutout(), insetsOf(left = cutoutLeft))
-                    .apply {
-                        val radius = bottomCornerRadius.toPx(targetContext)
-                        if (radius > 0) {
-                            // only the radius is read by the implementation; the center is unused
-                            setRoundedCorner(
-                                RoundedCornerCompat.POSITION_BOTTOM_LEFT,
-                                RoundedCornerCompat(RoundedCornerCompat.POSITION_BOTTOM_LEFT, radius, radius, radius),
-                            )
-                        }
-                    }.build()
-            }
-        ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
-    }
 
     private fun withMultimedia(block: (MultimediaActivity) -> Unit) {
         grantPermissions(RECORD_AUDIO)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersInsetsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersInsetsTest.kt
@@ -8,10 +8,6 @@ import android.view.View
 import android.view.WindowManager
 import androidx.annotation.IdRes
 import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsCompat.Type.displayCutout
-import androidx.core.view.WindowInsetsCompat.Type.navigationBars
-import androidx.core.view.WindowInsetsCompat.Type.statusBars
 import androidx.core.view.isVisible
 import androidx.core.view.marginBottom
 import androidx.core.view.marginRight
@@ -38,7 +34,7 @@ import com.ichi2.anki.reviewreminders.ScheduleRemindersFragment.FragmentHost
 import com.ichi2.anki.utils.ConfigAwareSingleFragmentActivity
 import com.ichi2.anki.withDeckPicker
 import com.ichi2.testutils.BackupManagerTestUtilities
-import com.ichi2.testutils.insetsOf
+import com.ichi2.testutils.windowInsetsOf
 import com.ichi2.testutils.withWritePermissions
 import com.ichi2.utils.Dp
 import com.ichi2.utils.dp
@@ -63,7 +59,7 @@ import org.robolectric.annotation.Config
  */
 @RunWith(AndroidJUnit4::class)
 class ReviewRemindersInsetsTest : RobolectricTest() {
-    /** The height of the simulated status bar */
+    /** The height of the status bar simulated by [windowInsetsOf] */
     private val statusBarHeight = 24.dp
 
     /** The size of the simulated navigation bar: its height, or its width when on the side of the screen */
@@ -353,12 +349,7 @@ class ReviewRemindersInsetsTest : RobolectricTest() {
     ) {
         val insets =
             with(targetContext) {
-                WindowInsetsCompat
-                    .Builder()
-                    .setInsets(statusBars(), insetsOf(top = statusBarHeight))
-                    .setInsets(navigationBars(), insetsOf(right = navBarRight, bottom = navBarBottom))
-                    .setInsets(displayCutout(), insetsOf(left = cutoutLeft))
-                    .build()
+                windowInsetsOf(navBarBottom = navBarBottom, navBarRight = navBarRight, cutoutLeft = cutoutLeft)
             }
         ViewCompat.dispatchApplyWindowInsets(findViewById(android.R.id.content), insets)
         // relayout synchronously so the insets affect view positions before the test asserts

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/managespace/ManageSpaceInsetsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/managespace/ManageSpaceInsetsTest.kt
@@ -3,18 +3,11 @@
 package com.ichi2.anki.ui.windows.managespace
 
 import android.content.Intent
-import androidx.core.view.RoundedCornerCompat
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsCompat.Type.displayCutout
-import androidx.core.view.WindowInsetsCompat.Type.navigationBars
-import androidx.core.view.WindowInsetsCompat.Type.statusBars
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.databinding.FragmentSettingsBinding
-import com.ichi2.testutils.insetsOf
-import com.ichi2.utils.Dp
+import com.ichi2.testutils.dispatchInsets
 import com.ichi2.utils.dp
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -66,34 +59,6 @@ class ManageSpaceInsetsTest : RobolectricTest() {
         get() = FragmentSettingsBinding.bind(manageSpaceFragment.requireView())
 
     private val ManageSpaceActivity.preferenceList: RecyclerView get() = manageSpaceFragment.listView
-
-    /** Dispatches realistic system-bar insets, which Robolectric otherwise reports as zero. */
-    private fun ManageSpaceActivity.dispatchInsets(
-        navBarBottom: Dp = 0.dp,
-        navBarRight: Dp = 0.dp,
-        cutoutLeft: Dp = 0.dp,
-        bottomCornerRadius: Dp = 0.dp,
-    ) {
-        val insets =
-            with(targetContext) {
-                WindowInsetsCompat
-                    .Builder()
-                    .setInsets(statusBars(), insetsOf(top = 24.dp))
-                    .setInsets(navigationBars(), insetsOf(right = navBarRight, bottom = navBarBottom))
-                    .setInsets(displayCutout(), insetsOf(left = cutoutLeft))
-                    .apply {
-                        val radius = bottomCornerRadius.toPx(targetContext)
-                        if (radius > 0) {
-                            // only the radius is read by the implementation; the center is unused
-                            setRoundedCorner(
-                                RoundedCornerCompat.POSITION_BOTTOM_LEFT,
-                                RoundedCornerCompat(RoundedCornerCompat.POSITION_BOTTOM_LEFT, radius, radius, radius),
-                            )
-                        }
-                    }.build()
-            }
-        ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
-    }
 
     private fun withManageSpace(block: (ManageSpaceActivity) -> Unit) {
         val activity =

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/InsetsUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/InsetsUtils.kt
@@ -10,9 +10,11 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.core.graphics.Insets
+import androidx.core.view.RoundedCornerCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsCompat.Type.displayCutout
+import androidx.core.view.WindowInsetsCompat.Type.ime
 import androidx.core.view.WindowInsetsCompat.Type.navigationBars
 import androidx.core.view.WindowInsetsCompat.Type.statusBars
 import com.ichi2.anki.RobolectricTest.Companion.advanceRobolectricLooper
@@ -43,6 +45,90 @@ fun insetsOf(
         right.toPx(context),
         bottom.toPx(context),
     )
+
+/**
+ * Builds realistic window insets, for Robolectric.
+ *
+ * A 24dp status bar is always present, others are optional:
+ *
+ * ```kt
+ * windowInsetsOf(navBarRight = 48.dp, cutoutLeft = 32.dp)
+ * ```
+ *
+ * The 'stable' insets ([WindowInsetsCompat.getInsetsIgnoringVisibility]) report the bars'
+ * regions whether or not the bars are currently visible: [navBarStableBottom] stays reported
+ * while immersive mode hides the bars themselves.
+ *
+ * @param navBarBottom a navigation bar along the bottom edge. Always appears in portrait,
+ * on tablets, or if gesture navigation is enabled.
+ * @param navBarRight a navigation bar along the right edge (phones in landscape mode with 3-button
+ * navigation)
+ * @param navBarStableBottom the bottom navigation bar's region, as still reported while it is hidden
+ * @param cutoutLeft a display cutout on the left edge (landscape phone with a notch)
+ * @param cutoutTop a display cutout on the top edge (portrait phone with a notch)
+ * @param bottomCornerRadius the radius of both bottom rounded display corners
+ * @param imeBottom the height of the on-screen keyboard
+ * @param barsVisible whether the status and navigation bars are shown; `false` in immersive mode
+ */
+context(context: Context)
+fun windowInsetsOf(
+    navBarBottom: Dp = 0.dp,
+    navBarRight: Dp = 0.dp,
+    navBarStableBottom: Dp = navBarBottom,
+    cutoutLeft: Dp = 0.dp,
+    cutoutTop: Dp = 0.dp,
+    bottomCornerRadius: Dp = 0.dp,
+    imeBottom: Dp = 0.dp,
+    barsVisible: Boolean = true,
+): WindowInsetsCompat =
+    WindowInsetsCompat
+        .Builder()
+        .setInsets(statusBars(), insetsOf(top = if (barsVisible) 24.dp else 0.dp))
+        .setInsetsIgnoringVisibility(statusBars(), insetsOf(top = 24.dp))
+        .setInsets(navigationBars(), insetsOf(right = navBarRight, bottom = navBarBottom))
+        .setInsetsIgnoringVisibility(
+            navigationBars(),
+            insetsOf(right = navBarRight, bottom = navBarStableBottom),
+        ).setInsets(displayCutout(), insetsOf(left = cutoutLeft, top = cutoutTop))
+        .setInsetsIgnoringVisibility(displayCutout(), insetsOf(left = cutoutLeft, top = cutoutTop))
+        .setInsets(ime(), insetsOf(bottom = imeBottom))
+        .setVisible(statusBars() or navigationBars(), barsVisible)
+        .apply {
+            // set even when zero: Robolectric's WindowInsets.Builder leaks rounded corners between tests
+            val radius = bottomCornerRadius.toPx(context)
+            for (position in intArrayOf(RoundedCornerCompat.POSITION_BOTTOM_LEFT, RoundedCornerCompat.POSITION_BOTTOM_RIGHT)) {
+                setRoundedCorner(position, RoundedCornerCompat(position, radius, radius, radius))
+            }
+        }.build()
+
+/**
+ * Dispatches [windowInsetsOf] at the decor, as an edge-to-edge device does.
+ *
+ * Robolectric otherwise reports all insets as zero.
+ */
+fun Activity.dispatchInsets(
+    navBarBottom: Dp = 0.dp,
+    navBarRight: Dp = 0.dp,
+    navBarStableBottom: Dp = navBarBottom,
+    cutoutLeft: Dp = 0.dp,
+    cutoutTop: Dp = 0.dp,
+    bottomCornerRadius: Dp = 0.dp,
+    imeBottom: Dp = 0.dp,
+    barsVisible: Boolean = true,
+) {
+    val insets =
+        windowInsetsOf(
+            navBarBottom = navBarBottom,
+            navBarRight = navBarRight,
+            navBarStableBottom = navBarStableBottom,
+            cutoutLeft = cutoutLeft,
+            cutoutTop = cutoutTop,
+            bottomCornerRadius = bottomCornerRadius,
+            imeBottom = imeBottom,
+            barsVisible = barsVisible,
+        )
+    ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
+}
 
 /**
  * Injects insets to simulate an edge-to-edge on a real device.


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5

## Purpose / Description
Fixes duplication of `dispatchInsets`, moved to 'InsetsUtils/windowInsetsOf'

## Fixes
* Fixes #21627

## How Has This Been Tested?
Test-only

## Learning
I need to recalibrate, I knew this was happening, but getting the functionality out was more important than slowing down the review queue with refactoring works.

Thank you @ericli3690 for the push!

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)