### PR TITLE
feat(reviewer): taps on the inset count as answers

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -13,6 +13,8 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.graphics.Color
+import android.graphics.Rect
+import android.graphics.Region
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
@@ -26,7 +28,10 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.MotionEvent
 import android.view.SubMenu
+import android.view.TouchDelegate
 import android.view.View
+import android.view.ViewGroup
+import android.view.accessibility.AccessibilityNodeInfo.TouchDelegateInfo
 import android.webkit.WebView
 import android.widget.ImageView
 import android.widget.LinearLayout
@@ -39,6 +44,7 @@ import androidx.annotation.CheckResult
 import androidx.annotation.DrawableRes
 import androidx.annotation.IdRes
 import androidx.annotation.IntDef
+import androidx.annotation.RequiresApi
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.view.menu.MenuBuilder
@@ -535,7 +541,7 @@ open class Reviewer :
             clearInsets(answerField, basePadding = answerField.paddingLeft)
         }
 
-        val answerArea = findViewById<View>(R.id.answer_options_layout)
+        val answerArea = findViewById<ViewGroup>(R.id.answer_options_layout)
         answerArea.setBackgroundColor(MaterialColors.getColor(this, R.attr.showAnswerColor, 0))
         // The bottom inset is painted showAnswerColor by the background, extending the
         // answer area's color underneath the navigation bar - or, in immersive review,
@@ -543,6 +549,7 @@ open class Reviewer :
         val answerAreaBottomHeld =
             if (immersive) resetInsetsWhenFadeEnds(answerArea, answerAreaBottom) else answerAreaBottom
         clearInsets(answerArea, bottom = answerAreaBottomHeld)
+        extendAnswerButtonsIntoInsets(answerArea)
 
         syncControlsWithSystemBars()
     }
@@ -593,6 +600,79 @@ open class Reviewer :
             }
         }
     }
+
+    /**
+     * Allows a user to tap the inset below 'show answer' to flip or answer a card.
+     * The inset is the same color as 'show answer', so it looks to be an extension
+     * of the button.
+     */
+    private fun extendAnswerButtonsIntoInsets(answerArea: ViewGroup) {
+        val buttons =
+            listOf(
+                R.id.flashcard_layout_flip,
+                R.id.flashcard_layout_ease1,
+                R.id.flashcard_layout_ease2,
+                R.id.flashcard_layout_ease3,
+                R.id.flashcard_layout_ease4,
+            ).map { answerArea.findViewById<View>(it) }
+        answerArea.touchDelegate = AnswerBandTouchDelegate(answerArea, buttons)
+    }
+
+    /** Routes a touch below a button to the button itself. */
+    private class AnswerBandTouchDelegate(
+        private val answerArea: ViewGroup,
+        private val buttons: List<View>,
+    ) : TouchDelegate(Rect(), answerArea) {
+        /** The button's delegate which took the current gesture's DOWN */
+        private var active: TouchDelegate? = null
+
+        /** The button hovered by explore by touch, via its band */
+        private var hovered: ButtonBandDelegate? = null
+
+        /** A delegate per shown button, bounded by the button and its bands as laid out now */
+        private fun bandDelegates(): List<ButtonBandDelegate> =
+            buttons.filter { it.isShown }.map { ButtonBandDelegate(answerArea.touchBoundsOf(it), it) }
+
+        override fun onTouchEvent(event: MotionEvent): Boolean {
+            if (event.actionMasked == MotionEvent.ACTION_DOWN) {
+                // bounds are read at the DOWN, so a layout pass mid-gesture cannot stale them
+                active = bandDelegates().firstOrNull { it.takes(event) }
+                return active != null
+            }
+            return active?.takes(event) ?: false
+        }
+
+        /** Handle talkback events: the area below the buttons delegates to the buttons. */
+        @RequiresApi(Build.VERSION_CODES.Q)
+        override fun onTouchExplorationHoverEvent(event: MotionEvent): Boolean {
+            val target =
+                if (event.actionMasked == MotionEvent.ACTION_HOVER_EXIT) {
+                    null
+                } else {
+                    bandDelegates().firstOrNull { it.bounds.contains(event.x.toInt(), event.y.toInt()) }
+                }
+            if (target?.button === hovered?.button) return target?.hovers(event, event.action) ?: false
+            // the finger crossed onto, off, or between bands: switch the buttons' hover
+            hovered?.hovers(event, MotionEvent.ACTION_HOVER_EXIT)
+            hovered = target
+            return target?.hovers(event, MotionEvent.ACTION_HOVER_ENTER) ?: false
+        }
+
+        /** The bands' regions: [View] forwards explore by touch inside them to [onTouchExplorationHoverEvent] */
+        @RequiresApi(Build.VERSION_CODES.Q)
+        override fun getTouchDelegateInfo(): TouchDelegateInfo {
+            val bands = bandDelegates()
+            // TouchDelegateInfo rejects an empty map: with no button shown there are no bands
+            if (bands.isEmpty()) return super.getTouchDelegateInfo()
+            return TouchDelegateInfo(bands.associate { Region(it.bounds) to it.button })
+        }
+    }
+
+    /** A button's [TouchDelegate], keeping [bounds] and [button] for [AnswerBandTouchDelegate] */
+    private class ButtonBandDelegate(
+        val bounds: Rect,
+        val button: View,
+    ) : TouchDelegate(bounds, button)
 
     /**
      * Immersive review: fades the overlaid controls in and out with the system bars
@@ -2074,4 +2154,52 @@ open class Reviewer :
         val gesture = (binding.binding as? Binding.GestureInput)?.gesture
         return executeCommand(action, gesture)
     }
+}
+
+/** Runs [block] on a copy of this event, recycled afterwards */
+private inline fun <T> MotionEvent.withCopy(block: (MotionEvent) -> T): T {
+    val copy = MotionEvent.obtain(this)
+    try {
+        return block(copy)
+    } finally {
+        copy.recycle()
+    }
+}
+
+/**
+ * Offers [event] to the delegate, which takes it if its bounds contain the touch.
+ * Given a copy: [TouchDelegate.onTouchEvent] rewrites the event's location to its view
+ *
+ * @return whether the delegate's view handled [event]: `false` if the touch is outside its bounds
+ */
+private fun TouchDelegate.takes(event: MotionEvent): Boolean = event.withCopy { onTouchEvent(it) }
+
+/**
+ * Explore by touch: forwards [event] to the delegate's view as [action], hovering it
+ *
+ * @return whether the delegate's view handled the hover
+ */
+@RequiresApi(Build.VERSION_CODES.Q)
+private fun TouchDelegate.hovers(
+    event: MotionEvent,
+    action: Int,
+): Boolean =
+    event.withCopy { copy ->
+        copy.action = action
+        onTouchExplorationHoverEvent(copy)
+    }
+
+/**
+ * [button]'s bounds, including insets:
+ * * the inset area under the button (if touching the bottom; not the top row of large answer buttons)
+ * * the sides of the button if it's at the far left/right of the answer area
+ */
+private fun ViewGroup.touchBoundsOf(button: View): Rect {
+    val bounds = Rect()
+    button.getDrawingRect(bounds)
+    offsetDescendantRectToMyCoords(button, bounds)
+    if (bounds.left <= paddingLeft) bounds.left = 0
+    if (bounds.right >= width - paddingRight) bounds.right = width
+    if (bounds.bottom >= height - paddingBottom) bounds.bottom = height
+    return bounds
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerInsetsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerInsetsTest.kt
@@ -3,10 +3,14 @@
 package com.ichi2.anki
 
 import android.annotation.SuppressLint
+import android.graphics.Rect
 import android.os.Build
+import android.view.MotionEvent
 import android.view.View
+import android.view.ViewGroup
 import android.view.WindowInsets
 import android.view.WindowInsetsAnimation
+import androidx.annotation.IdRes
 import androidx.core.content.edit
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -470,6 +474,143 @@ class ReviewerInsetsTest : RobolectricTest() {
         }
     }
 
+    @Test
+    fun `taps on the answer area's inset band press the button above it`() =
+        withReviewer { reviewer ->
+            reviewer.dispatchInsets(navBarBottom = 48.dp)
+            advanceRobolectricLooper()
+
+            assertThat("the card starts on the question side", reviewer.isDisplayingAnswer, equalTo(false))
+            // tap the showAnswerColor band painted below 'Show answer'
+            reviewer.tapBottomBand(below = R.id.flashcard_layout_flip)
+            advanceRobolectricLooper()
+            assertThat(
+                "a tap on the band below 'Show answer' flips the card",
+                reviewer.isDisplayingAnswer,
+                equalTo(true),
+            )
+
+            // the ease buttons replace the flip button; the band under 'Good' answers Good
+            reviewer.tapBottomBand(below = R.id.flashcard_layout_ease3)
+            advanceRobolectricLooper()
+            assertThat(
+                "a tap on the band below an ease button answers the card",
+                reviewer.isDisplayingAnswer,
+                equalTo(false),
+            )
+            assertThat("the card was answered 'Good'", lastAnsweredEase(), equalTo(REVLOG_EASE_GOOD))
+        }
+
+    @Test
+    fun `taps on the answer area's side band press the outer button beside it`() =
+        withReviewer { reviewer ->
+            reviewer.dispatchInsets(navBarBottom = 48.dp, cutoutLeft = 24.dp)
+            advanceRobolectricLooper()
+
+            assertThat(
+                "the answer area clears the cutout",
+                reviewer.answerArea.paddingLeft,
+                equalTo(24.dp.toPx(targetContext)),
+            )
+            // tap inside the cutout strip, level with 'Show answer'
+            reviewer.answerArea.tap(x = 1f, y = 1f)
+            advanceRobolectricLooper()
+            assertThat(
+                "a tap on the band beside 'Show answer' flips the card",
+                reviewer.isDisplayingAnswer,
+                equalTo(true),
+            )
+        }
+
+    @Test
+    fun `answer buttons at the top - taps on the side band press the outer button beside it`() =
+        withReviewer(answerButtonsPosition = "top") { reviewer ->
+            reviewer.dispatchInsets(cutoutLeft = 24.dp)
+            advanceRobolectricLooper()
+
+            assertThat(
+                "the answer area clears the cutout",
+                reviewer.answerArea.paddingLeft,
+                equalTo(24.dp.toPx(targetContext)),
+            )
+            reviewer.answerArea.tap(x = 1f, y = 1f)
+            advanceRobolectricLooper()
+            assertThat(
+                "a tap on the band beside 'Show answer' flips the card",
+                reviewer.isDisplayingAnswer,
+                equalTo(true),
+            )
+        }
+
+    @Test
+    fun `large answer buttons - the band below a bottom-row button presses only that button`() {
+        // large answer buttons are laid out in two rows: Hard and Easy above Again and Good
+        targetContext.sharedPrefs().edit { putBoolean("showLargeAnswerButtons", true) }
+        withReviewer { reviewer ->
+            reviewer.dispatchInsets(navBarBottom = 48.dp)
+            advanceRobolectricLooper()
+            reviewer.tapBottomBand(below = R.id.flashcard_layout_flip)
+            advanceRobolectricLooper()
+            assertThat("the ease buttons are shown", reviewer.isDisplayingAnswer, equalTo(true))
+
+            val hardBounds = reviewer.boundsInAnswerArea(R.id.flashcard_layout_ease2)
+            val againBounds = reviewer.boundsInAnswerArea(R.id.flashcard_layout_ease1)
+            assertThat("'Hard' is laid out above 'Again'", hardBounds.bottom, equalTo(againBounds.top))
+
+            // press, without releasing, the band below 'Again'
+            reviewer.answerArea.touch(MotionEvent.ACTION_DOWN, x = againBounds.exactCenterX(), y = reviewer.answerArea.height - 1f)
+            // inside a CoordinatorLayout, a press is only confirmed after the tap timeout
+            advanceRobolectricLooper()
+            assertThat(
+                "the band presses 'Again'",
+                reviewer.findViewById<View>(R.id.flashcard_layout_ease1).isPressed,
+                equalTo(true),
+            )
+            assertThat(
+                "the band leaves 'Hard', above 'Again', alone",
+                reviewer.findViewById<View>(R.id.flashcard_layout_ease2).isPressed,
+                equalTo(false),
+            )
+        }
+    }
+
+    /** The ease recorded for the most recent answer */
+    private fun lastAnsweredEase(): Long = col.db.queryLongScalar("select ease from revlog order by id desc limit 1")
+
+    /** The bounds of [button], in the answer area's coordinates */
+    private fun Reviewer.boundsInAnswerArea(
+        @IdRes button: Int,
+    ): Rect {
+        val view = findViewById<View>(button)
+        return Rect().also {
+            view.getDrawingRect(it)
+            answerArea.offsetDescendantRectToMyCoords(view, it)
+        }
+    }
+
+    /** Taps the showAnswerColor band painted [below] a button */
+    private fun Reviewer.tapBottomBand(
+        @IdRes below: Int,
+    ) = answerArea.tap(x = boundsInAnswerArea(below).exactCenterX(), y = answerArea.height - 1f)
+
+    private fun View.tap(
+        x: Float,
+        y: Float,
+    ) {
+        touch(MotionEvent.ACTION_DOWN, x, y)
+        touch(MotionEvent.ACTION_UP, x, y)
+    }
+
+    private fun View.touch(
+        action: Int,
+        x: Float,
+        y: Float,
+    ) {
+        val event = MotionEvent.obtain(0, 0, action, x, y, 0)
+        dispatchTouchEvent(event)
+        event.recycle()
+    }
+
     private val Reviewer.rootLayout: View
         get() = findViewById(R.id.root_layout)
 
@@ -494,7 +635,7 @@ class ReviewerInsetsTest : RobolectricTest() {
     private val Reviewer.typeAnswerField: View
         get() = findViewById(R.id.answer_field)
 
-    private val Reviewer.answerArea: View
+    private val Reviewer.answerArea: ViewGroup
         get() = findViewById(R.id.answer_options_layout)
 
     /**
@@ -545,3 +686,6 @@ class ReviewerInsetsTest : RobolectricTest() {
         block(ReviewerTest.startReviewer(this))
     }
 }
+
+/** The ease recorded in the revlog for a 'Good' answer */
+private const val REVLOG_EASE_GOOD = 3L


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5 & 5.1

## Fixes
* Fixes #17334
* Fixes #21504

## Approach
Define a custom `TouchDelegate` with the bounds including the insets.

## How Has This Been Tested?
Pixel 9 Pro

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->