### PR TITLE
fix: Deck rename self conflict

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2217,6 +2217,7 @@ open class DeckPicker :
                     title = TR.sentenceCase.renameDeck,
                     deckDialogType = CreateDeckDialog.DeckDialogType.RENAME_DECK,
                     parentId = null,
+                    renamedDeckId = did,
                 )
             createDeckDialog.deckName = currentName
             createDeckDialog.onNewDeckCreated = {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -27,7 +27,6 @@ import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.common.utils.android.showThemedToast
-import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.Decks
 import com.ichi2.anki.snackbar.showSnackbar
@@ -130,7 +129,8 @@ class CreateDeckDialog(
                         dialog.positiveButton.isEnabled = false
                         return@input
                     }
-                    if (!maybeDeckName.equals(initialDeckName, ignoreCase = true) && deckExists(getColUnsafe, maybeDeckName)) {
+                    val existingDeckId = getColUnsafe.decks.idForName(maybeDeckName)
+                    if (existingDeckId != null && existingDeckId != getColUnsafe.decks.idForName(initialDeckName)) {
                         dialog.getInputTextLayout().error = context.getString(R.string.error_name_exists)
                         dialog.positiveButton.isEnabled = false
                         return@input
@@ -150,14 +150,6 @@ class CreateDeckDialog(
         shownDialog = dialog
         return dialog
     }
-
-    /**
-     * @return true if the collection contains a deck with the given name
-     */
-    private fun deckExists(
-        col: Collection,
-        name: String,
-    ): Boolean = col.decks.byName(name) != null
 
     /**
      * Returns the fully qualified deck name for the provided input

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -37,6 +37,7 @@ import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
 import com.ichi2.utils.show
 import net.ankiweb.rsdroid.exceptions.BackendDeckIsFilteredException
+import net.ankiweb.rsdroid.exceptions.BackendNotFoundException
 import timber.log.Timber
 
 /**
@@ -51,11 +52,18 @@ class CreateDeckDialog(
     private val title: CharSequence,
     private val deckDialogType: DeckDialogType,
     private val parentId: DeckId?,
+    /** The deck to rename. Only used by [DeckDialogType.RENAME_DECK] */
+    private val renamedDeckId: DeckId? = null,
 ) {
-    private var previousDeckName: String? = null
     lateinit var onNewDeckCreated: ((DeckId) -> Unit)
     private var initialDeckName = ""
     private var shownDialog: AlertDialog? = null
+
+    init {
+        require(deckDialogType != DeckDialogType.RENAME_DECK || renamedDeckId != null) {
+            "renamedDeckId is required to rename a deck"
+        }
+    }
 
     enum class DeckDialogType {
         DECK,
@@ -70,7 +78,6 @@ class CreateDeckDialog(
     var deckName: String
         get() = shownDialog!!.getInputField().text.toString()
         set(deckName) {
-            previousDeckName = deckName
             initialDeckName = deckName
         }
 
@@ -130,7 +137,7 @@ class CreateDeckDialog(
                         return@input
                     }
                     val existingDeckId = getColUnsafe.decks.idForName(maybeDeckName)
-                    if (existingDeckId != null && existingDeckId != getColUnsafe.decks.idForName(initialDeckName)) {
+                    if (existingDeckId != null && existingDeckId != renamedDeckId) {
                         dialog.getInputTextLayout().error = context.getString(R.string.error_name_exists)
                         dialog.positiveButton.isEnabled = false
                         return@input
@@ -220,18 +227,21 @@ class CreateDeckDialog(
             Timber.w("CreateDeckDialog::renameDeck not renaming deck to invalid name")
             Timber.d("invalid deck name: %s", newDeckName)
             displayFeedback(context.getString(R.string.invalid_deck_name), Snackbar.LENGTH_LONG)
-        } else if (newDeckName != previousDeckName) {
+        } else {
+            val deckId = renamedDeckId!!
             try {
-                val decks = getColUnsafe.decks
-                val deckId = decks.id(previousDeckName!!)
-                decks.rename(decks.getLegacy(deckId)!!, newDeckName)
-                onNewDeckCreated(deckId)
-                // 11668: Display feedback if a deck is renamed
-                displayFeedback(context.getString(R.string.deck_renamed))
+                // the backend reports no change if the new name normalises to the old one
+                if (getColUnsafe.decks.rename(deckId, newDeckName).deck) {
+                    onNewDeckCreated(deckId)
+                    // 11668: Display feedback if a deck is renamed
+                    displayFeedback(context.getString(R.string.deck_renamed))
+                }
             } catch (e: BackendDeckIsFilteredException) {
                 Timber.w(e)
                 // We get a localized string from libanki to explain the error
                 displayFeedback(e.localizedMessage ?: e.message ?: "", Snackbar.LENGTH_LONG)
+            } catch (e: BackendNotFoundException) {
+                Timber.w(e, "not renaming deck %d", deckId)
             }
         }
         // AlertDialog should be dismissed after the Keyboard 'Done' or Deck 'Ok' button is pressed

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
@@ -252,6 +252,40 @@ class CreateDeckDialogTest : RobolectricTest() {
         }
     }
 
+    @Test
+    fun `renaming a deck with an extra colon does not conflict with itself`() {
+        testRenameDialog(currentName = "a::b") {
+            input = "a:::b"
+            assertThat("no error is displayed", getInputTextLayout().error, nullValue())
+            assertThat("rename is enabled", positiveButton.isEnabled, equalTo(true))
+        }
+    }
+
+    @Test
+    fun `renaming a deck to an existing deck name shows an error`() {
+        col.decks.id("c")
+        testRenameDialog(currentName = "a::b") {
+            input = "c"
+            assertThat(
+                "error is displayed",
+                getInputTextLayout().error?.toString(),
+                equalTo(getResourceString(R.string.error_name_exists)),
+            )
+            assertThat("rename is disabled", positiveButton.isEnabled, equalTo(false))
+        }
+    }
+
+    private fun testRenameDialog(
+        currentName: String,
+        callback: (AlertDialog.() -> Unit),
+    ) {
+        col.decks.id(currentName)
+        withCreateDeckDialog(DeckDialogType.RENAME_DECK) {
+            deckName = currentName
+            callback(this.showDialog())
+        }
+    }
+
     /**
      * Executes [callback] on the [AlertDialog] created from [CreateDeckDialog]
      */

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
@@ -37,6 +37,7 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.fail
 
 @RunWith(RobolectricTestRunner::class)
 class CreateDeckDialogTest : RobolectricTest() {
@@ -105,7 +106,8 @@ class CreateDeckDialogTest : RobolectricTest() {
     fun testRenameDeckFunction() {
         val deckName = "Deck Name"
         val deckNewName = "New Deck Name"
-        ensureExecutionOfScenario(DeckDialogType.RENAME_DECK) { createDeckDialog, assertionCalled ->
+        val deckId = col.decks.id(deckName)
+        ensureExecutionOfScenario(DeckDialogType.RENAME_DECK, renamedDeckId = deckId) { createDeckDialog, assertionCalled ->
             createDeckDialog.deckName = deckName
             createDeckDialog.onNewDeckCreated = { id: DeckId ->
                 // a deck name was renamed
@@ -120,7 +122,8 @@ class CreateDeckDialogTest : RobolectricTest() {
     fun testRenameDeckWithQuotes() {
         val deckName = "Deck Name"
         val deckNewNameWithQuotes = "New \"Quoted\" Deck Name"
-        ensureExecutionOfScenario(DeckDialogType.RENAME_DECK) { createDeckDialog, assertionCalled ->
+        val deckId = col.decks.id(deckName)
+        ensureExecutionOfScenario(DeckDialogType.RENAME_DECK, renamedDeckId = deckId) { createDeckDialog, assertionCalled ->
             createDeckDialog.deckName = deckName
             createDeckDialog.onNewDeckCreated = { id: DeckId ->
                 // Verify that the quotes are preserved in the renamed deck
@@ -246,7 +249,7 @@ class CreateDeckDialogTest : RobolectricTest() {
     @Test
     fun positiveButtonEnabledOnMatchingDeckNames() {
         val previousDeckName = "Deck Name"
-        testDialog(DeckDialogType.RENAME_DECK) {
+        testRenameDialog(currentName = previousDeckName) {
             input = previousDeckName
             assertThat("no error is displayed", getInputTextLayout().error, nullValue())
         }
@@ -275,12 +278,41 @@ class CreateDeckDialogTest : RobolectricTest() {
         }
     }
 
+    @Test
+    fun `renaming a deck to an equivalent name changes nothing`() {
+        val deckId = col.decks.id("a::b")
+        val deckCount = col.decks.count()
+        withRenameDeckDialog(deckId) {
+            deckName = "a::b"
+            onNewDeckCreated = { fail("the deck was not renamed") }
+            renameDeck("a:::b")
+        }
+        assertThat("the deck kept its name", col.decks.name(deckId), equalTo("a::b"))
+        assertThat("no deck was created", col.decks.count(), equalTo(deckCount))
+        activityScenario.onActivity { activity ->
+            assertThat("no rename is reported", activity.latestSnackbarText(), nullValue())
+        }
+    }
+
+    @Test
+    fun `renaming a deck which no longer exists does not create a deck`() {
+        val deckId = col.decks.id("Old Deck")
+        col.decks.remove(listOf(deckId))
+        val deckCount = col.decks.count()
+        withRenameDeckDialog(deckId) {
+            deckName = "Old Deck"
+            onNewDeckCreated = { fail("the deck was not renamed") }
+            renameDeck("New Deck")
+        }
+        assertThat("no deck was created", col.decks.count(), equalTo(deckCount))
+    }
+
     private fun testRenameDialog(
         currentName: String,
         callback: (AlertDialog.() -> Unit),
     ) {
-        col.decks.id(currentName)
-        withCreateDeckDialog(DeckDialogType.RENAME_DECK) {
+        val deckId = col.decks.id(currentName)
+        withRenameDeckDialog(deckId) {
             deckName = currentName
             callback(this.showDialog())
         }
@@ -292,9 +324,10 @@ class CreateDeckDialogTest : RobolectricTest() {
     private fun testDialog(
         deckDialogType: DeckDialogType,
         parentId: DeckId? = null,
+        renamedDeckId: DeckId? = null,
         callback: (AlertDialog.() -> Unit),
     ) {
-        withCreateDeckDialog(deckDialogType, parentId) {
+        withCreateDeckDialog(deckDialogType, parentId, renamedDeckId) {
             callback(this.showDialog())
         }
     }
@@ -305,6 +338,7 @@ class CreateDeckDialogTest : RobolectricTest() {
     private fun withCreateDeckDialog(
         deckDialogType: DeckDialogType,
         parentId: DeckId? = null,
+        renamedDeckId: DeckId? = null,
         callback: (CreateDeckDialog.() -> Unit),
     ) {
         activityScenario.onActivity { activity: DeckPicker ->
@@ -314,10 +348,19 @@ class CreateDeckDialogTest : RobolectricTest() {
                     title = "Create deck",
                     deckDialogType = deckDialogType,
                     parentId = parentId,
+                    renamedDeckId = renamedDeckId,
                 )
             callback(createDeckDialog)
         }
     }
+
+    /**
+     * Creates a test instance of [CreateDeckDialog] which renames [renamedDeckId]
+     */
+    private fun withRenameDeckDialog(
+        renamedDeckId: DeckId,
+        callback: (CreateDeckDialog.() -> Unit),
+    ) = withCreateDeckDialog(DeckDialogType.RENAME_DECK, renamedDeckId = renamedDeckId, callback = callback)
 
     /*
      * The next 8 testcases test every permutation of
@@ -392,7 +435,8 @@ class CreateDeckDialogTest : RobolectricTest() {
 
     @Test
     fun `renameDeck with activity context shows snackbar for valid name`() {
-        ensureExecutionOfScenario(DeckDialogType.RENAME_DECK) { dialog, assertionCalled ->
+        val deckId = col.decks.id("Old Deck")
+        ensureExecutionOfScenario(DeckDialogType.RENAME_DECK, renamedDeckId = deckId) { dialog, assertionCalled ->
             dialog.deckName = "Old Deck"
             dialog.onNewDeckCreated = { _: DeckId -> assertionCalled() }
             dialog.renameDeck("Rename Deck")
@@ -410,7 +454,7 @@ class CreateDeckDialogTest : RobolectricTest() {
     @Test
     fun `renameDeck with activity context shows snackbar for invalid name`() {
         activityScenario.onActivity { activity ->
-            val dialog = CreateDeckDialog(activity, "Create deck", DeckDialogType.RENAME_DECK, null)
+            val dialog = CreateDeckDialog(activity, "Create deck", DeckDialogType.RENAME_DECK, null, col.decks.id("Old Deck"))
             dialog.deckName = "Old Deck"
             dialog.onNewDeckCreated = { _: DeckId -> }
             dialog.renameDeck("   ")
@@ -427,7 +471,14 @@ class CreateDeckDialogTest : RobolectricTest() {
     @Test
     fun `renameDeck with non-activity context shows toast for valid name`() {
         activityScenario.onActivity { activity ->
-            val dialog = CreateDeckDialog(ContextWrapper(activity), "Create deck", DeckDialogType.RENAME_DECK, null)
+            val dialog =
+                CreateDeckDialog(
+                    ContextWrapper(activity),
+                    "Create deck",
+                    DeckDialogType.RENAME_DECK,
+                    null,
+                    col.decks.id("Old Deck"),
+                )
             dialog.deckName = "Old Deck"
             dialog.onNewDeckCreated = { _: DeckId -> }
             dialog.renameDeck("Rename Deck")
@@ -443,7 +494,14 @@ class CreateDeckDialogTest : RobolectricTest() {
     @Test
     fun `renameDeck with non-activity context shows toast for invalid name`() {
         activityScenario.onActivity { activity ->
-            val dialog = CreateDeckDialog(ContextWrapper(activity), "Create deck", DeckDialogType.RENAME_DECK, null)
+            val dialog =
+                CreateDeckDialog(
+                    ContextWrapper(activity),
+                    "Create deck",
+                    DeckDialogType.RENAME_DECK,
+                    null,
+                    col.decks.id("Old Deck"),
+                )
             dialog.deckName = "Old Deck"
             dialog.onNewDeckCreated = { _: DeckId -> }
             dialog.renameDeck("   ")
@@ -463,11 +521,12 @@ class CreateDeckDialogTest : RobolectricTest() {
     private fun ensureExecutionOfScenario(
         deckDialogType: DeckDialogType,
         parentId: DeckId? = null,
+        renamedDeckId: DeckId? = null,
         callback: ((CreateDeckDialog, (() -> Unit)) -> Unit),
     ) {
         activityScenario.onActivity { activity: DeckPicker ->
             val assertionCalled = AtomicReference(false)
-            callback(CreateDeckDialog(activity, "Create deck", deckDialogType, parentId)) {
+            callback(CreateDeckDialog(activity, "Create deck", deckDialogType, parentId, renamedDeckId)) {
                 assertionCalled.set(true)
             }
             assertThat("no call to assertionCalled()", assertionCalled.get(), equalTo(true))


### PR DESCRIPTION

> [!NOTE]
> Assisted-by: Claude Fable 5.1 -> See commit 2

## Purpose / Description
The dialog compared the names as text, but the backend drops the extra colon, so the name resolved to the deck being renamed.

## Fixes
* Fixes #21695

## Approach
See commits; compare the deck the new name by id rather than by name.

## How Has This Been Tested?
Unit testing and Google emulator

## Learning (optional, can help others)
I asked Claude if there is some better approach to my code hence it suggested the id fix

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->