### PR TITLE
fix(note-types): allow a case only rename of a note type

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt
@@ -311,7 +311,8 @@ class ManageNotetypes : AnkiActivity(R.layout.activity_manage_note_types) {
                         callback = { dialog, text ->
                             val inputStr = text.toString().trim()
 
-                            val isDuplicate = allNotetypes.any { it.name.equals(inputStr, ignoreCase = true) }
+                            val isDuplicate =
+                                allNotetypes.any { it.id != state.id && it.name.equals(inputStr, ignoreCase = true) }
 
                             val isUnchanged = inputStr == state.name
 


### PR DESCRIPTION




## Purpose / Description
Allow renaming in case it just letter casing as Anki allows it

## Fixes
NA

## Approach
See commit

## How Has This Been Tested?
Google Emulator 

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->