### PR TITLE
refactor(libanki): make `select()` match upstream

### DIFF
--- a/libanki/src/main/java/com/ichi2/anki/libanki/Decks.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Decks.kt
@@ -569,12 +569,6 @@ class Decks(
     @RustCleanup("does not match upstream")
     fun select(did: DeckId) {
         col.backend.setCurrentDeck(did)
-        val selectedDeckName = name(did)
-        val childrenDids =
-            allNamesAndIds(skipEmptyDefault = true, includeFiltered = false)
-                .filter { it.name.startsWith("$selectedDeckName::") }
-                .map { it.id }
-        col.config.set(ACTIVE_DECKS, listOf(did) + childrenDids)
     }
 
     /** @return The currently selected deck ID. */
@@ -739,9 +733,6 @@ class Decks(
 
         /** Configuration saving the current deck  */
         const val CURRENT_DECK = "curDeck"
-
-        /** Configuration saving the set of active decks (i.e. current decks and its descendants)  */
-        const val ACTIVE_DECKS = "activeDecks"
 
         @NotInPyLib
         const val DECK_SEPARATOR = "::"

--- a/libanki/src/main/java/com/ichi2/anki/libanki/Decks.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Decks.kt
@@ -564,11 +564,15 @@ class Decks(
         }
     }
 
-    /** Select a new branch (deck and descendants). */
+    /**
+     * Select a new branch (deck and descendants).
+     *
+     * @see setCurrent includes `undoableOp` support - use for UI code.
+     */
     @LibAnkiAlias("select")
-    @RustCleanup("does not match upstream")
+    @Suppress("CheckResult")
     fun select(did: DeckId) {
-        col.backend.setCurrentDeck(did)
+        setCurrent(did)
     }
 
     /** @return The currently selected deck ID. */


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5.1

## Purpose / Description
Minor refactoring to `Decks.select`, I wanted to handle before better documenting the concept

## Approach
* Remove `activeDecks` -> move to a table
* call a method rather than calling the backend directly, as upstream does.

## How Has This Been Tested?
Unit tests only

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)