### PR TITLE
feat: improve the review ahead dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -421,6 +421,10 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
                 }
                 launchCustomStudy(contextMenuOption, n)
             }
+            if (contextMenuOption == STUDY_AHEAD) {
+                // the stored default may match no cards
+                searchJob = launchCatchingTask { updateCreateButtonState(dialog, userInputValue) }
+            }
         }
 
         binding.detailsEditText2.doAfterTextChanged {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -74,6 +74,7 @@ import com.ichi2.utils.setPaddingRelative
 import com.ichi2.utils.textAsIntOrNull
 import com.ichi2.utils.title
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking
 import kotlinx.parcelize.Parcelize
 import net.ankiweb.rsdroid.BackendException
@@ -126,6 +127,9 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
 
     private val userInputValue: Int?
         get() = binding.detailsEditText2.textAsIntOrNull()
+
+    /** The search for cards to review ahead. Cancelled when the input changes, so only the latest input counts */
+    private var searchJob: Job? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -420,10 +424,14 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
         }
 
         binding.detailsEditText2.doAfterTextChanged {
-            dialog.positiveButton.isEnabled = userInputValue != null && userInputValue != 0
-            if (contextMenuOption == STUDY_AHEAD) {
-                userInputValue?.let { setSuffixText(it) }
+            val value = userInputValue
+            if (contextMenuOption != STUDY_AHEAD) {
+                dialog.positiveButton.isEnabled = value != null && value != 0
+                return@doAfterTextChanged
             }
+            value?.let { setSuffixText(it) }
+            searchJob?.cancel()
+            searchJob = launchCatchingTask { updateCreateButtonState(dialog, value) }
         }
 
         // Show soft keyboard
@@ -435,6 +443,33 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
     private fun setSuffixText(days: Int) {
         binding.detailsEditText2Layout.suffixText = resources.getQuantityString(R.plurals.set_due_date_label_suffix, days)
     }
+
+    /** Enables 'Create' only if some cards would be reviewed ahead by [days] */
+    private suspend fun updateCreateButtonState(
+        dialog: AlertDialog,
+        days: Int?,
+    ) {
+        if (days == null || days == 0) {
+            binding.detailsEditText2Layout.error = null
+            dialog.positiveButton.isEnabled = false
+            return
+        }
+        val hasCards = hasCardsDueWithin(days)
+        binding.detailsEditText2Layout.error = if (hasCards) null else TR.customStudyNoCardsMatchedTheCriteriaYou()
+        dialog.positiveButton.isEnabled = hasCards
+    }
+
+    /** Whether the deck has cards due in the next [days] days, as 'review ahead' would select them */
+    private suspend fun hasCardsDueWithin(days: Int): Boolean =
+        withCol {
+            val search =
+                listOf(
+                    SearchNode.newBuilder().setDeck(decks.name(viewModel.deckId)).build(),
+                    // prop:due<=days
+                    SearchNode.newBuilder().setDueInDays(days).build(),
+                )
+            findCards(buildSearchString(search)).isNotEmpty()
+        }
 
     // TODO cram kind and the included/excluded tags lists are only relevant for STUDY_TAGS and
     //  should be included in the option to not leak in the method's api

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -279,6 +279,8 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
         binding = FragmentCustomStudyBinding.inflate(requireActivity().layoutInflater)
 
         binding.detailsText1.text = text1
+        // 'review ahead' has a dialog title, so the empty label would only add a blank line
+        binding.detailsText1.isVisible = contextMenuOption != STUDY_AHEAD
         binding.detailsText2.text = text2
 
         binding.cardsStateSelectorLayout.isVisible = contextMenuOption == STUDY_TAGS
@@ -322,6 +324,8 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
         val positiveBtnLabel =
             if (contextMenuOption == STUDY_TAGS) {
                 TR.sentenceCase.chooseTags
+            } else if (contextMenuOption == STUDY_AHEAD) {
+                getString(R.string.dialog_positive_create)
             } else {
                 getString(R.string.dialog_ok)
             }
@@ -333,7 +337,11 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
         val dialog =
             AlertDialog
                 .Builder(requireActivity())
-                .customView(
+                .apply {
+                    if (contextMenuOption == STUDY_AHEAD) {
+                        title(text = contextMenuOption.getTitle(resources))
+                    }
+                }.customView(
                     view = binding.root,
                     paddingStart = horizontalPadding,
                     paddingEnd = horizontalPadding,
@@ -507,7 +515,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
                 EXTEND_NEW -> res.getString(R.string.custom_study_new_extend)
                 EXTEND_REV -> res.getString(R.string.custom_study_rev_extend)
                 STUDY_FORGOT -> res.getString(R.string.custom_study_forgotten)
-                STUDY_AHEAD -> res.getString(R.string.custom_study_ahead)
+                STUDY_AHEAD -> res.getString(R.string.custom_study_ahead_description)
                 STUDY_PREVIEW -> res.getString(R.string.custom_study_preview)
                 STUDY_TAGS -> res.getString(R.string.custom_study_tags)
                 null -> ""

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -8,6 +8,7 @@ import android.app.Dialog
 import android.content.res.Resources
 import android.os.Bundle
 import android.os.Parcelable
+import android.text.InputFilter
 import android.util.TypedValue
 import android.view.WindowManager
 import android.view.inputmethod.EditorInfo
@@ -56,6 +57,7 @@ import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.ui.NonLeadingZeroInputFilter
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
 import com.ichi2.anki.utils.ext.getIntOrNull
@@ -321,6 +323,8 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
                 inputType = EditorInfo.TYPE_CLASS_NUMBER or EditorInfo.TYPE_NUMBER_FLAG_SIGNED
             }
             if (contextMenuOption == STUDY_AHEAD) {
+                inputType = EditorInfo.TYPE_CLASS_NUMBER
+                filters += arrayOf(InputFilter.LengthFilter(5), NonLeadingZeroInputFilter)
                 setSuffixText(defaultValue.toInt())
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -450,7 +450,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
         days: Int?,
     ) {
         if (days == null || days == 0) {
-            binding.detailsEditText2Layout.error = null
+            binding.detailsEditText2Layout.error = if (days == 0) getString(R.string.minimum_value_is, 1) else null
             dialog.positiveButton.isEnabled = false
             return
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -320,6 +320,9 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
             if (contextMenuOption == EXTEND_NEW || contextMenuOption == EXTEND_REV) {
                 inputType = EditorInfo.TYPE_CLASS_NUMBER or EditorInfo.TYPE_NUMBER_FLAG_SIGNED
             }
+            if (contextMenuOption == STUDY_AHEAD) {
+                setSuffixText(defaultValue.toInt())
+            }
         }
         val positiveBtnLabel =
             if (contextMenuOption == STUDY_TAGS) {
@@ -414,11 +417,19 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
 
         binding.detailsEditText2.doAfterTextChanged {
             dialog.positiveButton.isEnabled = userInputValue != null && userInputValue != 0
+            if (contextMenuOption == STUDY_AHEAD) {
+                userInputValue?.let { setSuffixText(it) }
+            }
         }
 
         // Show soft keyboard
         dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE)
         return dialog
+    }
+
+    /** Sets the suffix of the days input: `[1] day`, `[3] days` */
+    private fun setSuffixText(days: Int) {
+        binding.detailsEditText2Layout.suffixText = resources.getQuantityString(R.plurals.set_due_date_label_suffix, days)
     }
 
     // TODO cram kind and the included/excluded tags lists are only relevant for STUDY_TAGS and

--- a/AnkiDroid/src/main/res/layout/fragment_custom_study.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_custom_study.xml
@@ -43,13 +43,13 @@
         android:id="@+id/details_edit_text_2_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:errorEnabled="true"
         app:suffixTextAppearance="@style/TextAppearance.MaterialComponents.Body1">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/details_edit_text_2"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp"
             android:inputType="number|numberSigned"
             tools:text="1"
             />

--- a/AnkiDroid/src/main/res/layout/fragment_custom_study.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_custom_study.xml
@@ -42,7 +42,8 @@
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/details_edit_text_2_layout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:suffixTextAppearance="@style/TextAppearance.MaterialComponents.Body1">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/details_edit_text_2"

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -36,7 +36,7 @@
     <string name="custom_study_new_extend">Increase/decrease (“-3”) today’s new card limit by</string>
     <string name="custom_study_rev_extend">Increase/decrease (“-3”) today’s review limit by</string>
     <string name="custom_study_forgotten">Review cards forgotten in last x days:</string>
-    <string name="custom_study_ahead">Review ahead by x days:</string>
+    <string name="custom_study_ahead_description">Review cards due in the next:</string>
     <string name="custom_study_preview">Preview new cards added in the last x days:</string>
     <string name="custom_study_tags">Select x cards from the deck:</string>
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
@@ -340,6 +340,20 @@ class CustomStudyDialogTest : RobolectricTest() {
         }
     }
 
+    @Test
+    fun `'review ahead' rejects leading zeros and more than 5 digits`() {
+        withStudyAheadDialog {
+            val editText = binding.detailsEditText2
+
+            onSubscreenEditText().perform(replaceText("0"))
+            editText.append("5")
+            assertThat("a digit typed after '0' is rejected", editText.text.toString(), equalTo("0"))
+
+            onSubscreenEditText().perform(replaceText("123456"))
+            assertThat(editText.text.toString(), equalTo("12345"))
+        }
+    }
+
     /**
      * Runs [block] on a [CustomStudyDialog]
      */

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
@@ -433,6 +433,22 @@ class CustomStudyDialogTest : RobolectricTest() {
             }
         }
 
+    @Test
+    fun `'review ahead' validates the default value on open`() =
+        runTest {
+            // the default is 1 day; the only card is due in 30 days
+            addBasicNote().firstCard().update {
+                queue = QueueType.Rev
+                type = CardType.Rev
+                due = col.sched.today + 30
+            }
+
+            withStudyAheadDialog { dialog ->
+                assertThat("nothing to review ahead", dialog.positiveButton.isEnabled, equalTo(false))
+                assertThat(binding.detailsEditText2Layout.error?.toString(), equalTo(TR.customStudyNoCardsMatchedTheCriteriaYou()))
+            }
+        }
+
     /** Adds a note to [deckName] whose card is due tomorrow */
     private fun addNoteDueTomorrow(deckName: String) {
         addBasicNote().update { moveToDeck(deckName, false) }.firstCard().update {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
@@ -416,6 +416,23 @@ class CustomStudyDialogTest : RobolectricTest() {
             }
         }
 
+    @Test
+    @Config(qualifiers = "en")
+    fun `'review ahead' warns when 0 days is entered`() =
+        runTest {
+            withStudyAheadDialog {
+                val layout = binding.detailsEditText2Layout
+
+                onSubscreenEditText().perform(replaceText("0"))
+                shadowOf(Looper.getMainLooper()).idle()
+                assertThat(layout.error?.toString(), equalTo("Minimum value is 1"))
+
+                onSubscreenEditText().perform(replaceText(""))
+                shadowOf(Looper.getMainLooper()).idle()
+                assertNull(layout.error, "an empty field is not an error yet")
+            }
+        }
+
     /** Adds a note to [deckName] whose card is due tomorrow */
     private fun addNoteDueTomorrow(deckName: String) {
         addBasicNote().update { moveToDeck(deckName, false) }.firstCard().update {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
@@ -40,6 +40,7 @@ import com.ichi2.anki.libanki.sched.Scheduler
 import com.ichi2.testutils.AnkiFragmentScenario
 import com.ichi2.testutils.isJsonEqual
 import com.ichi2.testutils.uninitializeField
+import com.ichi2.utils.positiveButton
 import io.mockk.every
 import io.mockk.mockk
 import org.hamcrest.CoreMatchers.allOf
@@ -351,6 +352,76 @@ class CustomStudyDialogTest : RobolectricTest() {
 
             onSubscreenEditText().perform(replaceText("123456"))
             assertThat(editText.text.toString(), equalTo("12345"))
+        }
+    }
+
+    @Test
+    fun `'review ahead' disables Create when no cards are due in the period`() =
+        runTest {
+            // a card due tomorrow matches 'review ahead by 1 day'
+            val card = addBasicNote().firstCard()
+            card.update {
+                queue = QueueType.Rev
+                type = CardType.Rev
+                due = col.sched.today + 1
+            }
+
+            withStudyAheadDialog { dialog ->
+                val layout = binding.detailsEditText2Layout
+
+                onSubscreenEditText().perform(replaceText("1"))
+                shadowOf(Looper.getMainLooper()).idle()
+                assertThat("enabled when a card matches", dialog.positiveButton.isEnabled, equalTo(true))
+                assertNull(layout.error)
+
+                onSubscreenEditText().perform(replaceText("0"))
+                shadowOf(Looper.getMainLooper()).idle()
+                assertThat("disabled for 0 days", dialog.positiveButton.isEnabled, equalTo(false))
+
+                card.update { due = col.sched.today + 30 }
+
+                onSubscreenEditText().perform(replaceText("1"))
+                shadowOf(Looper.getMainLooper()).idle()
+                assertThat("disabled when nothing matches", dialog.positiveButton.isEnabled, equalTo(false))
+                assertThat(layout.error?.toString(), equalTo(TR.customStudyNoCardsMatchedTheCriteriaYou()))
+            }
+        }
+
+    @Test
+    fun `'review ahead' search does not treat the deck name as a pattern`() =
+        runTest {
+            // '_' is a single-character wildcard in a search: "A_B" must not match "AXB"
+            val emptyDeckId = addDeck("A_B")
+            addDeck("AXB")
+            addNoteDueTomorrow(deckName = "AXB")
+
+            withStudyAheadDialog(deckId = emptyDeckId) { dialog ->
+                onSubscreenEditText().perform(replaceText("1"))
+                shadowOf(Looper.getMainLooper()).idle()
+                assertThat("A_B has no cards", dialog.positiveButton.isEnabled, equalTo(false))
+            }
+        }
+
+    @Test
+    fun `'review ahead' search escapes the deck name`() =
+        runTest {
+            // '\' starts an escape sequence in a search
+            val deckId = addDeck("""A\B""")
+            addNoteDueTomorrow(deckName = """A\B""")
+
+            withStudyAheadDialog(deckId = deckId) { dialog ->
+                onSubscreenEditText().perform(replaceText("1"))
+                shadowOf(Looper.getMainLooper()).idle()
+                assertThat(dialog.positiveButton.isEnabled, equalTo(true))
+            }
+        }
+
+    /** Adds a note to [deckName] whose card is due tomorrow */
+    private fun addNoteDueTomorrow(deckName: String) {
+        addBasicNote().update { moveToDeck(deckName, false) }.firstCard().update {
+            queue = QueueType.Rev
+            type = CardType.Rev
+            due = col.sched.today + 1
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
@@ -3,6 +3,7 @@
 package com.ichi2.anki.dialogs
 
 import android.os.Bundle
+import android.os.Looper
 import android.widget.AdapterView
 import android.widget.ListView
 import androidx.appcompat.app.AlertDialog
@@ -52,6 +53,7 @@ import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -323,6 +325,21 @@ class CustomStudyDialogTest : RobolectricTest() {
         assertThat(viewModel.selectedKind, equalTo(CramKind.CRAM_KIND_NEW))
     }
 
+    @Test
+    @Config(qualifiers = "en")
+    fun `'review ahead' shows a day or days suffix`() {
+        withStudyAheadDialog {
+            val layout = binding.detailsEditText2Layout
+            assertThat("default of 1 day", layout.suffixText.toString(), equalTo("day"))
+
+            onSubscreenEditText().perform(replaceText("2"))
+            assertThat(layout.suffixText.toString(), equalTo("days"))
+
+            onSubscreenEditText().perform(replaceText("1"))
+            assertThat(layout.suffixText.toString(), equalTo("day"))
+        }
+    }
+
     /**
      * Runs [block] on a [CustomStudyDialog]
      */
@@ -335,6 +352,15 @@ class CustomStudyDialogTest : RobolectricTest() {
                 block(dialogFragment)
             }
         }
+    }
+
+    /** Opens the 'review ahead' subscreen for [deckId] and runs [block] once the dialog is shown and its buttons exist */
+    private fun withStudyAheadDialog(
+        deckId: DeckId = Consts.DEFAULT_DECK_ID,
+        block: CustomStudyDialog.(dialog: AlertDialog) -> Unit,
+    ) = withCustomStudyFragment(args = argumentsDisplayingSubscreen(ContextMenuOption.STUDY_AHEAD, deckId = deckId)) { fragment ->
+        shadowOf(Looper.getMainLooper()).idle()
+        fragment.block(fragment.dialog as AlertDialog)
     }
 
     private fun mockCollectionWithSchedulerReturning(response: CustomStudyDefaultsResponse) =


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5.1
> This PR is a fixup of:
> * https://github.com/ankidroid/Anki-Android/pull/20678

## Purpose / Description
* improve wording and title
* handle leading zeroes
* validate on a '0' date
* add a day/days suffix
* disables 'create' if invalid

## Fixes
* Fixes #20600
* Closes #20678

## Approach

Fixup the linked PR, then add my own changes and improvements.

I initially refactored the `debounce` code into a class, but after a manual test, 300ms was far too much latency and the DB calls were effectively instant.

## How Has This Been Tested?
SDK 37 Google Pixel 9 Pro

<!-- <img width="960" height="1087" alt="image" src="https://github.com/user-attachments/assets/56020fa8-3b23-47c1-bfae-2be6fcbc9322" /> -->

<img width="959" height="1684" alt="image" src="https://github.com/user-attachments/assets/0f44eef4-2091-41b6-8a28-8ca000e7f15c" />



## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)