### PR TITLE
fix: fall back when the CustomTabs service throws on connect

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabActivityHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabActivityHelper.kt
@@ -107,10 +107,17 @@ class CustomTabActivityHelper : ServiceConnectionCallback {
                 Timber.w(e, "Ignoring CustomTabs implementation that doesn't conform to Android 8 background limits")
             }
             session
-        } catch (e: SecurityException) {
+        } catch (e: RuntimeException) {
             // #6142 - A securityException here means that we're not able to load the CustomTabClient at all, whereas
             // the IllegalStateException was a failure, but could be continued from
             Timber.w(e, "CustomTabsService bind attempt failed, using fallback")
+            CrashReportService.sendExceptionReport(
+                e = e,
+                origin = "CustomTabActivityHelper::onServiceConnected",
+                onlyIfSilent = true,
+            )
+            // TODO: https://github.com/ankidroid/Anki-Android/issues/21708
+            // Edge throws on a cold bind. Retry in the future instead of disabling the feature
             disableCustomTabHandler()
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/compat/customtabs/CustomTabActivityHelperTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/customtabs/CustomTabActivityHelperTest.kt
@@ -33,6 +33,7 @@ import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
@@ -79,6 +80,31 @@ class CustomTabActivityHelperTest {
         verify(fallback, times(1)).openUri(any(), any())
     }
 
+    @Test
+    fun ensureClientThrowingNullPointerExceptionFromWarmupDoesNotCrash() {
+        val badClient = getClientThrowing(NullPointerException("Attempt to get length of null array"))
+        val customTabActivityHelper = getValidTabHandler()
+
+        customTabActivityHelper.onServiceConnected(badClient)
+
+        assertThat("Should be failed after call", customTabActivityHelper.isFailed)
+    }
+
+    @Test
+    fun ensureClientThrowingNullPointerExceptionFromNewSessionDoesNotCrash() {
+        val exceptionToThrow = NullPointerException("Attempt to get length of null array")
+        val badClient =
+            mock<CustomTabsClient> {
+                on { it.warmup(anyLong()) } doReturn true
+                on { it.newSession(anyOrNull()) } doThrow exceptionToThrow
+            }
+        val customTabActivityHelper = getValidTabHandler()
+
+        customTabActivityHelper.onServiceConnected(badClient)
+
+        assertThat("Should be failed after call", customTabActivityHelper.isFailed)
+    }
+
     @CheckResult
     private fun getValidTabHandler(): CustomTabActivityHelper =
         CustomTabActivityHelper().also {
@@ -86,13 +112,14 @@ class CustomTabActivityHelperTest {
         }
 
     @CheckResult
-    private fun getClientThrowingSecurityException(): CustomTabsClient {
-        val exceptionToThrow = SecurityException("Binder invocation to an incorrect interface")
+    private fun getClientThrowingSecurityException(): CustomTabsClient =
+        getClientThrowing(SecurityException("Binder invocation to an incorrect interface"))
 
-        return mock {
+    @CheckResult
+    private fun getClientThrowing(exceptionToThrow: RuntimeException): CustomTabsClient =
+        mock {
             on { it.warmup(anyLong()) } doThrow exceptionToThrow
             on { it.extraCommand(anyString(), any()) } doThrow exceptionToThrow
-            on { it.newSession(any()) } doThrow exceptionToThrow
+            on { it.newSession(anyOrNull()) } doThrow exceptionToThrow
         }
-    }
 }


### PR DESCRIPTION

## Purpose / Description
Binder rethrows any RuntimeException from a browser's CustomTabsService on our main thread inside onServiceConnected. Microsoft Edge throws a NullPointerException from warmup() and newSession() when bound from a cold state, which crashed AnkiDroid on startup because only IllegalStateException and SecurityException were handled there.


## Fixes
* Fixes #21708

## Approach
See commit

## How Has This Been Tested?
Only unit tests(I haven't used LLM here so please verify)

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->