### PR TITLE
fix: disable native WebView zoom to prevent touch lockup

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
@@ -193,8 +193,7 @@ abstract class CardViewerFragment(
             with(settings) {
                 javaScriptEnabled = true
                 loadWithOverviewMode = true
-                builtInZoomControls = true
-                displayZoomControls = false
+                setSupportZoom(false)
                 allowFileAccess = true
                 domStorageEnabled = true
                 // allow videos to autoplay via our JavaScript eval

--- a/AnkiDroid/src/test/java/com/ichi2/anki/previewer/CardViewerFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/previewer/CardViewerFragmentTest.kt
@@ -113,8 +113,15 @@ class CardViewerFragmentTest : RobolectricTest() {
             whenever(it.resources).thenReturn(arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE))
         }
 
-    /** Runs [block] on the [WebChromeClient] attached to an open previewer's WebView */
-    private fun withCardViewerChromeClient(block: (WebChromeClient) -> Unit) {
+    @Test
+    fun `native double-tap and pinch zoom are disabled to avoid a WebView touch lockup`() {
+        withCardViewerWebView { webView ->
+            assertThat(webView.settings.supportZoom(), equalTo(false))
+        }
+    }
+
+    /** Runs [block] on the [WebView] of an open previewer */
+    private fun withCardViewerWebView(block: (WebView) -> Unit) {
         val note = addBasicAndReversedNote()
         val intent =
             PreviewerFragment.getIntent(
@@ -132,8 +139,15 @@ class CardViewerFragmentTest : RobolectricTest() {
                         .map { webViewLayout.getChildAt(it) }
                         .filterIsInstance<WebView>()
                         .single()
-                block(requireNotNull(webView.webChromeClient) { "no WebChromeClient attached" })
+                block(webView)
             }
+        }
+    }
+
+    /** Runs [block] on the [WebChromeClient] attached to an open previewer's WebView */
+    private fun withCardViewerChromeClient(block: (WebChromeClient) -> Unit) {
+        withCardViewerWebView { webView ->
+            block(requireNotNull(webView.webChromeClient) { "no WebChromeClient attached" })
         }
     }
 


### PR DESCRIPTION

> Assisted-by:  Claude Agent
--->

## Purpose / Description
Chromium's built-in double-tap-to-zoom gesture can get stuck mid- animation for certain image aspect ratios, permanently swallowing all further touch input on the page (double-tap an image and hold before releasing). The legacy reviewer avoids this by intercepting touch events through its own GestureDetector before they reach the WebView, but CardViewerFragment (new Reviewer, Previewer, Template Previewer) passes raw touch events straight to Chromium. Disabling native zoom removes the buggy gesture path entirely; content-level zoom is unaffected as it's handled separately via `Prefs.cardZoom`.


## Fixes
* Fixes #21263 

## Approach
_Approach: disable Chromium's native pinch/double-tap zoom (setSupportZoom(false)) in CardViewerFragment's WebView, since that built-in gesture path was the one getting stuck and swallowing touch input — content zoom stays     
  working via Prefs.cardZoom separately._

## How Has This Been Tested?

Added a regression test (CardViewerFragmentTest) that opens the Previewer's WebView and asserts webView.settings.supportZoom() is false, confirming native zoom stays disabled — plus existing tests continue to cover the        
WebChromeClient path via the refactored withCardViewerWebView helper

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->