### PR TITLE
refactor(review-reminders): remove renderEdgeToEdge

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
@@ -102,7 +102,6 @@ class ReminderTroubleshootingFragment : Fragment(R.layout.fragment_reminder_trou
         setupTroubleshootingChecks()
         setupSettingChangeDetector()
         setupContentInsets()
-        renderEdgeToEdge(host)
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
@@ -5,7 +5,6 @@ package com.ichi2.anki.reviewreminders
 
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.Menu
@@ -13,14 +12,10 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import android.view.Window
-import android.view.WindowManager
 import androidx.annotation.IdRes
-import androidx.annotation.RequiresApi
 import androidx.core.graphics.Insets
 import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
-import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat.Type.displayCutout
 import androidx.core.view.WindowInsetsCompat.Type.systemBars
 import androidx.core.view.isVisible
@@ -29,9 +24,7 @@ import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.commit
-import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.snackbar.Snackbar
@@ -213,7 +206,6 @@ class ScheduleRemindersFragment :
             }
         }
         setContentInsets()
-        renderEdgeToEdge(host)
 
         binding.floatingActionButtonAdd.setOnClickListener { addReminder() }
         troubleshootingViewModel.state.launchCollectionInLifecycleScope(::setupTroubleshootingSnackbar)
@@ -717,57 +709,4 @@ class ScheduleRemindersFragment :
                 )
             }
     }
-}
-
-/**
- * TODO: remove once all [FragmentHost]s are edge-to-edge.
- *
- * Renders the host window into a display cutout, removing a black bar.
- *
- * @see WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
- *
- * Needed even on API 35+: the app opts out of edge-to-edge enforcement
- * (`windowOptOutEdgeToEdgeEnforcement`), so these windows fit the system windows on every
- * API level.
- */
-internal fun Fragment.renderEdgeToEdge(host: FragmentHost) {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) return
-    // these hosts call `enableEdgeToEdge`
-    if (host == FragmentHost.STUDY_OPTIONS_FRAGMENT || host == FragmentHost.STUDY_OPTIONS_FRAME) return
-    if (host == FragmentHost.SETTINGS && isTwoPaneSettings) return
-    val window = requireActivity().window
-
-    viewLifecycleOwner.lifecycle.addObserver(
-        object : DefaultLifecycleObserver {
-            // resume/pause rather than view creation/destruction: when this fragment is replaced
-            // by one which also renders edge to edge, the new fragment's view is created
-            // before the old fragment restores the window, but it is resumed afterwards
-            override fun onResume(owner: LifecycleOwner) {
-                WindowCompat.setDecorFitsSystemWindows(window, false)
-                window.setLayoutInDisplayCutoutMode(
-                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES,
-                )
-            }
-
-            override fun onPause(owner: LifecycleOwner) {
-                WindowCompat.setDecorFitsSystemWindows(window, true)
-                window.setLayoutInDisplayCutoutMode(
-                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT,
-                )
-            }
-        },
-    )
-}
-
-/**
- * Whether the settings screen is showing its two-pane (sw600dp) layout,
- * with the headers pane alongside the content pane.
- */
-private val Fragment.isTwoPaneSettings: Boolean
-    get() = requireActivity().findViewById<View>(R.id.lateral_nav_container) != null
-
-@RequiresApi(Build.VERSION_CODES.P)
-private fun Window.setLayoutInDisplayCutoutMode(mode: Int) {
-    if (attributes.layoutInDisplayCutoutMode == mode) return
-    attributes = attributes.also { it.layoutInDisplayCutoutMode = mode }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersInsetsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersInsetsTest.kt
@@ -40,7 +40,6 @@ import com.ichi2.utils.Dp
 import com.ichi2.utils.dp
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
-import org.hamcrest.Matchers.notNullValue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RuntimeEnvironment
@@ -129,20 +128,20 @@ class ReviewRemindersInsetsTest : RobolectricTest() {
         }
 
     @Test
-    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P) // layoutInDisplayCutoutMode
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.R) // enableEdgeToEdge uses SHORT_EDGES below API 30
     fun `standalone host - the window renders into a display cutout`() =
         withStandaloneScheduleReminders { activity, _ ->
             assertThat(
                 "the window renders into the cutout instead of being letterboxed",
                 activity.window.attributes.layoutInDisplayCutoutMode,
-                equalTo(WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES),
+                equalTo(WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS),
             )
         }
 
     @Test
     @Config(sdk = [Build.VERSION_CODES.Q])
     @Suppress("DEPRECATION") // systemUiVisibility: how WindowCompat un-fits the window below API 30
-    fun `standalone host - the window renders edge to edge only while resumed`() =
+    fun `standalone host - the window stays edge to edge after pausing`() =
         withWritePermissions {
             val intent = ScheduleRemindersFragment.getIntent(targetContext, ReviewReminderScope.Global)
             ActivityScenario.launch<ConfigAwareSingleFragmentActivity>(intent).use { scenario ->
@@ -159,9 +158,9 @@ class ReviewRemindersInsetsTest : RobolectricTest() {
                 advanceRobolectricLooper()
                 scenario.onActivity { activity ->
                     assertThat(
-                        "pausing restores the window: other screens expect it to fit the system windows",
+                        "pausing leaves the window alone: the host renders every screen edge to edge",
                         activity.window.decorView.systemUiVisibility and DECOR_FITS_FLAGS,
-                        equalTo(0),
+                        equalTo(DECOR_FITS_FLAGS),
                     )
                 }
             }
@@ -239,22 +238,6 @@ class ReviewRemindersInsetsTest : RobolectricTest() {
                 equalTo((fabMargin + navigationBarSize).toPx(targetContext)),
             )
         }
-
-    @Test
-    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P) // layoutInDisplayCutoutMode
-    fun `settings host - the shared two-pane window is left alone`() {
-        // sw600dp: the settings host shares its window with the headers pane, which does not
-        // handle insets. Rendering the window edge to edge would slide that pane's content
-        // behind the system bars, so the reminders screens must leave the window untouched.
-        RuntimeEnvironment.setQualifiers(RobolectricDeviceQualifiers.MediumTablet)
-        withSettingsScheduleReminders { activity, _ ->
-            assertThat(
-                "sanity: the headers pane shares the window",
-                activity.findViewById<View>(R.id.lateral_nav_container),
-                notNullValue(),
-            )
-        }
-    }
 
     @Test
     fun `study options frame host - insets are applied by the host, not the fragment`() =


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5.1


## Purpose / Description
`enableEdgeToEdge` is now called on all fragment hosts.

## Fixes
* Part of #21693

## Approach
Handle the `TODO` on the method

## How Has This Been Tested?
Tested manually on API 29 and 34 emulators.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
