### PR TITLE
fix(review-reminders): edge to edge < API 29

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
@@ -16,6 +16,7 @@ import androidx.annotation.IdRes
 import androidx.core.graphics.Insets
 import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
+import androidx.core.view.ViewGroupCompat
 import androidx.core.view.WindowInsetsCompat.Type.displayCutout
 import androidx.core.view.WindowInsetsCompat.Type.systemBars
 import androidx.core.view.isVisible
@@ -341,6 +342,8 @@ class ScheduleRemindersFragment :
      * No-op in [FragmentHost.STUDY_OPTIONS_FRAGMENT] and [FragmentHost.STUDY_OPTIONS_FRAME]
      */
     private fun setRootInsetsListener(block: (bars: Insets) -> Unit) {
+        // API < 30: simulate API 30+ behaviour - insets are not affected by siblings.
+        ViewGroupCompat.installCompatInsetsDispatch(binding.rootLayout)
         ViewCompat.setOnApplyWindowInsetsListener(binding.rootLayout) { _, insets ->
             block(insets.getInsets(systemBars() or displayCutout()))
             insets


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5.1

## Fixes
* Part of #21519

## Approach
Use the API 30+ inset logic for children

## How Has This Been Tested?
<img width="254" height="570" alt="Screenshot 2026-09-04 at 22 00 43" src="https://github.com/user-attachments/assets/b9e7bc6d-a9ae-4348-b0f3-8339df8df662" />

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)