### PR TITLE
fix(tests): fix testUpdateNonExistentNoteDoesNotNotifyUI

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -42,6 +42,7 @@ import com.ichi2.anki.provider.pureAnswer
 import com.ichi2.anki.testutil.DatabaseUtils.cursorFillWindow
 import com.ichi2.anki.testutil.GrantStoragePermission.storagePermission
 import com.ichi2.anki.testutil.addNote
+import com.ichi2.anki.testutil.awaitPendingOpChanges
 import com.ichi2.anki.testutil.grantPermissions
 import com.ichi2.testutils.common.assertThrows
 import kotlinx.serialization.json.Json
@@ -2516,6 +2517,7 @@ class ContentProviderTest : InstrumentedTest() {
     @Test
     fun testUpdateNonExistentNoteDoesNotNotifyUI() {
         val counter = TestSubscriber()
+        ChangeManager.awaitPendingOpChanges()
         ChangeManager.subscribe(counter)
         try {
             val values =
@@ -2528,7 +2530,7 @@ class ContentProviderTest : InstrumentedTest() {
                 contentResolver.update(uri, values, null, null)
             }
 
-            Thread.sleep(1000)
+            ChangeManager.awaitPendingOpChanges()
             assertEquals("UI should not be notified if update is failed", 0, counter.count)
         } finally {
             ChangeManager.unsubscribe(counter)
@@ -2552,13 +2554,14 @@ class ContentProviderTest : InstrumentedTest() {
     @Test
     fun testDeleteNonExistentNoteDoesNotNotifyUI() {
         val counter = TestSubscriber()
+        ChangeManager.awaitPendingOpChanges()
         ChangeManager.subscribe(counter)
         try {
             val uri = Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, "999999")
             val deletedCount = contentResolver.delete(uri, null, null)
             assertEquals("It should return 0 for non-existent note", 0, deletedCount)
 
-            Thread.sleep(1000)
+            ChangeManager.awaitPendingOpChanges()
             assertEquals("UI should not be notify if nothing was deleted", 0, counter.count)
         } finally {
             ChangeManager.unsubscribe(counter)
@@ -2593,11 +2596,12 @@ class ContentProviderTest : InstrumentedTest() {
     @Test
     fun testBulkInsertEmptyListDoesNotNotifyUI() {
         val counter = TestSubscriber()
+        ChangeManager.awaitPendingOpChanges()
         ChangeManager.subscribe(counter)
         try {
             contentResolver.bulkInsert(FlashCardsContract.Note.CONTENT_URI, emptyArray())
 
-            Thread.sleep(1000)
+            ChangeManager.awaitPendingOpChanges()
             assertEquals("UI should not be notified for empty bulk insert", 0, counter.count)
         } finally {
             ChangeManager.unsubscribe(counter)

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/WaitUtils.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/WaitUtils.kt
@@ -5,7 +5,9 @@ package com.ichi2.anki.testutil
 import android.app.Activity
 import android.os.SystemClock
 import androidx.test.platform.app.InstrumentationRegistry
+import anki.collection.OpChanges
 import com.ichi2.anki.TestUtils
+import com.ichi2.anki.observability.ChangeManager
 import kotlin.test.fail
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -38,3 +40,10 @@ inline fun <reified T : Activity> awaitResumedActivity(timeout: Duration = 10.se
         timeout,
         message = { "Timed out waiting for ${T::class.java.simpleName}; resumed = ${TestUtils.activityInstance}" },
     ) { TestUtils.activityInstance is T }
+
+/**
+ * Waits for all published [OpChanges] to be delivered to [ChangeManager] subscribers.
+ */
+fun ChangeManager.awaitPendingOpChanges() {
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+}


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5.1

## Fixes
* Fixes #21722

## Approach
OpChanges is delivered asynchronously, so we need to wait for delivery.

## How Has This Been Tested?
Test-only

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)