### PR TITLE
fix(study-screen): whole screen being highlighted when focused

### DIFF
--- a/AnkiDroid/src/main/res/layout/fragment_reviewer.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_reviewer.xml
@@ -9,6 +9,7 @@
     android:background="?attr/alternativeBackgroundColor"
     android:fitsSystemWindows="true"
     android:focusableInTouchMode="true"
+    android:defaultFocusHighlightEnabled="false"
     tools:context=".ui.windows.reviewer.ReviewerFragment">
 
     <LinearLayout


### PR DESCRIPTION

## Fixes

* Fixes #21697

## How Has This Been Tested?

Galaxy Tab S9, Android 16

1. Open the new study screen
2. Press 'Tab' a lot to switch focus between elements

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->