### PR TITLE
refactor(startup): define `StoragePolicy`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1047,7 +1047,7 @@ open class DeckPicker :
 
                 override fun hasRequiredPermissions(): Boolean = permissions.hasRequiredPermissions(context)
 
-                override val requiredPermissions: PermissionSet
+                override val requiredPermissions: StoragePermissionSet
                     get() = permissions
 
                 override val preferences: SharedPreferences

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -2,6 +2,7 @@
 
 package com.ichi2.anki
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
 import android.database.sqlite.SQLiteDatabaseCorruptException
@@ -26,6 +27,8 @@ import com.ichi2.anki.compat.CompatHelper.Companion.sdkVersion
 import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService.setPreferencesUpToDate
+import com.ichi2.anki.startup.StoragePolicy
+import com.ichi2.anki.startup.folderToPersist
 import com.ichi2.anki.ui.windows.permissions.InternetPermissionFragment
 import com.ichi2.anki.ui.windows.permissions.LegacyNotificationsPermissionFragment
 import com.ichi2.anki.ui.windows.permissions.NotificationsPermissionFragment
@@ -227,6 +230,20 @@ enum class StoragePermissionSet(
     EXTERNAL_MANAGER(Permissions.externalManagerStorageAccessStartupPermissions, PermissionsStartingAt30Fragment::class.java),
 
     APP_PRIVATE(Permissions.appPrivateStartupPermissions, InternetPermissionFragment::class.java),
+    ;
+
+    /** Who chooses the collection folder on a fresh install. */
+    @get:SuppressLint("NewApi") // a branch on EXTERNAL_MANAGER does not use its APIs
+    val storagePolicy: StoragePolicy
+        get() =
+            when (this) {
+                LEGACY_ACCESS -> StoragePolicy.Fixed(AnkiDroidFolder.PUBLIC)
+                EXTERNAL_MANAGER -> StoragePolicy.Fixed(AnkiDroidFolder.PUBLIC)
+                APP_PRIVATE -> StoragePolicy.Fixed(AnkiDroidFolder.APP_PRIVATE)
+            }
+
+    /** The folder to persist on startup, or `null` if the user has yet to choose. */
+    fun folderToPersist(context: Context): AnkiDroidFolder? = storagePolicy.folderToPersist(hasRequiredPermissions(context))
 }
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -200,7 +200,7 @@ object InitialActivity {
 @Parcelize
 enum class PermissionSet(
     val permissions: List<String>,
-    val permissionsFragment: Class<out PermissionsFragment>?,
+    val permissionsFragment: Class<out PermissionsFragment>,
 ) : Parcelable {
     LEGACY_ACCESS(Permissions.legacyStorageAccessStartupPermissions, PermissionsUntil29Fragment::class.java),
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -29,6 +29,7 @@ import com.ichi2.anki.servicelayer.PreferenceUpgradeService.setPreferencesUpToDa
 import com.ichi2.anki.ui.windows.permissions.InternetPermissionFragment
 import com.ichi2.anki.ui.windows.permissions.LegacyNotificationsPermissionFragment
 import com.ichi2.anki.ui.windows.permissions.NotificationsPermissionFragment
+import com.ichi2.anki.ui.windows.permissions.PermissionsBottomSheet
 import com.ichi2.anki.ui.windows.permissions.PermissionsFragment
 import com.ichi2.anki.ui.windows.permissions.PermissionsStartingAt30Fragment
 import com.ichi2.anki.ui.windows.permissions.PermissionsUntil29Fragment
@@ -197,38 +198,64 @@ object InitialActivity {
     }
 }
 
+/**
+ * Permissions requested together on a [PermissionsFragment].
+ *
+ * @see StoragePermissionSet
+ * @see OptionalPermissionSet
+ */
+sealed interface PermissionSet : Parcelable {
+    val permissions: List<String>
+    val permissionsFragment: Class<out PermissionsFragment>
+
+    fun hasRequiredPermissions(context: Context): Boolean = hasAllPermissions(context, permissions)
+}
+
+/**
+ * The permissions required to access the folder where AnkiDroid data is saved.
+ *
+ * See [selectStoragePermissions].
+ */
 @Parcelize
-enum class PermissionSet(
-    val permissions: List<String>,
-    val permissionsFragment: Class<out PermissionsFragment>,
-) : Parcelable {
+enum class StoragePermissionSet(
+    override val permissions: List<String>,
+    override val permissionsFragment: Class<out PermissionsFragment>,
+) : PermissionSet {
     LEGACY_ACCESS(Permissions.legacyStorageAccessStartupPermissions, PermissionsUntil29Fragment::class.java),
 
     @RequiresApi(Build.VERSION_CODES.R)
     EXTERNAL_MANAGER(Permissions.externalManagerStorageAccessStartupPermissions, PermissionsStartingAt30Fragment::class.java),
 
     APP_PRIVATE(Permissions.appPrivateStartupPermissions, InternetPermissionFragment::class.java),
+}
 
+/**
+ * Permissions a feature requests when it is first used. AnkiDroid runs without them.
+ *
+ * Optional: requested on a [PermissionsBottomSheet].
+ */
+@Parcelize
+enum class OptionalPermissionSet(
+    override val permissions: List<String>,
+    override val permissionsFragment: Class<out PermissionsFragment>,
+) : PermissionSet {
     /**
-     * Optional. For devices with API >= 33.
+     * For devices with API >= 33.
      * @see NotificationsPermissionFragment
      */
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     NOTIFICATIONS(listOf(Permissions.notificationsPermission), NotificationsPermissionFragment::class.java),
 
     /**
-     * Optional. For devices with API < 33.
+     * For devices with API < 33.
      * There is no formal permission to request, but it is possible for the user to manually disable notifications in Settings.
      * If they want notifications, we need to direct the user to the OS settings via the [LegacyNotificationsPermissionFragment] so they can re-enable them.
      */
     LEGACY_NOTIFICATIONS(listOf(LEGACY_POST_NOTIFICATIONS), LegacyNotificationsPermissionFragment::class.java),
-    ;
-
-    fun hasRequiredPermissions(context: Context): Boolean = hasAllPermissions(context, permissions)
 }
 
 /**
- * Returns the [PermissionSet] required to access the folder where AnkiDroid data is saved.
+ * Returns the [StoragePermissionSet] required to access the folder where AnkiDroid data is saved.
  * [AnkiDroidFolder.PUBLIC] is preferred, as it reduces risk of data loss.
  * When impossible, we use the app-private directory.
  * See https://github.com/ankidroid/Anki-Android/issues/5304 for more context.
@@ -236,29 +263,29 @@ enum class PermissionSet(
 internal fun selectStoragePermissions(
     canManageExternalStorage: Boolean,
     currentFolderIsAccessibleAndLegacy: Boolean,
-): PermissionSet {
+): StoragePermissionSet {
     if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q || currentFolderIsAccessibleAndLegacy) {
         // match AnkiDroid behaviour before scoped storage - force the use of ~/AnkiDroid,
         // since it's fast & safe up to & including 'Q'
         // If a user upgrades their OS from Android 10 to 11 then storage speed is severely reduced
         // and a user should use one of the below options to provide faster speeds
-        return PermissionSet.LEGACY_ACCESS
+        return StoragePermissionSet.LEGACY_ACCESS
     }
 
     // If the user can manage external storage, we can access the safe folder & access is fast
     return if (canManageExternalStorage) {
-        PermissionSet.EXTERNAL_MANAGER
+        StoragePermissionSet.EXTERNAL_MANAGER
     } else {
-        PermissionSet.APP_PRIVATE
+        StoragePermissionSet.APP_PRIVATE
     }
 }
 
-fun selectStoragePermissions(context: Context): PermissionSet {
+fun selectStoragePermissions(context: Context): StoragePermissionSet {
     // `false`: the collection is app-private, so it can be accessed without storage permissions
     // `null`: no collection path is set
     val currentFolderIsLegacy = isLegacyStorage(context, setCollectionPath = false)
     if (currentFolderIsLegacy == false) {
-        return PermissionSet.APP_PRIVATE
+        return StoragePermissionSet.APP_PRIVATE
     }
 
     val canAccessLegacyStorage = Build.VERSION.SDK_INT < Build.VERSION_CODES.Q || Environment.isExternalStorageLegacy()
@@ -272,7 +299,7 @@ fun selectStoragePermissions(context: Context): PermissionSet {
 
 /** The folder where AnkiDroid data is saved. See [selectStoragePermissions]. */
 fun selectAnkiDroidFolder(context: Context): AnkiDroidFolder =
-    if (selectStoragePermissions(context) == PermissionSet.APP_PRIVATE) {
+    if (selectStoragePermissions(context) == StoragePermissionSet.APP_PRIVATE) {
         AnkiDroidFolder.APP_PRIVATE
     } else {
         AnkiDroidFolder.PUBLIC

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -20,7 +20,7 @@ import com.ichi2.anki.CollectionManager.withOpenColOrNull
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.InitialActivity
 import com.ichi2.anki.OnErrorListener
-import com.ichi2.anki.PermissionSet
+import com.ichi2.anki.StoragePermissionSet
 import com.ichi2.anki.common.destinations.BrowserDestination
 import com.ichi2.anki.common.destinations.DeckOptionsDestination
 import com.ichi2.anki.common.destinations.NoteEditorDestination
@@ -493,7 +493,7 @@ class DeckPickerViewModel :
 
     sealed class StartupResponse {
         data class RequestPermissions(
-            val requiredPermissions: PermissionSet,
+            val requiredPermissions: StoragePermissionSet,
         ) : StartupResponse()
 
         /**
@@ -538,7 +538,7 @@ class DeckPickerViewModel :
     interface AnkiDroidEnvironment {
         fun hasRequiredPermissions(): Boolean
 
-        val requiredPermissions: PermissionSet
+        val requiredPermissions: StoragePermissionSet
 
         /** The preferences of the (profile) context the collection path is read from */
         val preferences: SharedPreferences

--- a/AnkiDroid/src/main/java/com/ichi2/anki/startup/SetupStorage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/startup/SetupStorage.kt
@@ -6,21 +6,24 @@ import android.content.Context
 import android.os.Environment
 import androidx.annotation.CheckResult
 import androidx.core.content.edit
+import com.ichi2.anki.StoragePermissionSet
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.storage.AnkiDroidFolder
 import com.ichi2.anki.common.storage.CollectionHelper
+import com.ichi2.anki.common.storage.StorageDecision
 import com.ichi2.anki.exception.StorageNotConfiguredException
 import com.ichi2.anki.exception.SystemStorageException
 import com.ichi2.anki.selectAnkiDroidFolder
+import com.ichi2.anki.selectStoragePermissions
 import timber.log.Timber
 import java.io.File
 
 /**
- * Ensures [CollectionHelper.PREF_COLLECTION_PATH] is set, choosing and persisting
- * [getDefaultAnkiDroidDirectory] if it is unset.
+ * Persists the collection path ([CollectionHelper.PREF_COLLECTION_PATH]) chosen by the
+ * [StoragePolicy] of the required [StoragePermissionSet], if it is unset.
  *
- * This decides the storage location on the user's behalf: until a storage setup flow exists
- * (#19552), the user is not asked.
+ * Does nothing if the policy defers the choice to the user: the [StorageDecision] stays
+ * [StorageDecision.Undecided] until the permission screen is completed.
  *
  * @throws SystemStorageException if `getExternalFilesDir` returns null. The failure is recorded
  * in [CollectionHelper.systemStorageFailure] so reads report it rather than
@@ -29,9 +32,15 @@ import java.io.File
 fun ensureCollectionPathSet(context: Context) {
     val preferences = context.sharedPrefs()
     if (preferences.contains(CollectionHelper.PREF_COLLECTION_PATH)) return
+    val folder = selectStoragePermissions(context).folderToPersist(context)
+    if (folder == null) {
+        // unreachable until 13574 is fixed.
+        Timber.i("deferring the storage decision to the user")
+        return
+    }
     val defaultPath =
         try {
-            getDefaultAnkiDroidDirectory(context).absolutePath
+            getDefaultAnkiDroidDirectory(context, folder = folder).absolutePath
         } catch (e: SystemStorageException) {
             CollectionHelper.systemStorageFailure = e
             throw e

--- a/AnkiDroid/src/main/java/com/ichi2/anki/startup/StoragePolicy.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/startup/StoragePolicy.kt
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.startup
+
+import com.ichi2.anki.StoragePermissionSet
+import com.ichi2.anki.common.storage.AnkiDroidFolder
+import com.ichi2.anki.common.storage.StorageDecision
+
+/**
+ * Who chooses the [AnkiDroidFolder] on a fresh install.
+ *
+ * Declared per [StoragePermissionSet] ([StoragePermissionSet.storagePolicy]) and applied by
+ * [ensureCollectionPathSet].
+ */
+sealed interface StoragePolicy {
+    /** Only one folder is possible, so it is persisted on startup. */
+    data class Fixed(
+        val folder: AnkiDroidFolder,
+    ) : StoragePolicy
+
+    /**
+     * The user chooses on the permission screen: granting the permissions selects
+     * [AnkiDroidFolder.PUBLIC], skipping them selects [AnkiDroidFolder.APP_PRIVATE].
+     *
+     * The [StorageDecision] is [StorageDecision.Undecided] until the screen is completed.
+     */
+    data object UserChoosesOnPermissionScreen : StoragePolicy
+}
+
+/**
+ * The folder to persist on startup, or `null` if the user has yet to choose.
+ *
+ * @param hasRequiredPermissions [StoragePermissionSet.hasRequiredPermissions]
+ */
+fun StoragePolicy.folderToPersist(hasRequiredPermissions: Boolean): AnkiDroidFolder? =
+    when (this) {
+        is StoragePolicy.Fixed -> folder
+        StoragePolicy.UserChoosesOnPermissionScreen -> if (hasRequiredPermissions) AnkiDroidFolder.PUBLIC else null
+    }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivity.kt
@@ -57,10 +57,7 @@ class PermissionsActivity : AnkiActivity(R.layout.activity_permissions) {
             finish()
             return
         }
-        val permissionsFragment =
-            requireNotNull(permissionSet.permissionsFragment?.getDeclaredConstructor()?.newInstance()) {
-                "invalid permissionsFragment"
-            }
+        val permissionsFragment = permissionSet.permissionsFragment.getDeclaredConstructor().newInstance()
         setFragmentResultListener(PERMISSIONS_FRAGMENT_RESULT_KEY) { _, bundle ->
             val hasAllPermissions = bundle.getBoolean(HAS_ALL_PERMISSIONS_KEY)
             setContinueButtonEnabled(hasAllPermissions)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivity.kt
@@ -12,8 +12,8 @@ import androidx.activity.enableEdgeToEdge
 import androidx.core.content.IntentCompat
 import androidx.fragment.app.commit
 import com.ichi2.anki.AnkiActivity
-import com.ichi2.anki.PermissionSet
 import com.ichi2.anki.R
+import com.ichi2.anki.StoragePermissionSet
 import com.ichi2.anki.common.utils.android.showThemedToast
 import com.ichi2.anki.databinding.ActivityPermissionsBinding
 import com.ichi2.anki.ui.windows.permissions.PermissionsFragment.Companion.HAS_ALL_PERMISSIONS_KEY
@@ -49,7 +49,7 @@ class PermissionsActivity : AnkiActivity(R.layout.activity_permissions) {
         binding.continueButton.setOnClickListener { finish() }
 
         // #20881: Activity should not be launchd without extras
-        val permissionSet = IntentCompat.getParcelableExtra(intent, EXTRA_PERMISSIONS_SET, PermissionSet::class.java)
+        val permissionSet = IntentCompat.getParcelableExtra(intent, EXTRA_PERMISSIONS_SET, StoragePermissionSet::class.java)
         if (permissionSet == null) {
             Timber.w("EXTRA_PERMISSIONS_SET not set; finishing")
             showThemedToast(this, R.string.something_wrong, false)
@@ -79,7 +79,7 @@ class PermissionsActivity : AnkiActivity(R.layout.activity_permissions) {
 
         fun getIntent(
             context: Context,
-            permissionsSet: PermissionSet,
+            permissionsSet: StoragePermissionSet,
         ): Intent =
             Intent(context, PermissionsActivity::class.java).apply {
                 putExtra(EXTRA_PERMISSIONS_SET, permissionsSet as Parcelable)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsBottomSheet.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsBottomSheet.kt
@@ -65,10 +65,7 @@ class PermissionsBottomSheet : BottomSheetDialogFragment() {
         }
 
         val permissionSet = requireArguments().requireParcelable<PermissionSet>(ARG_PERMISSION_SET)
-        val permissionsFragment =
-            requireNotNull(permissionSet.permissionsFragment?.getDeclaredConstructor()?.newInstance()) {
-                "invalid permissionsFragment"
-            }
+        val permissionsFragment = permissionSet.permissionsFragment.getDeclaredConstructor().newInstance()
         view.post {
             childFragmentManager.commit {
                 replace(binding.bottomSheetFragmentContainer.id, permissionsFragment)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsBottomSheet.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsBottomSheet.kt
@@ -24,7 +24,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import com.ichi2.anki.PermissionSet
+import com.ichi2.anki.OptionalPermissionSet
 import com.ichi2.anki.R
 import com.ichi2.anki.databinding.FragmentPermissionsBottomSheetBinding
 import com.ichi2.anki.utils.ext.behavior
@@ -64,7 +64,7 @@ class PermissionsBottomSheet : BottomSheetDialogFragment() {
             dismiss()
         }
 
-        val permissionSet = requireArguments().requireParcelable<PermissionSet>(ARG_PERMISSION_SET)
+        val permissionSet = requireArguments().requireParcelable<OptionalPermissionSet>(ARG_PERMISSION_SET)
         val permissionsFragment = permissionSet.permissionsFragment.getDeclaredConstructor().newInstance()
         view.post {
             childFragmentManager.commit {
@@ -80,7 +80,7 @@ class PermissionsBottomSheet : BottomSheetDialogFragment() {
         private const val FRAGMENT_TAG = "notifications_bottom_sheet"
 
         /**
-         * Arguments key for the [PermissionSet] to launch this BottomSheet with.
+         * Arguments key for the [OptionalPermissionSet] to launch this BottomSheet with.
          */
         private const val ARG_PERMISSION_SET = "arg_permission_set"
 
@@ -91,11 +91,11 @@ class PermissionsBottomSheet : BottomSheetDialogFragment() {
         const val RESULT_DISMISS = "result_dismiss"
 
         /**
-         * Starts this BottomSheet with the provided [PermissionSet].
+         * Starts this BottomSheet with the provided [OptionalPermissionSet].
          */
         fun launch(
             fragmentManager: FragmentManager,
-            permissionsSet: PermissionSet,
+            permissionsSet: OptionalPermissionSet,
         ) {
             val bottomSheet =
                 PermissionsBottomSheet().apply {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -18,7 +18,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import com.ichi2.anki.NotificationChannel
-import com.ichi2.anki.PermissionSet
+import com.ichi2.anki.OptionalPermissionSet
 import com.ichi2.anki.R
 import com.ichi2.anki.common.permissions.LEGACY_POST_NOTIFICATIONS
 import com.ichi2.anki.common.permissions.MANAGE_EXTERNAL_STORAGE
@@ -144,14 +144,14 @@ object Permissions {
                 return
             }
             Timber.i("Showing notifications permissions bottom sheet: API >= 33")
-            PermissionsBottomSheet.launch(fragmentManager, PermissionSet.NOTIFICATIONS)
+            PermissionsBottomSheet.launch(fragmentManager, OptionalPermissionSet.NOTIFICATIONS)
         } else {
             if (Prefs.notificationsBottomSheetShownBelowAPI33) {
                 Timber.i("Not showing notifications permissions bottom sheet: already attempted")
                 return
             }
             Timber.i("Showing notifications permissions bottom sheet: API < 33")
-            PermissionsBottomSheet.launch(fragmentManager, PermissionSet.LEGACY_NOTIFICATIONS)
+            PermissionsBottomSheet.launch(fragmentManager, OptionalPermissionSet.LEGACY_NOTIFICATIONS)
             Prefs.notificationsBottomSheetShownBelowAPI33 = true
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -1040,7 +1040,7 @@ class DeckPickerTest : RobolectricTest() {
                         equalTo(PermissionsActivity::class.java.name),
                     )
 
-                    val extra = IntentCompat.getParcelableExtra(intent, EXTRA_PERMISSIONS_SET, PermissionSet::class.java)
+                    val extra = IntentCompat.getParcelableExtra(intent, EXTRA_PERMISSIONS_SET, StoragePermissionSet::class.java)
 
                     assertNotNull(extra)
                     assertThat(extra.permissions, equalTo(listOf(INTERNET)))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/IntroductionActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/IntroductionActivityTest.kt
@@ -30,7 +30,7 @@ class IntroductionActivityTest : RobolectricTest() {
     @Test
     fun `Sync without storage permission opens PermissionsActivity`() =
         runTest {
-            // Robolectric runs at API 35 where selectStoragePermissions returns PermissionSet.APP_PRIVATE,
+            // Robolectric runs at API 35 where selectStoragePermissions returns StoragePermissionSet.APP_PRIVATE,
             // which is just [INTERNET]. Denying INTERNET is the cheapest
             // way to make hasCollectionStoragePermissions() return false in this environment.
             withDeniedPermissions(INTERNET) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/SelectStoragePermissionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/SelectStoragePermissionsTest.kt
@@ -11,10 +11,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.testutils.EmptyApplication
-import com.ichi2.utils.Permissions
-import io.mockk.every
-import io.mockk.mockkObject
-import io.mockk.unmockkObject
+import com.ichi2.testutils.withManageExternalStorageInManifest
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.contains
@@ -140,17 +137,6 @@ class SelectStoragePermissionsTest {
 
     private val context: Context
         get() = ApplicationProvider.getApplicationContext()
-
-    /** a 'full' build: `MANAGE_EXTERNAL_STORAGE` is declared in the manifest */
-    private fun withManageExternalStorageInManifest(block: () -> Unit) {
-        mockkObject(Permissions)
-        every { Permissions.canManageExternalStorage(any()) } returns true
-        try {
-            block()
-        } finally {
-            unmockkObject(Permissions)
-        }
-    }
 
     /**
      * Helper for [com.ichi2.anki.selectStoragePermissions], making `currentFolderIsAccessibleAndLegacy` optional

--- a/AnkiDroid/src/test/java/com/ichi2/anki/SelectStoragePermissionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/SelectStoragePermissionsTest.kt
@@ -56,8 +56,8 @@ class SelectStoragePermissionsTest {
     @Config(sdk = [Q])
     @Test
     fun startupQ() {
-        assertThat(selectStoragePermissions(canManageExternalStorage = false), equalTo(PermissionSet.LEGACY_ACCESS))
-        assertThat(selectStoragePermissions(canManageExternalStorage = true), equalTo(PermissionSet.LEGACY_ACCESS))
+        assertThat(selectStoragePermissions(canManageExternalStorage = false), equalTo(StoragePermissionSet.LEGACY_ACCESS))
+        assertThat(selectStoragePermissions(canManageExternalStorage = true), equalTo(StoragePermissionSet.LEGACY_ACCESS))
     }
 
     @SuppressLint("InlinedApi")
@@ -101,7 +101,7 @@ class SelectStoragePermissionsTest {
     fun startupAfterQWithoutManageExternalStorage() {
         assertThat(
             selectStoragePermissions(canManageExternalStorage = false),
-            equalTo(PermissionSet.APP_PRIVATE),
+            equalTo(StoragePermissionSet.APP_PRIVATE),
         )
     }
 
@@ -111,7 +111,7 @@ class SelectStoragePermissionsTest {
     fun `full build - screen is required while no collection path is set`() {
         context.sharedPrefs().edit { remove(CollectionHelper.PREF_COLLECTION_PATH) }
         withManageExternalStorageInManifest {
-            assertThat(selectStoragePermissions(context), equalTo(PermissionSet.EXTERNAL_MANAGER))
+            assertThat(selectStoragePermissions(context), equalTo(StoragePermissionSet.EXTERNAL_MANAGER))
         }
     }
 
@@ -123,7 +123,7 @@ class SelectStoragePermissionsTest {
             putString(CollectionHelper.PREF_COLLECTION_PATH, "/storage/emulated/0/AnkiDroid")
         }
         withManageExternalStorageInManifest {
-            assertThat(selectStoragePermissions(context), equalTo(PermissionSet.EXTERNAL_MANAGER))
+            assertThat(selectStoragePermissions(context), equalTo(StoragePermissionSet.EXTERNAL_MANAGER))
         }
     }
 
@@ -134,7 +134,7 @@ class SelectStoragePermissionsTest {
             putString(CollectionHelper.PREF_COLLECTION_PATH, File(context.filesDir, "AnkiDroid").path)
         }
         withManageExternalStorageInManifest {
-            assertThat(selectStoragePermissions(context), equalTo(PermissionSet.APP_PRIVATE))
+            assertThat(selectStoragePermissions(context), equalTo(StoragePermissionSet.APP_PRIVATE))
         }
     }
 
@@ -158,7 +158,7 @@ class SelectStoragePermissionsTest {
     private fun selectStoragePermissions(
         canManageExternalStorage: Boolean,
         currentFolderIsAccessibleAndLegacy: Boolean = false,
-    ): PermissionSet =
+    ): StoragePermissionSet =
         com.ichi2.anki.selectStoragePermissions(
             canManageExternalStorage = canManageExternalStorage,
             currentFolderIsAccessibleAndLegacy = currentFolderIsAccessibleAndLegacy,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/startup/SetupStorageTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/startup/SetupStorageTest.kt
@@ -2,16 +2,26 @@
 
 package com.ichi2.anki.startup
 
+import android.annotation.SuppressLint
+import android.os.Build
+import android.os.Environment
 import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.common.permissions.isExternalStorageManager
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.exception.StorageNotConfiguredException
 import com.ichi2.anki.exception.SystemStorageException
+import com.ichi2.testutils.withManageExternalStorageInManifest
+import com.ichi2.testutils.withWritePermissions
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
 import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -93,5 +103,64 @@ class SetupStorageTest : RobolectricTest() {
         ensureCollectionPathSet(targetContext)
 
         assertEquals("/a/custom/path", collectionPath)
+    }
+
+    // The permission screen is mandatory on Android 10 and below: the folder is fixed
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.Q])
+    fun `Android 10 - public storage is persisted before permissions are granted`() {
+        prefs.edit { remove(CollectionHelper.PREF_COLLECTION_PATH) }
+
+        ensureCollectionPathSet(targetContext)
+
+        assertEquals(publicDirectory, collectionPath)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.Q])
+    fun `Android 10 - public storage is persisted once permissions are granted`() {
+        prefs.edit { remove(CollectionHelper.PREF_COLLECTION_PATH) }
+
+        withWritePermissions { ensureCollectionPathSet(targetContext) }
+
+        assertEquals(publicDirectory, collectionPath)
+    }
+
+    // TODO: 13574 - the decision is deferred to the user: the screen may be skipped
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.R])
+    fun `full build - public storage is persisted before 'All files access' is granted`() {
+        prefs.edit { remove(CollectionHelper.PREF_COLLECTION_PATH) }
+
+        withManageExternalStorageInManifest { ensureCollectionPathSet(targetContext) }
+
+        assertEquals(publicDirectory, collectionPath)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.R])
+    fun `full build - public storage is persisted once 'All files access' is granted`() {
+        prefs.edit { remove(CollectionHelper.PREF_COLLECTION_PATH) }
+
+        withManageExternalStorageInManifest {
+            withAllFilesAccess { ensureCollectionPathSet(targetContext) }
+        }
+
+        assertEquals(publicDirectory, collectionPath)
+    }
+
+    private val publicDirectory: String
+        get() = File(Environment.getExternalStorageDirectory(), "AnkiDroid").absolutePath
+
+    /** `MANAGE_EXTERNAL_STORAGE` is granted */
+    @SuppressLint("NewApi") // isExternalStorageManager requires R, guaranteed by @Config
+    private fun withAllFilesAccess(block: () -> Unit) {
+        mockkStatic(::isExternalStorageManager)
+        every { isExternalStorageManager() } returns true
+        try {
+            block()
+        } finally {
+            unmockkStatic(::isExternalStorageManager)
+        }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/startup/StoragePolicyTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/startup/StoragePolicyTest.kt
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.startup
+
+import android.annotation.SuppressLint
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.EmptyApplicationCategory
+import com.ichi2.anki.StoragePermissionSet
+import com.ichi2.anki.common.storage.AnkiDroidFolder
+import com.ichi2.testutils.EmptyApplication
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
+class StoragePolicyTest {
+    @Test
+    fun `a fixed folder is persisted whether or not permissions are granted`() {
+        for (folder in AnkiDroidFolder.entries) {
+            val policy = StoragePolicy.Fixed(folder)
+            assertEquals(folder, policy.folderToPersist(hasRequiredPermissions = true), "$folder: granted")
+            assertEquals(folder, policy.folderToPersist(hasRequiredPermissions = false), "$folder: not granted")
+        }
+    }
+
+    @Test // #13574
+    fun `a user choice is deferred until permissions are granted`() {
+        val policy = StoragePolicy.UserChoosesOnPermissionScreen
+        assertEquals(AnkiDroidFolder.PUBLIC, policy.folderToPersist(hasRequiredPermissions = true), "granted")
+        assertNull(policy.folderToPersist(hasRequiredPermissions = false), "not granted: deferred")
+    }
+
+    /** The folder persisted on startup for each [StoragePermissionSet], with and without its permissions */
+    @SuppressLint("NewApi") // EXTERNAL_MANAGER requires R: only the declared policy is tested
+    @Test
+    fun `folder persisted on startup by permission set`() {
+        val expected =
+            listOf(
+                Case(StoragePermissionSet.LEGACY_ACCESS, granted = false, persists = AnkiDroidFolder.PUBLIC),
+                Case(StoragePermissionSet.LEGACY_ACCESS, granted = true, persists = AnkiDroidFolder.PUBLIC),
+                // TODO: 13574 - not granted: null (deferred to the permission screen)
+                Case(StoragePermissionSet.EXTERNAL_MANAGER, granted = false, persists = AnkiDroidFolder.PUBLIC),
+                Case(StoragePermissionSet.EXTERNAL_MANAGER, granted = true, persists = AnkiDroidFolder.PUBLIC),
+                Case(StoragePermissionSet.APP_PRIVATE, granted = false, persists = AnkiDroidFolder.APP_PRIVATE),
+                Case(StoragePermissionSet.APP_PRIVATE, granted = true, persists = AnkiDroidFolder.APP_PRIVATE),
+            )
+
+        for (case in expected) {
+            val policy = case.permissions.storagePolicy
+            assertEquals(case.persists, policy.folderToPersist(case.granted), "${case.permissions}, granted = ${case.granted}")
+        }
+    }
+
+    private data class Case(
+        val permissions: StoragePermissionSet,
+        val granted: Boolean,
+        /** `null`: the decision is deferred to the user */
+        val persists: AnkiDroidFolder?,
+    )
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivityTest.kt
@@ -23,9 +23,11 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ActivityScenario.ActivityAction
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.OptionalPermissionSet
 import com.ichi2.anki.PermissionSet
 import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.StoragePermissionSet
 import com.ichi2.testutils.HamcrestUtils.containsInAnyOrder
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -66,7 +68,8 @@ class PermissionsActivityTest : RobolectricTest() {
     @Test
     fun `Each screen starts normally and has the same permissions of a PermissionSet`() {
         testActivity { activity ->
-            for (permissionSet in PermissionSet.entries) {
+            val permissionSets: List<PermissionSet> = StoragePermissionSet.entries + OptionalPermissionSet.entries
+            for (permissionSet in permissionSets) {
                 val fragment = permissionSet.permissionsFragment.getDeclaredConstructor().newInstance()
                 activity.supportFragmentManager.commitNow {
                     replace(R.id.fragment_container, fragment)
@@ -84,7 +87,7 @@ class PermissionsActivityTest : RobolectricTest() {
     }
 
     private fun testActivity(
-        permissionSet: PermissionSet? = ARBITRARY_PERMISSION_SET,
+        permissionSet: StoragePermissionSet? = ARBITRARY_PERMISSION_SET,
         action: ActivityAction<PermissionsActivity>,
     ) {
         val context = ApplicationProvider.getApplicationContext<Context>()
@@ -102,6 +105,6 @@ class PermissionsActivityTest : RobolectricTest() {
     }
 
     companion object {
-        val ARBITRARY_PERMISSION_SET = PermissionSet.entries.first()
+        val ARBITRARY_PERMISSION_SET = StoragePermissionSet.entries.first()
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivityTest.kt
@@ -67,7 +67,7 @@ class PermissionsActivityTest : RobolectricTest() {
     fun `Each screen starts normally and has the same permissions of a PermissionSet`() {
         testActivity { activity ->
             for (permissionSet in PermissionSet.entries) {
-                val fragment = permissionSet.permissionsFragment?.getDeclaredConstructor()?.newInstance() ?: continue
+                val fragment = permissionSet.permissionsFragment.getDeclaredConstructor().newInstance()
                 activity.supportFragmentManager.commitNow {
                     replace(R.id.fragment_container, fragment)
                 }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/PermissionMocks.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/PermissionMocks.kt
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.testutils
+
+import android.Manifest.permission.MANAGE_EXTERNAL_STORAGE
+import com.ichi2.utils.Permissions
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+
+/** a 'full' build: [MANAGE_EXTERNAL_STORAGE] is declared in the manifest */
+fun withManageExternalStorageInManifest(block: () -> Unit) {
+    mockkObject(Permissions)
+    every { Permissions.canManageExternalStorage(any()) } returns true
+    try {
+        block()
+    } finally {
+        unmockkObject(Permissions)
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/PermissionsTest.kt
@@ -17,7 +17,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SdkSuppress
-import com.ichi2.anki.PermissionSet
+import com.ichi2.anki.OptionalPermissionSet
 import com.ichi2.anki.R
 import com.ichi2.anki.common.permissions.LEGACY_POST_NOTIFICATIONS
 import com.ichi2.anki.settings.Prefs
@@ -172,11 +172,11 @@ class PermissionsTest {
         setCanPermissionBeRequested(true)
         showBottomSheetShouldSucceed()
         showBottomSheetShouldSucceed()
-        verify(exactly = 2) { PermissionsBottomSheet.launch(fragmentManager, PermissionSet.NOTIFICATIONS) }
+        verify(exactly = 2) { PermissionsBottomSheet.launch(fragmentManager, OptionalPermissionSet.NOTIFICATIONS) }
 
         setCanPermissionBeRequested(false)
         showBottomSheetShouldFail()
-        verify(exactly = 2) { PermissionsBottomSheet.launch(fragmentManager, PermissionSet.NOTIFICATIONS) }
+        verify(exactly = 2) { PermissionsBottomSheet.launch(fragmentManager, OptionalPermissionSet.NOTIFICATIONS) }
     }
 
     @Test
@@ -192,7 +192,7 @@ class PermissionsTest {
 
         setCanPermissionBeRequested(false)
         showBottomSheetShouldFail()
-        verify(exactly = 1) { PermissionsBottomSheet.launch(fragmentManager, PermissionSet.LEGACY_NOTIFICATIONS) }
+        verify(exactly = 1) { PermissionsBottomSheet.launch(fragmentManager, OptionalPermissionSet.LEGACY_NOTIFICATIONS) }
         assertThat(Prefs.notificationsBottomSheetShownBelowAPI33, equalTo(true))
     }
 


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5.1

## Purpose / Description
In my fix for #13574, I made a mistake, which meant `Undecided` was returned for < API 31.


## Fixes
* Prep for #13574

## Approach
This issue prompted me to better model the domain: Deferring permissions now depends on the permission set which the app requires, rather than the current state of storage. 

Now, neither `LEGACY_ACCESS` nor `APP_PRIVATE` will be able to expose the equivalent of `UserChoosesOnPermissionScreen` (even though `LEGACY_ACCESS` uses the public AnkiDroid folder).

I then reached a point where `selectStoragePermissions` could return an invalid value, so I split out the `enum` to remove `NOTIFICATIONS` from storage permission checks.

## How Has This Been Tested?
Unit tested; non-functional changes

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)