### PR TITLE
fix(card-template-editor): show bottom toolbar with physical keyboard

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -765,9 +765,9 @@ open class CardTemplateEditor : AnkiActivity(R.layout.activity_card_template_edi
             binding.editText.addTextChangedListener(templateEditorWatcher)
 
             ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, insets ->
-                /* When keyboard is visible, hide the bottom navigation bar to allow viewing
-                of all template text when resize happens */
-                binding.bottomNavigation.isVisible = !insets.isVisible(ime())
+                // Hide the template tabs to make room for a full software keyboard. A physical
+                // keyboard can report a visible IME with only a navigation strip (or zero height).
+                binding.bottomNavigation.isVisible = insets.getInsets(ime()).bottom <= binding.bottomNavigation.minimumHeight
                 // When fragmented, the activity insets the editor pane instead.
                 // The bottom navigation insets itself, so it is not padded here.
                 if (!templateEditor.fragmented) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorScreenshotTest.kt
@@ -13,6 +13,8 @@ import androidx.core.view.WindowInsetsCompat.Type.displayCutout
 import androidx.core.view.WindowInsetsCompat.Type.navigationBars
 import androidx.core.view.WindowInsetsCompat.Type.statusBars
 import androidx.test.core.app.ActivityScenario
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.ichi2.testutils.dispatchInsets
 import com.ichi2.testutils.insetsOf
 import com.ichi2.utils.Dp
 import com.ichi2.utils.dp
@@ -48,6 +50,29 @@ class CardTemplateEditorScreenshotTest : ScreenshotTest() {
             advanceRobolectricLooper()
             simulateSideNavigationBar()
             captureScreen("landscape")
+        }
+    }
+
+    /** How the IME appears while a physical keyboard is attached */
+    enum class PhysicalKeyboardIme { BUTTONS, GESTURES, SOFTWARE_KEYBOARD }
+
+    /** The template tabs stay for a physical keyboard, and only hide for the full software keyboard */
+    @Test
+    fun physicalKeyboard(
+        @TestParameter ime: PhysicalKeyboardIme,
+    ) {
+        RuntimeEnvironment.setQualifiers("+land-keysexposed-qwerty")
+        withCardTemplateEditor {
+            when (ime) {
+                // 3-button navigation reports a visible IME with no height
+                PhysicalKeyboardIme.BUTTONS -> dispatchInsets(navBarRight = 48.dp, imeVisible = true)
+                // gesture navigation shows only a 48dp strip
+                PhysicalKeyboardIme.GESTURES -> dispatchInsets(navBarBottom = 24.dp, imeBottom = 48.dp)
+                // the user may still opt into the software keyboard
+                PhysicalKeyboardIme.SOFTWARE_KEYBOARD -> dispatchInsets(navBarBottom = 24.dp, imeBottom = 240.dp)
+            }
+            advanceRobolectricLooper()
+            captureScreen("physical_keyboard_${ime.name.lowercase()}")
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/InsetsUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/InsetsUtils.kt
@@ -68,6 +68,8 @@ fun insetsOf(
  * @param cutoutTop a display cutout on the top edge (portrait phone with a notch)
  * @param bottomCornerRadius the radius of both bottom rounded display corners
  * @param imeBottom the height of the on-screen keyboard
+ * @param imeVisible whether the keyboard is shown. Defaults to whether it has a height: a physical
+ * keyboard may show an IME with only a navigation strip, or no height at all
  * @param barsVisible whether the status and navigation bars are shown; `false` in immersive mode
  */
 context(context: Context)
@@ -79,6 +81,7 @@ fun windowInsetsOf(
     cutoutTop: Dp = 0.dp,
     bottomCornerRadius: Dp = 0.dp,
     imeBottom: Dp = 0.dp,
+    imeVisible: Boolean = imeBottom.dp > 0f,
     barsVisible: Boolean = true,
 ): WindowInsetsCompat =
     WindowInsetsCompat
@@ -92,6 +95,7 @@ fun windowInsetsOf(
         ).setInsets(displayCutout(), insetsOf(left = cutoutLeft, top = cutoutTop))
         .setInsetsIgnoringVisibility(displayCutout(), insetsOf(left = cutoutLeft, top = cutoutTop))
         .setInsets(ime(), insetsOf(bottom = imeBottom))
+        .setVisible(ime(), imeVisible)
         .setVisible(statusBars() or navigationBars(), barsVisible)
         .apply {
             // set even when zero: Robolectric's WindowInsets.Builder leaks rounded corners between tests
@@ -114,6 +118,7 @@ fun Activity.dispatchInsets(
     cutoutTop: Dp = 0.dp,
     bottomCornerRadius: Dp = 0.dp,
     imeBottom: Dp = 0.dp,
+    imeVisible: Boolean = imeBottom.dp > 0f,
     barsVisible: Boolean = true,
 ) {
     val insets =
@@ -125,6 +130,7 @@ fun Activity.dispatchInsets(
             cutoutTop = cutoutTop,
             bottomCornerRadius = bottomCornerRadius,
             imeBottom = imeBottom,
+            imeVisible = imeVisible,
             barsVisible = barsVisible,
         )
     ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: GPT-6; Claude Fable 5.1

## Purpose / Description
Previously, tapping the field with a physical keyboard attached would hide the bottom Front/Back/Styling toolbar

## Fixes
* Fixes #21728

## Approach
```diff
- binding.bottomNavigation.isVisible = !insets.isVisible(ime())
+ binding.bottomNavigation.isVisible = insets.getInsets(ime()).bottom <= binding.bottomNavigation.minimumHeight
```

## How Has This Been Tested?
Screenshot test added

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)