### PR TITLE
test(insets): screenshots for hidden gesture bar & rounded corners

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserScreenshotTest.kt
@@ -14,7 +14,9 @@ import androidx.core.view.WindowInsetsCompat.Type.navigationBars
 import androidx.core.view.WindowInsetsCompat.Type.statusBars
 import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.ui.RecyclerFastScroller
+import com.ichi2.testutils.HIDDEN_GESTURE_BAR
 import com.ichi2.testutils.insetsOf
+import com.ichi2.testutils.simulateSystemBars
 import com.ichi2.utils.dp
 import org.junit.Test
 import org.robolectric.RuntimeEnvironment
@@ -107,6 +109,23 @@ class CardBrowserScreenshotTest : ScreenshotTest() {
             captureScreen("landscape_gesture_scrolled_to_bottom")
         }
     }
+
+    @Test
+    fun cardBrowserGestureBarHiddenScrolledToBottom() =
+        withCardBrowser(noteCount = 50) { browser ->
+            browser.simulateSystemBars(navBarBottom = HIDDEN_GESTURE_BAR, bottomCornerRadius = 34.dp)
+
+            val list = browser.findViewById<RecyclerView>(R.id.card_browser_list)
+            list.scrollToPosition(49)
+            while (list.canScrollVertically(1)) list.scrollBy(0, 50)
+            advanceRobolectricLooper()
+
+            // keep the auto-hiding fast scroller visible for the capture
+            browser.findViewById<RecyclerFastScroller>(R.id.browser_scroller).show(animate = false)
+            advanceRobolectricLooper()
+
+            captureScreen("gesture_bar_hidden_scrolled_to_bottom")
+        }
 
     @Test
     fun multiselect() =

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesScreenshotTest.kt
@@ -5,10 +5,12 @@ package com.ichi2.anki.preferences
 import androidx.fragment.app.Fragment
 import androidx.preference.Preference
 import androidx.test.core.app.ActivityScenario
+import com.google.android.material.appbar.AppBarLayout
 import com.ichi2.anki.R
 import com.ichi2.anki.ScreenshotTest
 import com.ichi2.anki.common.storage.CollectionHelper
 import com.ichi2.anki.settings.Prefs
+import com.ichi2.testutils.HIDDEN_GESTURE_BAR
 import com.ichi2.testutils.ext.clear
 import com.ichi2.testutils.simulateSystemBars
 import com.ichi2.utils.dp
@@ -41,6 +43,22 @@ class PreferencesScreenshotTest : ScreenshotTest() {
     }
 
     @Test
+    fun headerFragmentGestureBarHiddenScrolledToBottom() =
+        withPreferencesActivity(HeaderFragment::class) { activity ->
+            activity.simulateSystemBars(navBarBottom = HIDDEN_GESTURE_BAR, bottomCornerRadius = 34.dp)
+            activity.scrollSettingsToBottom()
+            captureScreen("HeaderFragment_gesture_bar_hidden_scrolled_to_bottom")
+        }
+
+    @Test
+    fun headerFragmentGestureBarScrolledToBottom() =
+        withPreferencesActivity(HeaderFragment::class) { activity ->
+            activity.simulateSystemBars(navBarBottom = 24.dp, bottomCornerRadius = 34.dp)
+            activity.scrollSettingsToBottom()
+            captureScreen("HeaderFragment_gesture_bar_scrolled_to_bottom")
+        }
+
+    @Test
     fun `capture all preference fragments`() {
         val fragments = PreferenceTestUtils.getAllPreferencesFragments(targetContext)
 
@@ -63,6 +81,23 @@ class PreferencesScreenshotTest : ScreenshotTest() {
                 captureScreen(fragmentClass.simpleName!!)
             }
         }
+    }
+
+    /**
+     * Scrolls the displayed settings list to its end, where its bottom padding is visible.
+     *
+     * The app bar is collapsed first, as a user's scroll would: while it is expanded, the list
+     * extends below the screen by the app bar's scroll range, which hides the padding.
+     */
+    private fun PreferencesActivity.scrollSettingsToBottom() {
+        findViewById<AppBarLayout>(R.id.appbar).setExpanded(false, false)
+        advanceRobolectricLooper()
+        val mainFragment = fragment as PreferencesFragment
+        val settingsFragment = mainFragment.childFragmentManager.findFragmentById(R.id.settings_container) as SettingsFragment
+        val list = settingsFragment.listView
+        list.scrollToPosition(list.adapter!!.itemCount - 1)
+        while (list.canScrollVertically(1)) list.scrollBy(0, 50)
+        advanceRobolectricLooper()
     }
 
     private fun withPreferencesActivity(

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/InsetsUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/InsetsUtils.kt
@@ -22,6 +22,13 @@ import com.ichi2.utils.Dp
 import com.ichi2.utils.dp
 
 /**
+ * The bottom navigation bar height when the gesture navigation indicator is hidden
+ * ('Hide full screen indicator' on MIUI): no inset is reported and nothing is drawn at the
+ * bottom of the screen, but the display corners are still rounded.
+ */
+val HIDDEN_GESTURE_BAR = 0.dp
+
+/**
  * Helper to build [Insets] using [Dp]
  *
  * Default parameters allow for succinct code:
@@ -137,27 +144,44 @@ fun Activity.dispatchInsets(
  *
  * @param cutoutLeft simulates a display cutout on the left edge, as when a phone with a
  * top notch is rotated to landscape.
+ * @param navBarBottom the height of a navigation bar along the bottom edge:
+ * * 48dp for 3-button
+ * * less for gesture navigation.
+ * * [HIDDEN_GESTURE_BAR] if the gesture indicator is hidden, in which case no band is drawn:
+ *   nothing marks the area on a real device either.
+ * @param bottomCornerRadius the radius of both bottom rounded display corners
  */
 @SuppressLint("RtlHardcoded") // insets and cutouts are physical: not layout-direction relative
-fun Activity.simulateSystemBars(cutoutLeft: Dp = 0.dp) {
+fun Activity.simulateSystemBars(
+    cutoutLeft: Dp = 0.dp,
+    navBarBottom: Dp = 48.dp,
+    bottomCornerRadius: Dp = 0.dp,
+) {
     val statusBarHeight = 24.dp
-    val navBarHeight = 48.dp
+    val context: Context = this
     val insets =
         WindowInsetsCompat
             .Builder()
             .setInsets(statusBars(), insetsOf(top = statusBarHeight))
             // workaround for 'systemWindowInsets', so snackbars match a real device
-            .setInsets(navigationBars(), insetsOf(left = cutoutLeft, bottom = navBarHeight))
+            .setInsets(navigationBars(), insetsOf(left = cutoutLeft, bottom = navBarBottom))
             .setInsets(displayCutout(), insetsOf(left = cutoutLeft))
-            .build()
+            .apply {
+                // set even when zero: Robolectric's WindowInsets.Builder leaks rounded corners between tests
+                val radius = bottomCornerRadius.toPx(context)
+                for (position in intArrayOf(RoundedCornerCompat.POSITION_BOTTOM_LEFT, RoundedCornerCompat.POSITION_BOTTOM_RIGHT)) {
+                    setRoundedCorner(position, RoundedCornerCompat(position, radius, radius, radius))
+                }
+            }.build()
     ViewCompat.dispatchApplyWindowInsets(findViewById(android.R.id.content), insets)
 
     val decor = window.decorView as ViewGroup
-    val context: Context = this
     val bands =
         buildList {
             add(FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, statusBarHeight.toPx(context), Gravity.TOP))
-            add(FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, navBarHeight.toPx(context), Gravity.BOTTOM))
+            if (navBarBottom.dp > 0) {
+                add(FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, navBarBottom.toPx(context), Gravity.BOTTOM))
+            }
             if (cutoutLeft.dp > 0) {
                 add(FrameLayout.LayoutParams(cutoutLeft.toPx(context), FrameLayout.LayoutParams.MATCH_PARENT, Gravity.LEFT))
             }


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: GPT-6 - initial implementation; Claude Fable 5.1 - refactors/cleanups

## Purpose / Description
Test-only reproduction-case for #21724

## Fixes
* Prep for #21724

## Learning

This may be slightly visible on 'normal' Androids with the 24dp gesture nav.

* MUI can report an bottom inset of 0: "Hide full screen indicator"
* A rounded corner radius can be larger than this inset [~33dp on Zorn's phone]

This leads to `max(0dp, 33dp)` of empty space.

This is useful when content hugs the edges (Card Browser scrollbar), but settings has a full-width row with padding, where this empty space is overkill

## How Has This Been Tested?
Test-only

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)