### PR TITLE
tests: make Preference screenshot tests full-height

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/ViewUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ViewUtils.kt
@@ -129,11 +129,13 @@ val Double.dp
 @JvmInline
 value class Dp(
     val dp: Float,
-) {
+) : Comparable<Dp> {
     // TODO: improve once we have context parameters
     fun toPx(context: Context) = dp.dpToPx(context)
 
     operator fun plus(other: Dp) = Dp(dp = dp + other.dp)
+
+    override fun compareTo(other: Dp) = dp.compareTo(other.dp)
 }
 
 private fun Float.dpToPx(context: Context): Int = (this * context.resources.displayMetrics.density + 0.5f).toInt()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesScreenshotTest.kt
@@ -4,14 +4,18 @@ package com.ichi2.anki.preferences
 
 import androidx.fragment.app.Fragment
 import androidx.preference.Preference
+import androidx.preference.PreferenceFragmentCompat
+import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ActivityScenario
 import com.google.android.material.appbar.AppBarLayout
 import com.ichi2.anki.R
 import com.ichi2.anki.ScreenshotTest
 import com.ichi2.anki.common.storage.CollectionHelper
+import com.ichi2.anki.preferences.reviewer.ReviewerMenuSettingsFragment
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.testutils.HIDDEN_GESTURE_BAR
 import com.ichi2.testutils.ext.clear
+import com.ichi2.testutils.launchForFullHeightScreenshot
 import com.ichi2.testutils.simulateSystemBars
 import com.ichi2.utils.dp
 import org.junit.After
@@ -60,13 +64,16 @@ class PreferencesScreenshotTest : ScreenshotTest() {
 
     @Test
     fun `capture all preference fragments`() {
+        Prefs.isNewStudyScreenEnabled = true
         val fragments = PreferenceTestUtils.getAllPreferencesFragments(targetContext)
 
         fragments.forEach { fragment ->
             val fragmentClass = fragment::class
-            withPreferencesActivity(fragmentClass) { activity ->
-                Prefs.isNewStudyScreenEnabled = true
-                activity.stabilizeContent()
+            withPreferencesActivity(
+                fragmentClass,
+                fullHeightList = fragment.fullHeightList(),
+                setup = { activity -> activity.stabilizeContent() },
+            ) {
                 captureScreen(fragmentClass.simpleName!!)
             }
         }
@@ -104,13 +111,24 @@ class PreferencesScreenshotTest : ScreenshotTest() {
         }
     }
 
+    /**
+     * @param fullHeightList if set, the screenshot is full height: the screen is sized to show the whole list
+     * @param setup run after each launch of the screen, before [block]
+     */
     private fun withPreferencesActivity(
         fragmentClass: KClass<out Fragment>,
+        fullHeightList: ((PreferencesActivity) -> RecyclerView)? = null,
+        setup: (PreferencesActivity) -> Unit = {},
         block: (PreferencesActivity) -> Unit,
     ) {
         val intent = PreferencesActivity.getIntent(targetContext, fragmentClass)
+        if (fullHeightList != null) {
+            launchForFullHeightScreenshot(intent, fullHeightList, setup, block)
+            return
+        }
         ActivityScenario.launch<PreferencesActivity>(intent).use { scenario ->
             scenario.onActivity { activity ->
+                setup(activity)
                 block(activity)
             }
         }
@@ -119,4 +137,12 @@ class PreferencesScreenshotTest : ScreenshotTest() {
     /** The fragment displayed in the settings pane */
     private val PreferencesActivity.settingsFragment: Fragment?
         get() = (fragment as PreferencesFragment).childFragmentManager.findFragmentById(R.id.settings_container)
+
+    /** @return the list which makes the screenshot full height, or null to capture at the device height */
+    private fun Fragment.fullHeightList(): ((PreferencesActivity) -> RecyclerView)? =
+        when (this) {
+            is PreferenceFragmentCompat -> { activity -> (activity.settingsFragment as PreferenceFragmentCompat).listView }
+            is ReviewerMenuSettingsFragment -> { activity -> activity.settingsFragment!!.requireView().findViewById(R.id.recycler_view) }
+            else -> null
+        }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesScreenshotTest.kt
@@ -66,18 +66,7 @@ class PreferencesScreenshotTest : ScreenshotTest() {
             val fragmentClass = fragment::class
             withPreferencesActivity(fragmentClass) { activity ->
                 Prefs.isNewStudyScreenEnabled = true
-                val mainFragment = activity.fragment as PreferencesFragment
-                val settingsFragment = mainFragment.childFragmentManager.findFragmentById(R.id.settings_container)
-                // Robolectric generates a different temporary path every time,
-                // so avoid creating an unnecessary diff in the collection path pref summary
-                (settingsFragment as? AdvancedSettingsFragment)?.apply {
-                    requirePreference<Preference>(CollectionHelper.PREF_COLLECTION_PATH).summaryProvider = {
-                        "/storage/emulated/0/AnkiDroid"
-                    }
-                }
-                (settingsFragment as? AboutFragment)?.apply {
-                    binding.buildDate.text = "May 18, 2026"
-                }
+                activity.stabilizeContent()
                 captureScreen(fragmentClass.simpleName!!)
             }
         }
@@ -100,17 +89,34 @@ class PreferencesScreenshotTest : ScreenshotTest() {
         advanceRobolectricLooper()
     }
 
+    /** Replaces content which changes between runs, so it does not appear in diffs */
+    private fun PreferencesActivity.stabilizeContent() {
+        val settingsFragment = settingsFragment
+        // Robolectric generates a different temporary path every time,
+        // so avoid creating an unnecessary diff in the collection path pref summary
+        (settingsFragment as? AdvancedSettingsFragment)?.apply {
+            requirePreference<Preference>(CollectionHelper.PREF_COLLECTION_PATH).summaryProvider = {
+                "/storage/emulated/0/AnkiDroid"
+            }
+        }
+        (settingsFragment as? AboutFragment)?.apply {
+            binding.buildDate.text = "May 18, 2026"
+        }
+    }
+
     private fun withPreferencesActivity(
         fragmentClass: KClass<out Fragment>,
         block: (PreferencesActivity) -> Unit,
     ) {
-        ActivityScenario
-            .launch<PreferencesActivity>(
-                PreferencesActivity.getIntent(targetContext, fragmentClass),
-            ).use { scenario ->
-                scenario.onActivity { activity ->
-                    block(activity)
-                }
+        val intent = PreferencesActivity.getIntent(targetContext, fragmentClass)
+        ActivityScenario.launch<PreferencesActivity>(intent).use { scenario ->
+            scenario.onActivity { activity ->
+                block(activity)
             }
+        }
     }
+
+    /** The fragment displayed in the settings pane */
+    private val PreferencesActivity.settingsFragment: Fragment?
+        get() = (fragment as PreferencesFragment).childFragmentManager.findFragmentById(R.id.settings_container)
 }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/ScreenSize.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/ScreenSize.kt
@@ -16,8 +16,18 @@
 
 package com.ichi2.testutils
 
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import com.ichi2.anki.RobolectricTest.Companion.advanceRobolectricLooper
+import com.ichi2.utils.Dp
+import com.ichi2.utils.dp
 import org.robolectric.RuntimeEnvironment
 import timber.log.Timber
+import kotlin.math.ceil
 
 /** [block] runs with a runtime qualifier emulating a split-pane display */
 fun withSplitPaneUi(block: () -> Unit) = withQualifier("sw700dp", block)
@@ -53,4 +63,79 @@ suspend fun withQualifierAsync(
         Timber.d("Resetting qualifiers to $qualifiers")
         RuntimeEnvironment.setQualifiers(qualifiers)
     }
+}
+
+/** Height of the screen used to measure a list */
+private val MAX_LIST_HEIGHT = 10000.dp
+
+/**
+ * Launches [intent] with a full-height screen: tall enough to show all of the list returned
+ * by [listView]. The device height is kept if the list already fits.
+ *
+ * @param setup run after each launch, before [block]
+ */
+fun <A : Activity> launchForFullHeightScreenshot(
+    intent: Intent,
+    listView: (A) -> RecyclerView,
+    setup: (A) -> Unit = {},
+    block: (A) -> Unit,
+) {
+    val deviceQualifiers = RuntimeEnvironment.getQualifiers()
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val deviceHeight = context.resources.configuration.screenHeightDp.dp
+    try {
+        // measure the list in a tall window, then relaunch at its height
+        setScreenHeight(MAX_LIST_HEIGHT)
+        var listHeight = 0.dp
+        launchAndCheckListFits(intent, listView, setup) { _, list -> listHeight = list.screenHeightToFit() }
+        if (listHeight > deviceHeight) {
+            setScreenHeight(listHeight)
+        } else {
+            RuntimeEnvironment.setQualifiers(deviceQualifiers)
+        }
+        launchAndCheckListFits(intent, listView, setup) { activity, _ -> block(activity) }
+    } finally {
+        RuntimeEnvironment.setQualifiers(deviceQualifiers)
+    }
+}
+
+private fun <A : Activity> launchAndCheckListFits(
+    intent: Intent,
+    listView: (A) -> RecyclerView,
+    setup: (A) -> Unit,
+    block: (A, RecyclerView) -> Unit,
+) {
+    ActivityScenario.launch<A>(intent).use { scenario ->
+        scenario.onActivity { activity ->
+            setup(activity)
+            advanceRobolectricLooper() // apply layout changes from setup
+            val list = listView(activity)
+            check(!list.canScrollVertically(1)) {
+                "${activity::class.simpleName}: list does not fit a ${activity.resources.configuration.screenHeightDp}dp screen"
+            }
+            block(activity, list)
+        }
+    }
+}
+
+private fun setScreenHeight(height: Dp) {
+    val qualifiers =
+        RuntimeEnvironment.getQualifiers().split("-").mapNotNull { qualifier ->
+            when {
+                // `+h...dp` is avoided: Robolectric then rebuilds the display from pixels, losing
+                // up to 1dp of width per call. Orientation is dropped so a tall screen is not
+                // swapped to landscape.
+                qualifier.matches(Regex("h\\d+dp")) -> "h${height.dp.toInt()}dp"
+                qualifier == "port" || qualifier == "land" -> null
+                else -> qualifier
+            }
+        }
+    RuntimeEnvironment.setQualifiers(qualifiers.joinToString("-"))
+}
+
+/** The screen height showing every item. Every item must already be laid out */
+private fun RecyclerView.screenHeightToFit(): Dp {
+    val top = IntArray(2).also { getLocationOnScreen(it) }[1]
+    val bottom = top + paddingTop + computeVerticalScrollRange() + paddingBottom
+    return (ceil(bottom / resources.displayMetrics.density) + 1).dp // +1: rounding
 }


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Assisted-by: Claude Fable 5.1

## Purpose / Description
I was concerned that in my string changes, some of the changes could be missed by screenshot tests if the preferences were not scrolled to the correct position.

## Approach
* Perform one pass to obtain the correct height to screenshot
* Then another pass to take the screenshots at the correct height

## How Has This Been Tested?
* Test-only

## Learning (optional, can help others)
Robolectric issue with `+h...dp`

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)