### PR TITLE
fix flaky test: testCustomSchedulerWithCustomDataAndSlowScheduler

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerFragmentTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerFragmentTest.kt
@@ -16,10 +16,10 @@ import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.previewer.CardViewerActivity
 import com.ichi2.anki.tests.InstrumentedTest
 import com.ichi2.anki.tests.checkWithTimeout
-import com.ichi2.anki.tests.libanki.RetryRule
 import com.ichi2.anki.testutil.GrantStoragePermission.storagePermission
 import com.ichi2.anki.testutil.grantPermissions
 import com.ichi2.anki.testutil.notificationPermission
+import com.ichi2.anki.testutil.waitUntil
 import com.ichi2.anki.ui.windows.reviewer.ReviewerFragment
 import com.ichi2.anki.utils.ext.cardStateCustomizer
 import org.hamcrest.MatcherAssert.assertThat
@@ -36,9 +36,6 @@ import java.util.concurrent.TimeUnit
 class ReviewerFragmentTest : InstrumentedTest() {
     @get:Rule
     val runtimePermissionRule = grantPermissions(storagePermission, notificationPermission)
-
-    @get:Rule
-    val retry = RetryRule(10)
 
     /** The collection is shared between tests: review a deck which only contains this test's cards */
     private var testDeckId: DeckId = 0
@@ -103,6 +100,10 @@ class ReviewerFragmentTest : InstrumentedTest() {
             assertThat(cardFromDb.customData, equalTo("""{"c":1}"""))
 
             clickShowAnswerAndAnswerGood()
+            // Answering runs on the IO dispatcher, which Espresso does not wait for.
+            waitUntil(message = { "The review of card ${card.id} was not saved" }) {
+                col.getCard(card.id).reps == card.reps + 1
+            }
 
             cardFromDb = col.getCard(card.id).toBackendCard()
             assertThat(cardFromDb.easeFactor, equalTo(3000))

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerFragmentTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerFragmentTest.kt
@@ -56,6 +56,7 @@ class ReviewerFragmentTest : InstrumentedTest() {
     @After
     fun tearDown() {
         col.decks.remove(listOf(testDeckId))
+        col.cardStateCustomizer = ""
     }
 
     @Test

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerFragmentTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerFragmentTest.kt
@@ -11,7 +11,8 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.common.preferences.sharedPrefs
-import com.ichi2.anki.libanki.Consts
+import com.ichi2.anki.libanki.Card
+import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.previewer.CardViewerActivity
 import com.ichi2.anki.tests.InstrumentedTest
 import com.ichi2.anki.tests.checkWithTimeout
@@ -23,10 +24,12 @@ import com.ichi2.anki.ui.windows.reviewer.ReviewerFragment
 import com.ichi2.anki.utils.ext.cardStateCustomizer
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
@@ -37,13 +40,22 @@ class ReviewerFragmentTest : InstrumentedTest() {
     @get:Rule
     val retry = RetryRule(10)
 
+    /** The collection is shared between tests: review a deck which only contains this test's cards */
+    private var testDeckId: DeckId = 0
+
     @Before
     fun setUp() {
         testContext.sharedPrefs().edit {
             putBoolean("newReviewer", true)
             putBoolean("newReviewerOptions", true)
         }
-        col.decks.select(Consts.DEFAULT_DECK_ID)
+        testDeckId = col.decks.addNormalDeckWithName("ReviewerFragmentTest-${UUID.randomUUID()}").id
+        col.decks.select(testDeckId)
+    }
+
+    @After
+    fun tearDown() {
+        col.decks.remove(listOf(testDeckId))
     }
 
     @Test
@@ -70,7 +82,7 @@ class ReviewerFragmentTest : InstrumentedTest() {
             states.good.normal.review.scheduledDays = 123;
             customData.good.c += 1;
             """
-        val card = addNoteUsingBasicNoteType("foo", "bar").firstCard(col)
+        val card = addCardToTestDeck()
         card.moveToReviewQueue()
         col.backend.updateCards(
             listOf(
@@ -102,13 +114,15 @@ class ReviewerFragmentTest : InstrumentedTest() {
     fun testCustomSchedulerWithRuntimeError() {
         // Issue 15035 - runtime errors weren't handled
         col.cardStateCustomizer = "states.this_is_not_defined.normal.review = 12;"
-        addNoteUsingBasicNoteType()
+        addCardToTestDeck()
 
         withReviewer {
             clickShowAnswer()
             ensureAnswerButtonsAreDisplayed()
         }
     }
+
+    private fun addCardToTestDeck(): Card = addNoteUsingBasicNoteType("foo", "bar").firstCard(col).update { did = testDeckId }
 
     private fun withReviewer(block: () -> Unit) {
         ActivityScenario.launch<CardViewerActivity>(ReviewerFragment.getIntent(testContext)).use { block() }

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerFragmentTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerFragmentTest.kt
@@ -3,26 +3,27 @@
 package com.ichi2.anki
 
 import androidx.core.content.edit
+import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.libanki.Consts
+import com.ichi2.anki.previewer.CardViewerActivity
 import com.ichi2.anki.tests.InstrumentedTest
 import com.ichi2.anki.tests.checkWithTimeout
 import com.ichi2.anki.tests.libanki.RetryRule
 import com.ichi2.anki.testutil.GrantStoragePermission.storagePermission
-import com.ichi2.anki.testutil.closeBackupCollectionDialogIfExists
-import com.ichi2.anki.testutil.closeGetStartedScreenIfExists
 import com.ichi2.anki.testutil.grantPermissions
 import com.ichi2.anki.testutil.notificationPermission
-import com.ichi2.anki.testutil.reviewDeckWithName
+import com.ichi2.anki.ui.windows.reviewer.ReviewerFragment
 import com.ichi2.anki.utils.ext.cardStateCustomizer
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -30,21 +31,20 @@ import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
 class ReviewerFragmentTest : InstrumentedTest() {
-    // Launch IntroductionActivity instead of DeckPicker activity because in CI
-    // builds, it seems to create IntroductionActivity after the DeckPicker,
-    // causing the DeckPicker activity to be destroyed. As a consequence, this
-    // will throw RootViewWithoutFocusException when Espresso tries to interact
-    // with an already destroyed activity. By launching IntroductionActivity, we
-    // ensure that IntroductionActivity is launched first and navigate to the
-    // DeckPicker -> Reviewer activities
-    @get:Rule
-    val activityScenarioRule = ActivityScenarioRule(IntroductionActivity::class.java)
-
     @get:Rule
     val runtimePermissionRule = grantPermissions(storagePermission, notificationPermission)
 
     @get:Rule
     val retry = RetryRule(10)
+
+    @Before
+    fun setUp() {
+        testContext.sharedPrefs().edit {
+            putBoolean("newReviewer", true)
+            putBoolean("newReviewerOptions", true)
+        }
+        col.decks.select(Consts.DEFAULT_DECK_ID)
+    }
 
     @Test
     fun testCustomSchedulerWithCustomData() = testCustomSchedulerWithCustomData(schedulerDelayMs = 0)
@@ -57,7 +57,6 @@ class ReviewerFragmentTest : InstrumentedTest() {
     fun testCustomSchedulerWithCustomDataAndSlowScheduler() = testCustomSchedulerWithCustomData(schedulerDelayMs = 5000)
 
     private fun testCustomSchedulerWithCustomData(schedulerDelayMs: Long) {
-        setNewReviewer()
         val delayJs =
             if (schedulerDelayMs > 0) {
                 "await new Promise(resolve => setTimeout(resolve, $schedulerDelayMs));"
@@ -71,9 +70,7 @@ class ReviewerFragmentTest : InstrumentedTest() {
             states.good.normal.review.scheduledDays = 123;
             customData.good.c += 1;
             """
-        val note = addNoteUsingBasicNoteType("foo", "bar")
-        val card = note.firstCard(col)
-        val deck = col.decks.getLegacy(note.notetype.did)!!
+        val card = addNoteUsingBasicNoteType("foo", "bar").firstCard(col)
         card.moveToReviewQueue()
         col.backend.updateCards(
             listOf(
@@ -86,37 +83,35 @@ class ReviewerFragmentTest : InstrumentedTest() {
             true,
         )
 
-        closeGetStartedScreenIfExists()
-        closeBackupCollectionDialogIfExists()
-        reviewDeckWithName(deck.name)
+        withReviewer {
+            var cardFromDb = col.getCard(card.id).toBackendCard()
+            assertThat(cardFromDb.easeFactor, equalTo(card.factor))
+            assertThat(cardFromDb.interval, equalTo(card.ivl))
+            assertThat(cardFromDb.customData, equalTo("""{"c":1}"""))
 
-        var cardFromDb = col.getCard(card.id).toBackendCard()
-        assertThat(cardFromDb.easeFactor, equalTo(card.factor))
-        assertThat(cardFromDb.interval, equalTo(card.ivl))
-        assertThat(cardFromDb.customData, equalTo("""{"c":1}"""))
+            clickShowAnswerAndAnswerGood()
 
-        clickShowAnswerAndAnswerGood()
-
-        cardFromDb = col.getCard(card.id).toBackendCard()
-        assertThat(cardFromDb.easeFactor, equalTo(3000))
-        assertThat(cardFromDb.interval, equalTo(123))
-        assertThat(cardFromDb.customData, equalTo("""{"c":2}"""))
+            cardFromDb = col.getCard(card.id).toBackendCard()
+            assertThat(cardFromDb.easeFactor, equalTo(3000))
+            assertThat(cardFromDb.interval, equalTo(123))
+            assertThat(cardFromDb.customData, equalTo("""{"c":2}"""))
+        }
     }
 
     @Test
     fun testCustomSchedulerWithRuntimeError() {
-        setNewReviewer()
         // Issue 15035 - runtime errors weren't handled
         col.cardStateCustomizer = "states.this_is_not_defined.normal.review = 12;"
         addNoteUsingBasicNoteType()
 
-        closeGetStartedScreenIfExists()
-        closeBackupCollectionDialogIfExists()
-        reviewDeckWithName("Default")
+        withReviewer {
+            clickShowAnswer()
+            ensureAnswerButtonsAreDisplayed()
+        }
+    }
 
-        clickShowAnswer()
-
-        ensureAnswerButtonsAreDisplayed()
+    private fun withReviewer(block: () -> Unit) {
+        ActivityScenario.launch<CardViewerActivity>(ReviewerFragment.getIntent(testContext)).use { block() }
     }
 
     private fun clickShowAnswerAndAnswerGood() {
@@ -141,12 +136,5 @@ class ReviewerFragmentTest : InstrumentedTest() {
             // slow
             TimeUnit.SECONDS.toMillis(30),
         )
-    }
-
-    private fun setNewReviewer() {
-        testContext.sharedPrefs().edit {
-            putBoolean("newReviewer", true)
-            putBoolean("newReviewerOptions", true)
-        }
     }
 }

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerFragmentTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerFragmentTest.kt
@@ -17,6 +17,7 @@ import com.ichi2.anki.previewer.CardViewerActivity
 import com.ichi2.anki.tests.InstrumentedTest
 import com.ichi2.anki.tests.checkWithTimeout
 import com.ichi2.anki.testutil.GrantStoragePermission.storagePermission
+import com.ichi2.anki.testutil.ensureWebViewIsSupported
 import com.ichi2.anki.testutil.grantPermissions
 import com.ichi2.anki.testutil.notificationPermission
 import com.ichi2.anki.testutil.waitUntil
@@ -26,6 +27,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.After
 import org.junit.Before
+import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -152,5 +154,11 @@ class ReviewerFragmentTest : InstrumentedTest() {
             // slow
             TimeUnit.SECONDS.toMillis(30),
         )
+    }
+
+    companion object {
+        @JvmStatic
+        @BeforeClass
+        fun checkWebView() = ensureWebViewIsSupported()
     }
 }

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/WebViewUtils.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/WebViewUtils.kt
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.testutil
+
+import androidx.core.content.pm.PackageInfoCompat
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.webkit.WebViewCompat
+import com.ichi2.utils.checkWebViewVersionComponents
+import kotlin.test.fail
+
+/**
+ * Fails if the WebView is older than AnkiDroid supports: its scripts would not run.
+ *
+ * Launching a screen directly bypasses the DeckPicker's outdated WebView dialog.
+ */
+fun ensureWebViewIsSupported() {
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    val webView = WebViewCompat.getCurrentWebViewPackage(context)!!
+    val outdatedVersion =
+        checkWebViewVersionComponents(
+            packageName = webView.packageName,
+            webviewVersion = webView.versionName!!,
+            versionCode = PackageInfoCompat.getLongVersionCode(webView),
+            userAgent = null,
+        )
+    if (outdatedVersion != null) {
+        fail("Unsupported WebView $outdatedVersion: AnkiDroid's scripts cannot run. Use a newer emulator")
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -128,12 +128,12 @@ class ReviewerViewModel(
      * ensure that the custom JS scheduler has persisted its SchedulingStates
      * back to the Reviewer before we save it to the database.
      *
-     * This flag should be reset when we show the front of the card
-     * and only complete once we know the custom scheduler has finished its
-     * execution, or complete immediately if the custom scheduler has not
+     * This flag is reset before we show the front of the card
+     * and only completes once we know the custom scheduler has finished its
+     * execution, or completes immediately if the custom scheduler has not
      * been configured.
      */
-    private var mutationSignal = CompletableDeferred(Unit)
+    private var mutationSignal = CompletableDeferred<Unit>()
 
     val isAutoAdvanceEnabledFlow = MutableStateFlow(autoAdvance.isEnabled)
     val answerButtonsNextTimeFlow: MutableStateFlow<AnswerButtonsNextTime?> = MutableStateFlow(null)
@@ -455,6 +455,11 @@ class ReviewerViewModel(
 
     override suspend fun showQuestion() {
         Timber.v("ReviewerViewModel::showQuestion")
+        // 'Show answer' may be pressed while the question loads: reset before, not after.
+        // If it was pressed earlier, it is already waiting on the pending signal: keep it.
+        if (mutationSignal.isCompleted) {
+            mutationSignal = CompletableDeferred()
+        }
         super.showQuestion()
         runStateMutationHook()
         updateMarkIcon()
@@ -472,7 +477,6 @@ class ReviewerViewModel(
             }
             return
         }
-        mutationSignal = CompletableDeferred()
         // https://github.com/ankitects/anki/commit/bd88c6d352dc7aeb4a674029eab7bdda2a821a78
         statesMutationEvalFlow.emit(
             """
@@ -511,6 +515,7 @@ class ReviewerViewModel(
 
     private suspend fun answerCardInternal(rating: Rating) {
         Timber.v("ReviewerViewModel::answerCard")
+        mutationSignal.await()
         val state = queueState.await() ?: return
         val card = currentCard.await()
         val answer =

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModelTest.kt
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.ui.windows.reviewer
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModelStore
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import anki.scheduler.CardAnswer.Rating
+import com.ichi2.anki.utils.ext.cardStateCustomizer
+import com.ichi2.testutils.JvmTest
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+@RunWith(AndroidJUnit4::class)
+class ReviewerViewModelTest : JvmTest() {
+    private val viewModelStore = ViewModelStore()
+
+    @After
+    fun clearViewModels() {
+        viewModelStore.clear()
+    }
+
+    @Test
+    fun `answering waits for the custom scheduler of the first card`() =
+        runTest {
+            val card = addBasicNote().firstCard()
+            col.cardStateCustomizer = "await new Promise(resolve => setTimeout(resolve, 5000));"
+            val viewModel = ReviewerViewModel(SavedStateHandle()).also { viewModelStore.put("reviewer", it) }
+
+            viewModel.onShowAnswer()
+            viewModel.answerCard(Rating.GOOD)
+            viewModel.onPageFinished(false)
+            advanceUntilIdle()
+            assertFalse(viewModel.showingAnswer.value)
+            assertEquals(0, col.getCard(card.id).reps)
+
+            viewModel.onStateMutationCallback()
+            advanceUntilIdle()
+            assertEquals(1, col.getCard(card.id).reps)
+        }
+}


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: GPT-6
> Assisted-by: Claude Fable 5.1

## Fixes
* Fixes #21744

## Approach
* Fix various issues:
  * Wrong card was shown in tests
  * Outdated WebView
  * Custom scheduler was not reset
* Launch the Reviewer directly  

Then the issue reproduced: 'Show answer' could be be pressed while the question loads, handle it via the `MutationSignal`

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)