### PR TITLE
feat(reminders): show battery optimization exemption dialog

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -41,6 +41,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <!-- Disabled on Play Store -->
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <permission android:name="${applicationId}.permission.READ_WRITE_DATABASE"
                 android:label="@string/read_write_permission_label"
                 android:description="@string/read_write_permission_description"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
@@ -4,6 +4,7 @@ package com.ichi2.anki.reviewreminders
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
@@ -13,7 +14,6 @@ import android.view.ViewGroup
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.VisibleForTesting
-import androidx.core.net.toUri
 import androidx.core.view.WindowInsetsCompat.Type.displayCutout
 import androidx.core.view.WindowInsetsCompat.Type.systemBars
 import androidx.core.view.isVisible
@@ -453,7 +453,7 @@ private fun TroubleshootingCheck.resolveAction(): ResolveCheckAction? {
         return ResolveCheckAction(label = "Grant permission", logDescription = "opening ACTION_REQUEST_SCHEDULE_EXACT_ALARM") {
             context.startActivity(
                 Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM).apply {
-                    data = "package:${context.packageName}".toUri()
+                    data = Uri.fromParts("package", context.packageName, null)
                 },
             )
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
@@ -2,6 +2,7 @@
 
 package com.ichi2.anki.reviewreminders
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -39,6 +40,7 @@ import com.ichi2.anki.utils.ext.launchCollectionInLifecycleScope
 import com.ichi2.anki.utils.ext.onWindowFocusChanged
 import com.ichi2.anki.utils.ext.requireParcelable
 import com.ichi2.anki.utils.ext.setBackgroundTint
+import com.ichi2.utils.Permissions
 import com.ichi2.utils.Permissions.attemptToEnableNotifications
 import com.ichi2.utils.Permissions.openAppNotificationsSettingsScreen
 import com.ichi2.utils.copyToClipboard
@@ -434,14 +436,32 @@ private fun TroubleshootingCheck.resolveAction(): ResolveCheckAction? {
         }
     }
 
-    // Opens the full battery optimization list. The user must manually find the app.
-    // For 'full' (non-Play) builds, ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS could be used
-    // with the REQUEST_IGNORE_BATTERY_OPTIMIZATIONS manifest permission for a direct dialog,
-    // but Google Play restricts that permission.
-    fun requestUnrestrictedBackgroundUsage() =
-        ResolveCheckAction(label = "Open battery settings", logDescription = "opening ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS") {
-            context.startActivity(Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS))
+    fun requestUnrestrictedBackgroundUsage(): ResolveCheckAction {
+        fun openBatteryOptimizationList() = context.startActivity(Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS))
+
+        return if (Permissions.canRequestIgnoreBatteryOptimizations(context)) {
+            ResolveCheckAction(
+                label = "Disable battery optimization",
+                logDescription = "opening ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS",
+            ) {
+                try {
+                    context.startActivity(
+                        Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
+                            data = Uri.fromParts("package", context.packageName, null)
+                        },
+                    )
+                } catch (e: ActivityNotFoundException) {
+                    // not all devices can request an exemption
+                    Timber.w(e, "cannot request a battery optimization exemption; opening the list")
+                    openBatteryOptimizationList()
+                }
+            }
+        } else {
+            ResolveCheckAction(label = "Open battery settings", logDescription = "opening ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS") {
+                openBatteryOptimizationList()
+            }
         }
+    }
 
     fun openBatterySaverSettings() =
         ResolveCheckAction(label = "Open battery settings", logDescription = "opening ACTION_BATTERY_SAVER_SETTINGS") {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingFragment.kt
@@ -12,6 +12,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import androidx.core.view.WindowInsetsCompat.Type.displayCutout
 import androidx.core.view.WindowInsetsCompat.Type.systemBars
@@ -69,7 +70,8 @@ class ReminderTroubleshootingFragment : Fragment(R.layout.fragment_reminder_trou
         reminderTroubleshootingViewModelFactory(requireContext())
     }
 
-    private val binding by viewBinding(FragmentReminderTroubleshootingBinding::bind)
+    @VisibleForTesting
+    internal val binding by viewBinding(FragmentReminderTroubleshootingBinding::bind)
 
     /**
      * [ScheduleRemindersFragment] can be hosted from multiple activities and must change its UI to accommodate its host

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -250,6 +250,15 @@ object Permissions {
     }
 
     /**
+     * Whether [Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS] may be used to ask the user
+     * to exempt AnkiDroid from battery optimization.
+     *
+     * Google Play restricts [Manifest.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS].
+     */
+    fun canRequestIgnoreBatteryOptimizations(context: Context): Boolean =
+        context.arePermissionsDefinedInAnkiDroidManifest(Manifest.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
+
+    /**
      * Opens the Android settings for AnkiDroid if the device provide this feature.
      * Lets a user grant any missing permissions which have been permanently denied.
      */

--- a/AnkiDroid/src/play/AndroidManifest.xml
+++ b/AnkiDroid/src/play/AndroidManifest.xml
@@ -12,4 +12,13 @@
         android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
         tools:node="remove"
         tools:ignore="ScopedStorage" />
+
+    <!--
+    Google Play policies prohibit requesting an exemption from battery optimization
+    unless the core function of the app is adversely affected
+    https://developer.android.com/training/monitoring-device-state/doze-standby#support_for_other_use_cases
+     -->
+    <uses-permission
+        android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"
+        tools:node="remove" />
 </manifest> 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingLayoutTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingLayoutTest.kt
@@ -2,14 +2,9 @@
 
 package com.ichi2.anki.reviewreminders
 
-import androidx.fragment.app.commit
 import androidx.recyclerview.widget.ListAdapter
-import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
-import com.ichi2.anki.reviewreminders.ScheduleRemindersFragment.FragmentHost
-import com.ichi2.anki.utils.ConfigAwareSingleFragmentActivity
 import com.ichi2.utils.dp
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -63,20 +58,6 @@ class ReminderTroubleshootingLayoutTest : RobolectricTest() {
                 checksList.height,
                 greaterThanOrEqualTo(itemCount * checkItemMinHeight.toPx(targetContext)),
             )
-        }
-    }
-
-    /** Runs [block] on a [ReminderTroubleshootingFragment] in its standalone activity */
-    private fun withTroubleshootingFragment(block: ReminderTroubleshootingFragment.() -> Unit) {
-        val intent = ScheduleRemindersFragment.getIntent(targetContext, ReviewReminderScope.Global)
-        ActivityScenario.launch<ConfigAwareSingleFragmentActivity>(intent).use { scenario ->
-            advanceRobolectricLooper()
-            scenario.onActivity { activity ->
-                val fragment = ReminderTroubleshootingFragment.newInstance(FragmentHost.STANDALONE_ACTIVITY)
-                activity.supportFragmentManager.commit { replace(R.id.fragment_container, fragment) }
-                advanceRobolectricLooper()
-                fragment.block()
-            }
         }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingLayoutTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingLayoutTest.kt
@@ -8,7 +8,6 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
-import com.ichi2.anki.databinding.FragmentReminderTroubleshootingBinding
 import com.ichi2.anki.reviewreminders.ScheduleRemindersFragment.FragmentHost
 import com.ichi2.anki.utils.ConfigAwareSingleFragmentActivity
 import com.ichi2.utils.dp
@@ -42,7 +41,8 @@ class ReminderTroubleshootingLayoutTest : RobolectricTest() {
                 TroubleshootingCheck.ExactAlarmPermission(CheckResult.Warning),
             )
 
-        withReviewRemindersTroubleshooting {
+        withTroubleshootingFragment {
+            val checksList = binding.checksList
             @Suppress("UNCHECKED_CAST")
             (checksList.adapter as ListAdapter<TroubleshootingCheck, *>).submitList(checks)
             advanceRobolectricLooper()
@@ -66,30 +66,16 @@ class ReminderTroubleshootingLayoutTest : RobolectricTest() {
         }
     }
 
-    /**
-     * Launches [ReminderTroubleshootingFragment] in a standalone activity and runs [block] on
-     * its binding
-     */
-    private fun withReviewRemindersTroubleshooting(block: FragmentReminderTroubleshootingBinding.() -> Unit) {
+    /** Runs [block] on a [ReminderTroubleshootingFragment] in its standalone activity */
+    private fun withTroubleshootingFragment(block: ReminderTroubleshootingFragment.() -> Unit) {
         val intent = ScheduleRemindersFragment.getIntent(targetContext, ReviewReminderScope.Global)
         ActivityScenario.launch<ConfigAwareSingleFragmentActivity>(intent).use { scenario ->
             advanceRobolectricLooper()
             scenario.onActivity { activity ->
-                activity.supportFragmentManager.commit {
-                    replace(
-                        R.id.fragment_container,
-                        ReminderTroubleshootingFragment.newInstance(FragmentHost.STANDALONE_ACTIVITY),
-                    )
-                }
+                val fragment = ReminderTroubleshootingFragment.newInstance(FragmentHost.STANDALONE_ACTIVITY)
+                activity.supportFragmentManager.commit { replace(R.id.fragment_container, fragment) }
                 advanceRobolectricLooper()
-
-                val binding =
-                    FragmentReminderTroubleshootingBinding.bind(
-                        activity.supportFragmentManager
-                            .findFragmentById(R.id.fragment_container)!!
-                            .requireView(),
-                    )
-                binding.block()
+                fragment.block()
             }
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingResolveActionTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingResolveActionTest.kt
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.reviewreminders
+
+import android.app.Application
+import android.content.ComponentName
+import android.content.Intent
+import android.content.IntentFilter
+import android.provider.Settings
+import androidx.core.net.toUri
+import androidx.core.view.children
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.databinding.ItemTroubleshootingCheckBinding
+import com.ichi2.testutils.withRequestIgnoreBatteryOptimizationsInManifest
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import kotlin.test.assertNotNull
+
+/**
+ * The actions offered by [ReminderTroubleshootingFragment] to resolve a failing check
+ */
+@RunWith(AndroidJUnit4::class)
+class ReminderTroubleshootingResolveActionTest : RobolectricTest() {
+    /** 'Optimized': the battery optimization check is a warning, so its resolve action is displayed */
+    @Before
+    fun enableBatteryOptimization() = targetContext.setTroubleshootingChecks(batteryOptimization = CheckResult.Warning)
+
+    @Test
+    fun `battery optimization asks for an exemption when the permission is in the manifest`() {
+        withRequestIgnoreBatteryOptimizationsInManifest(true) {
+            withTroubleshootingFragment {
+                batteryOptimizationCheck.actionLink.performClick()
+
+                val intent = assertNotNull(shadowOf(requireActivity()).nextStartedActivity)
+                assertThat(intent.action, equalTo(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS))
+                assertThat(intent.data, equalTo("package:${targetContext.packageName}".toUri()))
+            }
+        }
+    }
+
+    @Test
+    fun `battery optimization opens the settings list when the permission is not in the manifest`() {
+        withRequestIgnoreBatteryOptimizationsInManifest(false) {
+            withTroubleshootingFragment {
+                batteryOptimizationCheck.actionLink.performClick()
+
+                val intent = assertNotNull(shadowOf(requireActivity()).nextStartedActivity)
+                assertThat(intent.action, equalTo(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS))
+            }
+        }
+    }
+
+    @Test
+    fun `battery optimization falls back to the settings list when exemption fails`() {
+        throwOnAllSettingsExcept(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
+
+        withRequestIgnoreBatteryOptimizationsInManifest(true) {
+            withTroubleshootingFragment {
+                batteryOptimizationCheck.actionLink.performClick()
+
+                val intent = assertNotNull(shadowOf(requireActivity()).nextStartedActivity)
+                assertThat(intent.action, equalTo(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS))
+            }
+        }
+    }
+
+    /**
+     * Starting any activity other than the settings screen for [action] throws
+     * `ActivityNotFoundException`
+     */
+    private fun throwOnAllSettingsExcept(
+        @Suppress("SameParameterValue") action: String,
+    ) {
+        val settingsScreen = ComponentName("com.android.settings", action)
+        shadowOf(targetContext.packageManager).apply {
+            addActivityIfNotPresent(settingsScreen)
+            addIntentFilterForActivity(settingsScreen, IntentFilter(action).apply { addCategory(Intent.CATEGORY_DEFAULT) })
+        }
+        shadowOf(ApplicationProvider.getApplicationContext<Application>()).checkActivities(true)
+    }
+}
+
+/** The displayed 'Battery optimization' check */
+private val ReminderTroubleshootingFragment.batteryOptimizationCheck: ItemTroubleshootingCheckBinding
+    get() =
+        binding.checksList.children
+            .map { ItemTroubleshootingCheckBinding.bind(it) }
+            .single { it.title.text.toString() == "Battery optimization" }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingScreenshotTest.kt
@@ -2,12 +2,9 @@
 
 package com.ichi2.anki.reviewreminders
 
-import androidx.fragment.app.commit
-import com.ichi2.anki.R
 import com.ichi2.anki.ScreenshotTest
 import com.ichi2.anki.reviewreminders.CheckResult.Failed
 import com.ichi2.anki.reviewreminders.CheckResult.Warning
-import com.ichi2.anki.reviewreminders.ScheduleRemindersFragment.FragmentHost
 import org.junit.Test
 
 class ReminderTroubleshootingScreenshotTest : ScreenshotTest() {
@@ -40,15 +37,5 @@ class ReminderTroubleshootingScreenshotTest : ScreenshotTest() {
     }
 
     /** Shows [ReminderTroubleshootingFragment] as a standalone screen and captures it as [name] */
-    private fun captureReminderTroubleshooting(name: String) =
-        withStandaloneScheduleReminders { activity ->
-            activity.supportFragmentManager.commit {
-                replace(
-                    R.id.fragment_container,
-                    ReminderTroubleshootingFragment.newInstance(FragmentHost.STANDALONE_ACTIVITY),
-                )
-            }
-            advanceRobolectricLooper()
-            captureScreen(name)
-        }
+    private fun captureReminderTroubleshooting(name: String) = withTroubleshootingFragment { captureScreen(name) }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingTestApi.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReminderTroubleshootingTestApi.kt
@@ -8,13 +8,28 @@ import android.content.Context
 import android.os.Build
 import android.os.PowerManager
 import androidx.core.content.getSystemService
+import androidx.fragment.app.commit
 import androidx.test.filters.SdkSuppress
 import com.ichi2.anki.NotificationChannel
+import com.ichi2.anki.R
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.RobolectricTest.Companion.advanceRobolectricLooper
 import com.ichi2.anki.reviewreminders.CheckResult.Failed
 import com.ichi2.anki.reviewreminders.CheckResult.Passed
 import com.ichi2.anki.reviewreminders.CheckResult.Warning
+import com.ichi2.anki.reviewreminders.ScheduleRemindersFragment.FragmentHost
 import org.robolectric.Shadows.shadowOf
 import android.app.NotificationChannel as AndroidNotificationChannel
+
+/** Runs [block] on a [ReminderTroubleshootingFragment] in its standalone activity */
+context(test: RobolectricTest)
+fun withTroubleshootingFragment(block: ReminderTroubleshootingFragment.() -> Unit) =
+    withStandaloneScheduleReminders { activity ->
+        val fragment = ReminderTroubleshootingFragment.newInstance(FragmentHost.STANDALONE_ACTIVITY)
+        activity.supportFragmentManager.commit { replace(R.id.fragment_container, fragment) }
+        advanceRobolectricLooper()
+        fragment.block()
+    }
 
 /**
  * Sets the outcomes of the visible troubleshooting checks using Android service shadows.

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/PermissionMocks.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/PermissionMocks.kt
@@ -3,6 +3,7 @@
 package com.ichi2.testutils
 
 import android.Manifest.permission.MANAGE_EXTERNAL_STORAGE
+import android.Manifest.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
 import com.ichi2.utils.Permissions
 import io.mockk.every
 import io.mockk.mockkObject
@@ -12,6 +13,24 @@ import io.mockk.unmockkObject
 fun withManageExternalStorageInManifest(block: () -> Unit) {
     mockkObject(Permissions)
     every { Permissions.canManageExternalStorage(any()) } returns true
+    try {
+        block()
+    } finally {
+        unmockkObject(Permissions)
+    }
+}
+
+/**
+ * Whether [REQUEST_IGNORE_BATTERY_OPTIMIZATIONS] is declared in the manifest.
+ *
+ * It is removed by the 'play' flavor.
+ */
+fun withRequestIgnoreBatteryOptimizationsInManifest(
+    inManifest: Boolean,
+    block: () -> Unit,
+) {
+    mockkObject(Permissions)
+    every { Permissions.canRequestIgnoreBatteryOptimizations(any()) } returns inManifest
     try {
         block()
     } finally {


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5.1

## Purpose / Description
Google Play prohibits `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`, but we can show it on non-Play builds

## Fixes
* Fixes #21751

## Approach
* Enable in Manifest (non-Play)
* Perform the check

## How Has This Been Tested?
API 37 emulator; both `play` and `full` variants. Unit test

<img width="300" alt="image" src="https://github.com/user-attachments/assets/54956981-7d60-4af5-b178-18835664d1b4" />

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
   - @ericli3690 do you want a screenshot test?
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)