### PR TITLE
fix: Profile name handling

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/profiles/ProfileItem.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/profiles/ProfileItem.kt
@@ -3,12 +3,14 @@
 
 package com.ichi2.anki.preferences.profiles
 
+import com.ichi2.anki.common.utils.firstGraphemeOrNull
+
 /** UI model for a row in the profile list. */
 data class ProfileItem(
     val id: String,
     val name: String,
 ) {
-    /** Uppercased first letter of the name, shown in the avatar circle. */
+    /** Uppercased first character of the name, shown in the avatar circle. */
     val initial: String
-        get() = name.firstOrNull()?.uppercaseChar()?.toString() ?: "?"
+        get() = name.firstGraphemeOrNull()?.uppercase() ?: "?"
 }

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -453,7 +453,7 @@ opening the system text to speech settings fails">Failed to open text to speech 
     <string comment="Shown when retrying a running action" name="already_in_progress">Already in progress</string>
 
     <!-- Switch profiles screen -->
-    <string name="switch_profile" comment="Title of the screen where the user switches between profiles">Switch profile</string>
+    <string name="switch_profile" maxLength="41" comment="Title of the screen where the user switches between profiles">Switch profile</string>
     <string name="edit_profile" comment="Content description of the button that edits a profile in the profile list">Edit profile</string>
     <string name="delete_profile" comment="Content description of the button that deletes a profile in the profile list">Delete profile</string>
 </resources>

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -92,7 +92,7 @@
     <!-- Switch Profile Preferences  -->
     <com.ichi2.preferences.HeaderPreference
         android:key="@string/pref_switch_profile_screen_key"
-        android:title="Switch Profile"
+        android:title="@string/switch_profile"
         android:icon="@drawable/ic_switch_profile"
         android:fragment="com.ichi2.anki.preferences.profiles.SwitchProfilesFragment" />
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/profiles/ProfileItemTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/profiles/ProfileItemTest.kt
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Ashish Yadav <mailtoashish693@gmail.com>
+
+package com.ichi2.anki.preferences.profiles
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class ProfileItemTest {
+    private fun initialOf(name: String) = ProfileItem(id = "id", name = name).initial
+
+    @Test
+    fun `initial is the uppercased first letter`() {
+        assertEquals("W", initialOf("work"))
+    }
+
+    @Test
+    fun `initial of an empty name falls back to a placeholder`() {
+        assertEquals("?", initialOf(""))
+    }
+
+    @Test
+    fun `initial keeps an emoji whole`() {
+        assertEquals("😀", initialOf("😀 Study"))
+    }
+
+    @Test
+    fun `initial keeps a flag emoji whole`() {
+        assertEquals("🇮🇳", initialOf("🇮🇳 India"))
+    }
+
+    @Test
+    fun `initial keeps a combining accent attached to its base letter`() {
+        assertEquals("E\u0301", initialOf("e\u0301cole"))
+    }
+}

--- a/common/src/main/java/com/ichi2/anki/common/utils/StringUtils.kt
+++ b/common/src/main/java/com/ichi2/anki/common/utils/StringUtils.kt
@@ -157,3 +157,13 @@ private fun String.indexOfLastGraphemeCluster(
 
     return lastSafe
 }
+
+/** The first grapheme cluster, keeping an emoji, a flag or an accented letter whole. */
+fun String.firstGraphemeOrNull(): String? {
+    val iterator = BreakIterator.getCharacterInstance()
+    iterator.setText(this)
+
+    val end = iterator.next()
+    if (end == BreakIterator.DONE || end == 0) return null
+    return this.substring(0, end)
+}

--- a/common/src/test/java/com/ichi2/anki/common/utils/StringUtilsTest.kt
+++ b/common/src/test/java/com/ichi2/anki/common/utils/StringUtilsTest.kt
@@ -250,4 +250,29 @@ class StringUtilsTest {
         assertThat(input.ellipsize(10), equalTo("Brazil\uD83C\uDDE7\uD83C\uDDF7"))
         assertThat(input + " ".ellipsize(11), equalTo("Brazil\uD83C\uDDE7\uD83C\uDDF7 "))
     }
+
+    @Test
+    fun firstGraphemeOrNull_plain_letter() {
+        assertThat("work".firstGraphemeOrNull(), equalTo("w"))
+    }
+
+    @Test
+    fun firstGraphemeOrNull_empty_string() {
+        assertNull("".firstGraphemeOrNull())
+    }
+
+    @Test
+    fun firstGraphemeOrNull_emoji_is_not_split() {
+        assertThat("\uD83D\uDE00 Study".firstGraphemeOrNull(), equalTo("\uD83D\uDE00"))
+    }
+
+    @Test
+    fun firstGraphemeOrNull_flag_is_not_split() {
+        assertThat("\uD83C\uDDEE\uD83C\uDDF3 India".firstGraphemeOrNull(), equalTo("\uD83C\uDDEE\uD83C\uDDF3"))
+    }
+
+    @Test
+    fun firstGraphemeOrNull_keeps_combining_accent_with_its_base_letter() {
+        assertThat("e\u0301cole".firstGraphemeOrNull(), equalTo("e\u0301"))
+    }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

<!---
Uncomment this section if AI tools were used. New contributors may not use AI tools. See:
https://github.com/ankidroid/Anki-Android/blob/main/AI_POLICY.md
> [!NOTE]
> Assisted-by: ___
--->

## Purpose / Description
Improves how we handle naming of profile i.e. ProfileItem

## Fixes
* Fixes part of #18117

## Approach
See commits

## How Has This Been Tested?

Added unit tests

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->