### PR TITLE
fix: only reset WebView cookies when the profile changed

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileManager.kt
@@ -198,9 +198,43 @@ class ProfileManager private constructor(
         prefs.edit { putString(PREF_COLLECTION_PATH, profileCollectionDir.absolutePath) }
     }
 
+    /**
+     * Records [profileId] as the owner of the shared WebView storage, clearing the cookies of the
+     * previous owner first.
+     *
+     * [WebView.setDataDirectorySuffix] is unavailable before API 28, so every profile shares one
+     * WebView data directory and a profile change has to clear it. No recorded owner means the
+     * first run of a build which records one: if Default is also the only profile then no other
+     * profile has ever run here, so the existing data is adopted rather than cleared, which would
+     * otherwise touch the WebView on the startup path and drop the AnkiWeb session of users who
+     * never switch profiles.
+     */
+    private fun resetWebViewDataIfProfileChanged(profileId: ProfileId) {
+        val webViewOwner = profileRegistry.getWebViewProfileId()
+        if (webViewOwner == profileId) return
+
+        if (webViewOwner == null && profileId.isDefault() && profileRegistry.isOnlyProfile(profileId)) {
+            Timber.i("Adopting the existing WebView data: no other profile has run on this install")
+            profileRegistry.setWebViewProfileId(profileId)
+            return
+        }
+
+        Timber.i("WebView data belongs to another profile, clearing cookies")
+        CookieManager.getInstance().removeAllCookiesSync {
+            profileRegistry.setWebViewProfileId(profileId)
+        }
+    }
+
+    /** Runs [block] once the removal has completed and the cookies are flushed to disk. */
+    private fun CookieManager.removeAllCookiesSync(block: CookieManager.() -> Unit) =
+        removeAllCookies {
+            flush()
+            block()
+        }
+
     private fun configureWebView(profileId: ProfileId) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
-            CookieManager.getInstance().removeAllCookies(null)
+            resetWebViewDataIfProfileChanged(profileId)
             return
         }
 
@@ -550,6 +584,26 @@ class ProfileManager private constructor(
             globalPrefs.edit { putString(KEY_LAST_ACTIVE_PROFILE_ID, id.value) }
         }
 
+        fun getWebViewProfileId(): ProfileId? {
+            val id = globalPrefs.getString(KEY_WEBVIEW_PROFILE_ID, null)
+            return id?.let { ProfileId(it) }
+        }
+
+        fun setWebViewProfileId(id: ProfileId) {
+            globalPrefs.edit { putString(KEY_WEBVIEW_PROFILE_ID, id.value) }
+        }
+
+        /**
+         * Whether [id] is the only profile in the registry.
+         *
+         * Counts raw keys rather than [getAllProfiles] so that an entry which fails to parse still
+         * counts as a profile.
+         */
+        fun isOnlyProfile(id: ProfileId): Boolean {
+            val profileKeys = globalPrefs.all.keys - BOOKKEEPING_KEYS
+            return profileKeys.size == 1 && id.value in profileKeys
+        }
+
         fun saveProfile(
             id: ProfileId,
             metadata: ProfileMetadata,
@@ -589,7 +643,7 @@ class ProfileManager private constructor(
             val allEntries = globalPrefs.all
             for ((key, value) in allEntries) {
                 // Skip internal bookkeeping keys; only profile entries remain
-                if (key == KEY_LAST_ACTIVE_PROFILE_ID) continue
+                if (key in BOOKKEEPING_KEYS) continue
 
                 val metadata =
                     try {
@@ -633,6 +687,12 @@ class ProfileManager private constructor(
         private const val MAX_ATTEMPTS = 10
         const val PROFILE_REGISTRY_FILENAME = "profiles_prefs"
         const val KEY_LAST_ACTIVE_PROFILE_ID = "last_active_profile_id"
+
+        /** Profile whose data the shared WebView storage currently holds. Pre-API 28 only. */
+        const val KEY_WEBVIEW_PROFILE_ID = "webview_profile_id"
+
+        /** Registry keys that are not profile entries. */
+        private val BOOKKEEPING_KEYS = setOf(KEY_LAST_ACTIVE_PROFILE_ID, KEY_WEBVIEW_PROFILE_ID)
 
         const val DEFAULT_PROFILE_DISPLAY_NAME = "Default"
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/ProfileManagerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/ProfileManagerTest.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.os.Build
 import android.webkit.CookieManager
+import android.webkit.ValueCallback
 import android.webkit.WebView
 import androidx.core.content.edit
 import androidx.test.core.app.ApplicationProvider
@@ -28,6 +29,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.storage.CollectionHelper.PREF_COLLECTION_PATH
 import com.ichi2.anki.multiprofile.ProfileManager.Companion.KEY_LAST_ACTIVE_PROFILE_ID
+import com.ichi2.anki.multiprofile.ProfileManager.Companion.KEY_WEBVIEW_PROFILE_ID
 import com.ichi2.anki.multiprofile.ProfileManager.Companion.PROFILE_REGISTRY_FILENAME
 import io.mockk.every
 import io.mockk.just
@@ -46,6 +48,7 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.io.File
+import kotlin.test.assertNull
 
 @RunWith(AndroidJUnit4::class)
 class ProfileManagerTest {
@@ -149,13 +152,87 @@ class ProfileManagerTest {
 
     @Test
     @Config(sdk = [Build.VERSION_CODES.O_MR1])
-    fun `Legacy device clears cookies on init (Pre-API 28)`() {
-        mockkStatic(CookieManager::class)
-        val mockCookies = mockk<CookieManager>(relaxed = true)
-        every { CookieManager.getInstance() } returns mockCookies
+    fun `Legacy device keeps cookies on first run as the WebView data is already Default's (Pre-API 28)`() {
+        val cookieManager = mockCookieManager()
+        assertNull(prefs.getString(KEY_WEBVIEW_PROFILE_ID, null), "no WebView owner is recorded before the first run")
+
         ProfileManager.create(context)
 
-        verify(exactly = 1) { mockCookies.removeAllCookies(null) }
+        verify(exactly = 0) { cookieManager.removeAllCookies(any()) }
+        verify(exactly = 0) { CookieManager.getInstance() }
+        assertEquals(ProfileId.DEFAULT.value, prefs.getString(KEY_WEBVIEW_PROFILE_ID, null))
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.O_MR1])
+    fun `Legacy device does not clear cookies for the same profile repeatedly (Pre-API 28)`() {
+        val cookieManager = mockCookieManager()
+        prefs.edit(commit = true) { putString(KEY_LAST_ACTIVE_PROFILE_ID, "p_bob") }
+
+        // the first launch clears the cookies as p_bob takes ownership of the WebView data
+        ProfileManager.create(context)
+        // the second launch does not clear them again as p_bob already owns the data
+        ProfileManager.create(context)
+
+        verify(exactly = 1) { cookieManager.removeAllCookies(any()) }
+        verify(exactly = 1) { cookieManager.flush() }
+        assertEquals("p_bob", prefs.getString(KEY_WEBVIEW_PROFILE_ID, null))
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.O_MR1])
+    fun `Legacy device clears cookies once the active profile changed (Pre-API 28)`() {
+        val cookieManager = mockCookieManager()
+
+        ProfileManager.create(context)
+        prefs.edit(commit = true) { putString(KEY_LAST_ACTIVE_PROFILE_ID, "p_bob") }
+        ProfileManager.create(context)
+
+        verify(exactly = 1) { cookieManager.removeAllCookies(any()) }
+        assertEquals("p_bob", prefs.getString(KEY_WEBVIEW_PROFILE_ID, null))
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.O_MR1])
+    fun `Legacy device clears cookies with no recorded owner once another profile exists (Pre-API 28)`() {
+        val cookieManager = mockCookieManager()
+        val manager = ProfileManager.create(context)
+        manager.createNewProfile(ProfileName.fromTrustedSource("Bob"))
+        prefs.edit(commit = true) { remove(KEY_WEBVIEW_PROFILE_ID) }
+
+        ProfileManager.create(context)
+
+        verify(exactly = 1) { cookieManager.removeAllCookies(any()) }
+        assertEquals(ProfileId.DEFAULT.value, prefs.getString(KEY_WEBVIEW_PROFILE_ID, null))
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.O_MR1])
+    fun `Legacy device clears cookies again if the removal never completed (Pre-API 28)`() {
+        val cookieManager = mockCookieManager(completesRemoval = false)
+        prefs.edit(commit = true) { putString(KEY_LAST_ACTIVE_PROFILE_ID, "p_bob") }
+
+        ProfileManager.create(context)
+        ProfileManager.create(context)
+
+        verify(exactly = 2) { cookieManager.removeAllCookies(any()) }
+        assertNull(prefs.getString(KEY_WEBVIEW_PROFILE_ID, null))
+    }
+
+    @Test
+    fun `getAllProfiles ignores bookkeeping keys whose value parses as profile JSON`() {
+        val manager = ProfileManager.create(context)
+        val metadataJson =
+            ProfileManager
+                .ProfileMetadata(displayName = ProfileName.fromTrustedSource("Not a profile"))
+                .toJson()
+
+        prefs.edit(commit = true) { putString(KEY_WEBVIEW_PROFILE_ID, metadataJson) }
+
+        assertFalse(
+            "Bookkeeping keys must never surface as profiles",
+            manager.getAllProfiles().containsKey(ProfileId(KEY_WEBVIEW_PROFILE_ID)),
+        )
     }
 
     @Test
@@ -529,6 +606,19 @@ class ProfileManagerTest {
 
         assertFalse("media.trash contents should be deleted", trashFile.exists())
         assertFalse("media.trash folder should be deleted", trashFile.parentFile!!.exists())
+    }
+
+    /** Stubs [CookieManager.getInstance]. [completesRemoval] fires the cookie removal callback. */
+    private fun mockCookieManager(completesRemoval: Boolean = true): CookieManager {
+        mockkStatic(CookieManager::class)
+        val cookieManager = mockk<CookieManager>(relaxed = true)
+        every { CookieManager.getInstance() } returns cookieManager
+        if (completesRemoval) {
+            every { cookieManager.removeAllCookies(any()) } answers {
+                firstArg<ValueCallback<Boolean>>().onReceiveValue(true)
+            }
+        }
+        return cookieManager
     }
 
     private fun writeProfileCollectionPath(


### PR DESCRIPTION


<!--- Please fill the necessary details below -->

<!---
Uncomment this section if AI tools were used. New contributors may not use AI tools. See:
https://github.com/ankidroid/Anki-Android/blob/main/AI_POLICY.md
> [!NOTE]
> Assisted-by: ___
--->

## Purpose / Description
`setDataDirectorySuffix` is unavailable before API 28 so this PR handles that

## Fixes
* Fixes part of #18117

## Approach
See commits

## How Has This Been Tested?
Added unit tests and read documentation for the API

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->