### PR TITLE
refactor(profiles): construct ProfileManager from a base context

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileManager.kt
@@ -28,7 +28,7 @@ import java.io.File
 class ProfileManager private constructor(
     context: Context,
 ) {
-    private val profileContext = context.applicationContext
+    private val profileContext = context.applicationContext ?: context
 
     lateinit var activeProfileContext: Context
         private set
@@ -662,6 +662,10 @@ class ProfileManager private constructor(
         /**
          * Factory method to safely create and initialize the ProfileManager.
          * Guaranteed to return a ProfileManager with a valid [activeProfileContext].
+         *
+         * @param context an application-level context. Safe to call from
+         *   [android.app.Application.attachBaseContext], where the base context is
+         *   passed directly because [Context.getApplicationContext] is still null.
          */
         fun create(context: Context): ProfileManager {
             val manager = ProfileManager(context)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/ProfileManagerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/ProfileManagerTest.kt
@@ -18,6 +18,7 @@
 package com.ichi2.anki.multiprofile
 
 import android.content.Context
+import android.content.ContextWrapper
 import android.content.SharedPreferences
 import android.os.Build
 import android.webkit.CookieManager
@@ -71,6 +72,19 @@ class ProfileManagerTest {
         ProfileManager.create(context)
 
         assertEquals("default", prefs.getString(KEY_LAST_ACTIVE_PROFILE_ID, null))
+    }
+
+    @Test
+    fun `create works before the application context is available`() {
+        val duringAttachBaseContext =
+            object : ContextWrapper(context) {
+                override fun getApplicationContext(): Context? = null
+            }
+
+        val manager = ProfileManager.create(duringAttachBaseContext)
+
+        assertEquals("default", prefs.getString(KEY_LAST_ACTIVE_PROFILE_ID, null))
+        assertEquals(context.filesDir.absolutePath, manager.activeProfileContext.filesDir.absolutePath)
     }
 
     @Test


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

<!---
Uncomment this section if AI tools were used. New contributors may not use AI tools. See:
https://github.com/ankidroid/Anki-Android/blob/main/AI_POLICY.md
> [!NOTE]
> Assisted-by: ___
--->

## Purpose / Description
Fallback for base context in case  context in not available before the application is registered avoid NPE

Fixes
* Fixes part of #18117

## Approach
See commits

## How Has This Been Tested?
Added a unit test

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->