### PR TITLE
feat: use new credentials manager API for AnkiWeb passwords

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -507,6 +507,7 @@ dependencies {
     implementation libs.androidx.appcompat
     implementation libs.androidx.browser
     implementation libs.androidx.core.ktx
+    implementation libs.androidx.credentials
     implementation libs.androidx.draganddrop
     implementation libs.androidx.exifinterface
     implementation libs.androidx.fragment.ktx

--- a/AnkiDroid/src/main/java/com/ichi2/anki/account/LoginFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/account/LoginFragment.kt
@@ -262,9 +262,9 @@ class LoginFragment : Fragment(R.layout.fragment_my_account) {
         }
 
         viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.loginState.collect { state ->
-                when (state) {
-                    is LoginState.Success -> {
+            viewModel.loginFlow.collect { login ->
+                when (login) {
+                    is Login.Success -> {
                         Timber.i("Login Successful")
                         val activity = requireActivity()
                         val isForResult = arguments?.getBoolean(START_FROM_DECKPICKER) ?: false
@@ -278,10 +278,9 @@ class LoginFragment : Fragment(R.layout.fragment_my_account) {
                         }
                         showLoginSuccessDialog()
                     }
-                    is LoginState.Error -> {
-                        showSnackbar(text = state.exception.message.toString())
+                    is Login.Error -> {
+                        showSnackbar(text = login.exception.message.toString())
                     }
-                    is LoginState.Idle -> { /* Not needed */ }
                 }
             }
         }
@@ -327,7 +326,7 @@ class LoginFragment : Fragment(R.layout.fragment_my_account) {
                     endpoint,
                 )
 
-                viewModel.loginState.first { it is LoginState.Success || it is LoginState.Error }
+                viewModel.loginFlow.first()
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/account/LoginFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/account/LoginFragment.kt
@@ -19,6 +19,19 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
 import androidx.core.widget.doOnTextChanged
+import androidx.credentials.CreatePasswordRequest
+import androidx.credentials.CredentialManager
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.GetCredentialResponse
+import androidx.credentials.GetPasswordOption
+import androidx.credentials.PasswordCredential
+import androidx.credentials.exceptions.CreateCredentialCancellationException
+import androidx.credentials.exceptions.CreateCredentialException
+import androidx.credentials.exceptions.CreateCredentialNoCreateOptionException
+import androidx.credentials.exceptions.CreateCredentialProviderConfigurationException
+import androidx.credentials.exceptions.GetCredentialCancellationException
+import androidx.credentials.exceptions.GetCredentialException
+import androidx.credentials.exceptions.NoCredentialException
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
@@ -49,6 +62,8 @@ import timber.log.Timber
 
 class LoginFragment : Fragment(R.layout.fragment_my_account) {
     private val viewModel: LoginViewModel by viewModels()
+
+    private val credentialManager: CredentialManager by lazy { CredentialManager.create(requireContext()) }
 
     private lateinit var username: TextInputEditText
     private lateinit var userNameLayout: TextInputLayout
@@ -88,6 +103,10 @@ class LoginFragment : Fragment(R.layout.fragment_my_account) {
 
         initListeners()
         initObservers()
+
+        if (savedInstanceState == null) {
+            fetchStoredCredentials()
+        }
     }
 
     private fun initLoginSuccessDialogResultListener() {
@@ -206,7 +225,7 @@ class LoginFragment : Fragment(R.layout.fragment_my_account) {
             password.setAutoFillListener {
                 passwordLayout.isEndIconVisible = false
                 Timber.i("Attempting login from autofill")
-                attemptLogin()
+                attemptLoginFromSavedPassword()
             }
         }
     }
@@ -266,6 +285,9 @@ class LoginFragment : Fragment(R.layout.fragment_my_account) {
                 when (login) {
                     is Login.Success -> {
                         Timber.i("Login Successful")
+                        if (!login.fromSavedPassword) {
+                            saveCredential(login.username, login.password)
+                        }
                         val activity = requireActivity()
                         val isForResult = arguments?.getBoolean(START_FROM_DECKPICKER) ?: false
 
@@ -287,6 +309,82 @@ class LoginFragment : Fragment(R.layout.fragment_my_account) {
     }
 
     /**
+     * Queries the system's [CredentialManager] for saved password credentials.
+     * If available, prompts the user or auto-selects to populate credentials and log in.
+     */
+    private fun fetchStoredCredentials() {
+        val passwordOption = GetPasswordOption(isAutoSelectAllowed = true)
+        val request =
+            GetCredentialRequest
+                .Builder()
+                .addCredentialOption(passwordOption)
+                .build()
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                val response =
+                    credentialManager.getCredential(
+                        context = requireActivity(),
+                        request = request,
+                    )
+                handleCredentialResponse(response)
+            } catch (_: GetCredentialCancellationException) {
+                Timber.i("User cancelled credential retrieval")
+            } catch (_: NoCredentialException) {
+                Timber.i("No saved credentials found in credential manager")
+            } catch (e: GetCredentialException) {
+                Timber.w(e, "Failed to retrieve credentials from credential manager")
+            }
+        }
+    }
+
+    /**
+     * Handles the successful credential response by populating the text fields and initiating login.
+     */
+    private fun handleCredentialResponse(response: GetCredentialResponse) {
+        when (val credential = response.credential) {
+            is PasswordCredential -> {
+                Timber.i("Retrieved PasswordCredential for user: ${credential.id}")
+                username.setText(credential.id)
+                password.setText(credential.password)
+                passwordLayout.isEndIconVisible = false
+                attemptLoginFromSavedPassword()
+            }
+            else -> {
+                Timber.w("Received unexpected credential type: ${credential.type}")
+            }
+        }
+    }
+
+    /**
+     * Tries to save the username and password on the system's credential manager.
+     */
+    private suspend fun saveCredential(
+        username: String,
+        password: String,
+    ) {
+        if (username.isEmpty() || password.isEmpty()) return
+        val request = CreatePasswordRequest(id = username, password = password)
+        try {
+            credentialManager.createCredential(
+                context = requireActivity(),
+                request = request,
+            )
+            Timber.i("Credential saved to credential manager")
+        } catch (_: CreateCredentialCancellationException) {
+            Timber.i("User declined to save credential")
+        } catch (_: CreateCredentialNoCreateOptionException) {
+            // may happen if 1. the manager can't save the password for some reason,
+            //  2. manager is set to 'None' in the system settings
+            Timber.i("The defined credential manager can't save the password")
+        } catch (_: CreateCredentialProviderConfigurationException) {
+            Timber.i("No credential manager provider available on this device")
+        } catch (e: CreateCredentialException) {
+            Timber.w(e, "Failed to save credential to credential manager")
+        }
+    }
+
+    /**
      * Displays a dialog asking if a user would like to sync after a login success
      *
      * * **Positive:** opens the Deck Picker and starts a sync
@@ -296,7 +394,7 @@ class LoginFragment : Fragment(R.layout.fragment_my_account) {
         showDialogFragment(LoginSuccessDialogFragment())
     }
 
-    private fun attemptLogin() {
+    private fun attemptLoginFromSavedPassword() {
         val username = username.text.toString().trim()
         val password = password.text.toString()
         if (username.isEmpty() || password.isEmpty()) {
@@ -304,12 +402,13 @@ class LoginFragment : Fragment(R.layout.fragment_my_account) {
             return
         }
         Timber.i("Attempting auto-login")
-        handleNewLogin(username, password)
+        handleNewLogin(username, password, fromSavedPassword = true)
     }
 
     private fun handleNewLogin(
         username: String,
         password: String,
+        fromSavedPassword: Boolean = false,
     ) {
         val endpoint = getEndpoint()
 
@@ -324,6 +423,7 @@ class LoginFragment : Fragment(R.layout.fragment_my_account) {
                     username,
                     password,
                     endpoint,
+                    fromSavedPassword,
                 )
 
                 viewModel.loginFlow.first()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/account/LoginFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/account/LoginFragment.kt
@@ -25,7 +25,6 @@ import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.appbar.MaterialToolbar
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import com.ichi2.anki.CollectionManager.TR
@@ -44,9 +43,6 @@ import com.ichi2.anki.utils.openUrl
 import com.ichi2.anki.withProgress
 import com.ichi2.ui.TextInputEditField
 import com.ichi2.utils.Permissions
-import com.ichi2.utils.negativeButton
-import com.ichi2.utils.positiveButton
-import com.ichi2.utils.show
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -94,6 +90,45 @@ class LoginFragment : Fragment(R.layout.fragment_my_account) {
         initObservers()
     }
 
+    private fun initLoginSuccessDialogResultListener() {
+        /** @see DeckPicker.onNewIntent */
+        fun openDeckPickerAndSync() {
+            Timber.i("Opening Deck Picker for Sync")
+            val intent =
+                DeckPicker.getIntent(
+                    requireContext(),
+                    autoSync = true,
+                )
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            startActivity(intent)
+            requireActivity().finish()
+        }
+
+        fun showLoggedInView() {
+            Timber.i("Showing LoggedIn view")
+            val fragmentManager = requireActivity().supportFragmentManager
+            fragmentManager.popBackStack(
+                null,
+                FragmentManager.POP_BACK_STACK_INCLUSIVE,
+            )
+            fragmentManager.commit {
+                replace(R.id.fragment_container, LoggedInFragment())
+            }
+            Permissions.requestNotificationPermissionsForSyncing(requireActivity())
+        }
+
+        parentFragmentManager.setFragmentResultListener(
+            LoginSuccessDialogFragment.REQUEST_KEY,
+            viewLifecycleOwner,
+        ) { _, bundle ->
+            when (LoginSuccessDialogFragment.actionFrom(bundle)) {
+                LoginSuccessDialogFragment.Action.SYNC -> openDeckPickerAndSync()
+                LoginSuccessDialogFragment.Action.CONTINUE -> showLoggedInView()
+                null -> {}
+            }
+        }
+    }
+
     /** Applies edge-to-edge insets for the screen */
     private fun setupEdgeToEdge(view: View) {
         val toolbarContainer = view.findViewById<View>(R.id.toolbar_container)
@@ -130,6 +165,7 @@ class LoginFragment : Fragment(R.layout.fragment_my_account) {
         initUsernameListeners()
         initPasswordListeners()
         initButtonListeners()
+        initLoginSuccessDialogResultListener()
     }
 
     private fun initUsernameListeners() {
@@ -258,42 +294,7 @@ class LoginFragment : Fragment(R.layout.fragment_my_account) {
      * * **Negative:** continues to [LoggedInFragment]
      */
     private fun showLoginSuccessDialog() {
-        /** @see LoggedInFragment */
-        fun showLoggedInView() {
-            Timber.i("Showing LoggedIn view")
-            val fragmentManager = requireActivity().supportFragmentManager
-            fragmentManager.popBackStack(
-                null,
-                FragmentManager.POP_BACK_STACK_INCLUSIVE,
-            )
-            fragmentManager.commit {
-                replace(R.id.fragment_container, LoggedInFragment())
-            }
-            Permissions.requestNotificationPermissionsForSyncing(requireActivity())
-        }
-
-        /** @see DeckPicker.onNewIntent */
-        fun openDeckPickerAndSync() {
-            Timber.i("Opening Deck Picker for Sync")
-            val intent =
-                DeckPicker.getIntent(
-                    requireContext(),
-                    autoSync = true,
-                )
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
-            startActivity(intent)
-            requireActivity().finish()
-        }
-
-        MaterialAlertDialogBuilder(requireContext()).show {
-            Timber.i("Showing dialog: 'Sync now?'")
-            setTitle(R.string.login_successful)
-            setIcon(R.drawable.ic_sync)
-            setMessage(R.string.sync_now)
-            positiveButton(R.string.button_sync) { openDeckPickerAndSync() }
-            negativeButton(R.string.dialog_continue) { showLoggedInView() }
-            setOnCancelListener { showLoggedInView() }
-        }
+        showDialogFragment(LoginSuccessDialogFragment())
     }
 
     private fun attemptLogin() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/account/LoginSuccessDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/account/LoginSuccessDialogFragment.kt
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2026 Brayan Oliveira <69634269+brayandso@users.noreply.github.com>
+package com.ichi2.anki.account
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.core.os.BundleCompat
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.setFragmentResult
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.ichi2.anki.R
+
+class LoginSuccessDialogFragment : DialogFragment() {
+    enum class Action {
+        SYNC,
+        CONTINUE,
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.login_successful)
+            .setIcon(R.drawable.ic_sync)
+            .setMessage(R.string.sync_now)
+            .setPositiveButton(R.string.button_sync) { _, _ -> reportResult(Action.SYNC) }
+            .setNegativeButton(R.string.dialog_continue) { _, _ -> reportResult(Action.CONTINUE) }
+            .create()
+
+    override fun onCancel(dialog: android.content.DialogInterface) {
+        super.onCancel(dialog)
+        reportResult(Action.CONTINUE)
+    }
+
+    private fun reportResult(action: Action) {
+        setFragmentResult(REQUEST_KEY, bundleOf(KEY_ACTION to action))
+    }
+
+    companion object {
+        const val REQUEST_KEY = "LoginSuccessDialogFragment_request"
+        const val KEY_ACTION = "action"
+
+        fun actionFrom(bundle: Bundle): Action? = BundleCompat.getSerializable(bundle, KEY_ACTION, Action::class.java)
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/account/LoginViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/account/LoginViewModel.kt
@@ -26,7 +26,9 @@ import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.settings.Prefs
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import net.ankiweb.rsdroid.exceptions.BackendSyncException
@@ -46,8 +48,8 @@ class LoginViewModel : ViewModel() {
     val passwordError: StateFlow<LoginError?>
         field = MutableStateFlow<LoginError?>(null)
 
-    val loginState: StateFlow<LoginState>
-        field = MutableStateFlow<LoginState>(LoginState.Idle)
+    val loginFlow: SharedFlow<Login>
+        field = MutableSharedFlow()
 
     fun onUserNameFocusChange(
         hasFocus: Boolean,
@@ -90,15 +92,15 @@ class LoginViewModel : ViewModel() {
                 val auth = syncLogin(username, password, endpoint)
                 Timber.i("Login success")
                 updateLogin(username, auth.hkey)
-                loginState.value = LoginState.Success
+                loginFlow.emit(Login.Success)
             } catch (exc: BackendSyncException.BackendSyncAuthFailedException) {
                 Timber.i("Login auth failed")
                 updateLogin("", "")
-                loginState.value = LoginState.Error(exc)
+                loginFlow.emit(Login.Error(exc))
             } catch (exc: Exception) {
                 // do not log the error, can contain PII
                 Timber.w("Login error")
-                loginState.value = LoginState.Error(exc)
+                loginFlow.emit(Login.Error(exc))
             }
         }
     }
@@ -135,11 +137,8 @@ enum class LoginError(
     fun toHumanReadableString(context: Context): String = context.getString(this.messageResId)
 }
 
-/** Handles the Login State */
-sealed class LoginState {
-    data object Idle : LoginState()
-
-    data object Success : LoginState()
+sealed class Login {
+    data object Success : Login()
 
     /**
      * The error here is an exception from the login attempt itself i.e. [net.ankiweb.rsdroid.exceptions.BackendSyncException.BackendSyncAuthFailedException]
@@ -148,5 +147,5 @@ sealed class LoginState {
      */
     data class Error(
         val exception: Exception,
-    ) : LoginState()
+    ) : Login()
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/account/LoginViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/account/LoginViewModel.kt
@@ -85,6 +85,7 @@ class LoginViewModel : ViewModel() {
         username: String,
         password: String,
         endpoint: String?,
+        fromSavedPassword: Boolean,
     ) {
         Timber.i("Logging in")
         viewModelScope.launch {
@@ -92,7 +93,7 @@ class LoginViewModel : ViewModel() {
                 val auth = syncLogin(username, password, endpoint)
                 Timber.i("Login success")
                 updateLogin(username, auth.hkey)
-                loginFlow.emit(Login.Success)
+                loginFlow.emit(Login.Success(username, password, fromSavedPassword))
             } catch (exc: BackendSyncException.BackendSyncAuthFailedException) {
                 Timber.i("Login auth failed")
                 updateLogin("", "")
@@ -138,7 +139,11 @@ enum class LoginError(
 }
 
 sealed class Login {
-    data object Success : Login()
+    data class Success(
+        val username: String,
+        val password: String,
+        val fromSavedPassword: Boolean,
+    ) : Login()
 
     /**
      * The error here is an exception from the login attempt itself i.e. [net.ankiweb.rsdroid.exceptions.BackendSyncException.BackendSyncAuthFailedException]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,8 @@ androidxComposeBillOfMaterials = "2026.06.01"
 androidxConstraintlayout = "2.2.2"
 # https://developer.android.com/jetpack/androidx/releases/core
 androidxCoreKtx = "1.17.0"
+# https://developer.android.com/jetpack/androidx/releases/credentials
+androidxCredentials = "1.6.0"
 # https://developer.android.com/jetpack/androidx/releases/draganddrop
 androidxDragAndDrop = "1.0.0"
 # https://developer.android.com/jetpack/androidx/releases/exifinterface
@@ -140,6 +142,7 @@ acra-dialog = { module = "ch.acra:acra-dialog", version.ref = "acra" }
 acra-http = { module = "ch.acra:acra-http", version.ref = "acra" }
 android-image-cropper = { module = "com.vanniktech:android-image-cropper", version.ref = "imageCropper" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidxConstraintlayout" }
+androidx-credentials = { module = "androidx.credentials:credentials", version.ref = "androidxCredentials" }
 androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "androidxFragmentKtx" }
 androidx-exifinterface = { module = "androidx.exifinterface:exifinterface", version.ref = "androidxExifinterface" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidxCoreKtx" }

--- a/lint-release.xml
+++ b/lint-release.xml
@@ -466,6 +466,11 @@
     <issue id="NotSibling" severity="ignore" />
     <issue id="UnknownIdInLayout" severity="ignore" />
     <issue id="WrongThreadInterprocedural" severity="ignore" />
+    <!-- Requires a `assetlinks.json` file available on AnkiWeb
+    https://developer.android.com/training/app-links/configure-assetlinks -->
+    <issue id="CredManMissingDal" severity="ignore" />
+    <!--Demands a Google Play Services dependency to save credentials on API < 34 -->
+    <issue id="CredentialDependency" severity="ignore" />
 
     <!-- PERF: Could improve by not using notifyDataSetChanged() -->
     <issue id="NotifyDataSetChanged" severity="ignore" />


### PR DESCRIPTION
On top of #21770 

## Approach

In the commits

## How Has This Been Tested?

Galaxy Tab S9, Android 16, Samsung Password manager


https://github.com/user-attachments/assets/9e6ed814-37cf-4046-b3b1-01c4b4124f18



Emulator 28, with no credentials manager installed

[Screen_recording_20260906_111636.webm](https://github.com/user-attachments/assets/c6f2b4b8-0d29-4530-8882-34ffbaad6fa5)

## Learning (optional, can help others)

https://developer.android.com/identity/credential-manager

https://developer.android.com/reference/kotlin/androidx/credentials/package-summary

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->