### PR TITLE
feat(preferences): toggle to disable learn-ahead and timebox limits

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangeWithSwitchPreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangeWithSwitchPreferenceCompat.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Ibrahim Iqbal <ibrahim-iqbal@users.noreply.github.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.preferences
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.preference.PreferenceViewHolder
+import com.google.android.material.materialswitch.MaterialSwitch
+import com.ichi2.anki.R
+
+/** Adds a trailing enable/disable switch to [IncrementerNumberRangePreferenceCompat]. A value of 0 is treated as disabled. */
+class IncrementerNumberRangeWithSwitchPreferenceCompat :
+    IncrementerNumberRangePreferenceCompat {
+    @Suppress("unused")
+    constructor(
+        context: Context,
+        attrs: AttributeSet?,
+        defStyleAttr: Int,
+        defStyleRes: Int,
+    ) : super(context, attrs, defStyleAttr, defStyleRes)
+
+    @Suppress("unused")
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+
+    @Suppress("unused")
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+
+    @Suppress("unused")
+    constructor(context: Context) : super(context)
+
+    init {
+        widgetLayoutResource = R.layout.preference_widget_switch_with_separator
+    }
+
+    private val isFeatureEnabled: Boolean get() = getValue() > 0
+
+    override fun onBindViewHolder(holder: PreferenceViewHolder) {
+        super.onBindViewHolder(holder)
+
+        val switch = holder.findViewById(R.id.switch_widget) as MaterialSwitch
+        switch.setOnCheckedChangeListener(null)
+        switch.isFocusable = isFeatureEnabled
+        switch.isClickable = isFeatureEnabled
+        switch.isChecked = isFeatureEnabled
+        switch.setOnCheckedChangeListener { _, checked ->
+            if (!checked && isFeatureEnabled) {
+                if (callChangeListener(0)) {
+                    setValue(0)
+                    notifyChanged()
+                }
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -35,13 +35,13 @@
             android:title="@string/day_offset_with_description"
             app:persistent="false"
             app:summaryFormat="@plurals/day_offset_summ"/>
-        <com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
+        <com.ichi2.preferences.IncrementerNumberRangeWithSwitchPreferenceCompat
             android:key="@string/learn_cutoff_preference"
             android:title="@string/learn_cutoff"
             app:max="999"
             app:min="0"
             app:summaryFormat="@plurals/pref_summ_minutes"/>
-        <com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
+        <com.ichi2.preferences.IncrementerNumberRangeWithSwitchPreferenceCompat
             android:key="@string/time_limit_preference"
             android:title="@string/time_limit"
             app:max="999"


### PR DESCRIPTION
Refs #20478 — the last remaining sub-task (disable toggle) on the "Learn ahead limit" and "Timebox time limit" dialogs.

Adds \`IncrementerNumberRangeWithSwitchPreferenceCompat\`, a thin subclass of \`IncrementerNumberRangePreferenceCompat\` that renders a trailing switch using the shared \`preference_widget_switch_with_separator\` layout. The switch mirrors the underlying integer:

- value > 0 → switch on, tappable to turn off (writes 0 through the existing change listener)
- value == 0 → switch off, not clickable; tapping the row still opens the stepper so the user can enter a value

Zero is Anki's own "disabled" sentinel for both \`collapseTime\` (learn ahead) and \`timeLim\` (timebox), so no new preference key is needed — the existing \`CollectionPreferences.setLearnAheadLimit\` / \`setTimeboxTimeLimit\` calls in \`ReviewingSettingsFragment\` handle the write side unchanged. \`preferences_reviewing.xml\` swaps the two entries over to the new type.

Follows the "sync URL" row design that came out of the discussion in #20478 (row + trailing Material 3 switch, dialog opens when the row is tapped), matching the pattern already used by \`VersatileTextWithASwitchPreference\`.

### Files
- \`AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangeWithSwitchPreferenceCompat.kt\` (new)
- \`AnkiDroid/src/main/res/xml/preferences_reviewing.xml\` (two entries swapped to the new type)

Strings are unchanged; the sub-tasks that required string edits are already done in prior PRs.