### PR TITLE
de-flake emulator tests

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/pages/DeckOptionsTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/pages/DeckOptionsTest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.After
+import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -74,7 +75,14 @@ class DeckOptionsTest : InstrumentedTest() {
                 scenario.onActivity { ready = fragment.webViewLayout.isVisible }
                 ready
             }
-            block(fragment)
+            val webView = fragment.webViewLayout.webView
+            try {
+                block(fragment)
+            } catch (e: Throwable) {
+                // catching Throwable handles assertions/timeouts caused by a renderer segfault
+                assumeTrue("WebView renderer should not crash: ${e.message}", fragment.webViewLayout.webView === webView)
+                throw e
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
@@ -11,6 +11,7 @@ import android.webkit.JavascriptInterface
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import androidx.activity.OnBackPressedCallback
+import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentActivity
 import anki.collection.ComputeParamsProgress
@@ -229,6 +230,21 @@ class DeckOptions : PageFragment() {
 
         webViewLayout.evaluateJavascript(openJs) {}
         webViewLayout.evaluateJavascript(closeJs) {}
+    }
+
+    /**
+     * The WebView was recreated after its renderer crashed, and the page is being reloaded
+     *
+     * Restore the loading state until the page reports it is ready again
+     *
+     * @see onWebViewReady
+     */
+    override fun onWebViewRecreated(webView: WebView) {
+        Timber.i("WebView recreated: reloading deck options")
+        webViewIsReady = false
+        webViewLayout.isInvisible = true
+        pageLoadingIndicator.isVisible = true
+        super.onWebViewRecreated(webView)
     }
 
     fun onWebViewReady() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/SafeWebViewLayout.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/SafeWebViewLayout.kt
@@ -24,6 +24,7 @@ import android.webkit.WebSettings
 import android.webkit.WebView
 import android.widget.FrameLayout
 import androidx.annotation.MainThread
+import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.findFragment
 import com.ichi2.anki.BuildConfig
@@ -37,7 +38,10 @@ open class SafeWebViewLayout :
     constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
     constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
 
-    private var webView: WebView = createWebView()
+    /** The wrapped [WebView], replaced if its renderer crashes */
+    @VisibleForTesting
+    var webView: WebView = createWebView()
+        private set
 
     var scrollBars: Int = webView.scrollBarStyle
         set(value) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/pages/DeckOptionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/pages/DeckOptionsTest.kt
@@ -2,8 +2,6 @@
 
 package com.ichi2.anki.pages
 
-import android.webkit.WebView
-import androidx.core.view.children
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
@@ -51,9 +49,5 @@ class DeckOptionsTest : RobolectricTest() {
 
     /** The last JavaScript evaluated by the WebView of [DeckOptions] */
     private val DeckOptions.lastEvaluatedJavascript: String?
-        get() =
-            webViewLayout.children
-                .filterIsInstance<WebView>()
-                .single()
-                .let { shadowOf(it).lastEvaluatedJavascript }
+        get() = shadowOf(webViewLayout.webView).lastEvaluatedJavascript
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/pages/DeckOptionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/pages/DeckOptionsTest.kt
@@ -2,6 +2,7 @@
 
 package com.ichi2.anki.pages
 
+import androidx.core.view.isVisible
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
@@ -11,6 +12,7 @@ import com.ichi2.anki.settings.Prefs
 import com.ichi2.testutils.ext.clear
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.equalTo
 import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -34,6 +36,25 @@ class DeckOptionsTest : RobolectricTest() {
 
             assertThat(lastEvaluatedJavascript, containsString("setParameterUnlockClickTimeoutMs"))
             assertThat(lastEvaluatedJavascript, containsString("800"))
+        }
+    }
+
+    @Test
+    fun `loading state is restored when the WebView is recreated`() {
+        withDeckOptions {
+            onWebViewReady()
+            assertThat("WebView is shown when ready", webViewLayout.isVisible, equalTo(true))
+            assertThat("loading indicator is hidden when ready", pageLoadingIndicator.isVisible, equalTo(false))
+
+            onWebViewRecreated(webViewLayout.webView)
+
+            assertThat("WebView is hidden while the page reloads", webViewLayout.isVisible, equalTo(false))
+            assertThat("loading indicator is shown while the page reloads", pageLoadingIndicator.isVisible, equalTo(true))
+
+            onWebViewReady()
+
+            assertThat("WebView is shown when the reloaded page is ready", webViewLayout.isVisible, equalTo(true))
+            assertThat("loading indicator is hidden when the reloaded page is ready", pageLoadingIndicator.isVisible, equalTo(false))
         }
     }
 


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5.1

## Purpose / Description
Standard de-flake: turns out it's [likely] caused by the WebView crashing

## Fixes
* Fixes #21756
* Fixes #21740

## Approach
* Add a few QoL improvements for 'real' crash events
* ⚠️ skip tests where the underlying emulator is flaky


## How Has This Been Tested?
Test-only

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)