### PR TITLE
test: extend 'ReviewRemindersScreenshotTest'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersFragment.kt
@@ -13,6 +13,7 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.IdRes
+import androidx.annotation.VisibleForTesting
 import androidx.core.graphics.Insets
 import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
@@ -161,7 +162,8 @@ class ScheduleRemindersFragment :
             ?: FragmentHost.SETTINGS
     }
 
-    private val binding by viewBinding(FragmentScheduleRemindersBinding::bind)
+    @VisibleForTesting
+    internal val binding by viewBinding(FragmentScheduleRemindersBinding::bind)
 
     private val troubleshootingViewModel: ReminderTroubleshootingViewModel by activityViewModels {
         reminderTroubleshootingViewModelFactory(requireContext())

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersScreenshotTest.kt
@@ -170,6 +170,20 @@ class ReviewRemindersScreenshotTest : ScreenshotTest() {
     }
 
     @Test
+    fun `reminders for a deleted deck`() {
+        val deckId = addDeck("Deleted deck")
+        val deckScope = ReviewReminderScope.DeckSpecific(deckId)
+        insertReminder(ReviewReminderTime(8, 0))
+        insertReminder(ReviewReminderTime(9, 30), scope = deckScope)
+        insertReminder(ReviewReminderTime(18, 15), scope = deckScope, enabled = false)
+        col.decks.remove(listOf(deckId))
+
+        withStandaloneScheduleReminders {
+            captureScreen("deletedDeckReminders")
+        }
+    }
+
+    @Test
     fun `standalone activity host with system bars`() =
         withStandaloneScheduleReminders { activity ->
             activity.simulateSystemBars()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersScreenshotTest.kt
@@ -3,8 +3,10 @@
 
 package com.ichi2.anki.reviewreminders
 
+import android.app.NotificationManager
 import androidx.annotation.IdRes
 import androidx.core.content.edit
+import androidx.core.content.getSystemService
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
 import androidx.test.core.app.ActivityScenario
@@ -18,9 +20,13 @@ import com.ichi2.anki.databinding.FragmentReminderTroubleshootingBinding
 import com.ichi2.anki.preferences.PreferencesActivity
 import com.ichi2.anki.preferences.PreferencesFragment
 import com.ichi2.anki.reviewreminders.ScheduleRemindersFragment.FragmentHost
+import com.ichi2.anki.settings.Prefs
+import com.ichi2.anki.ui.windows.permissions.PermissionsBottomSheet
+import com.ichi2.anki.ui.windows.permissions.PermissionsFragment
 import com.ichi2.anki.utils.ConfigAwareSingleFragmentActivity
 import com.ichi2.anki.withDeckPicker
 import com.ichi2.testutils.BackupManagerTestUtilities
+import com.ichi2.testutils.positiveButton
 import com.ichi2.testutils.scrollToLastPosition
 import com.ichi2.testutils.simulateSystemBars
 import com.ichi2.utils.dp
@@ -29,6 +35,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
 
 /**
  * Covers all [FragmentHost] configurations of the fragment.
@@ -184,6 +191,25 @@ class ReviewRemindersScreenshotTest : ScreenshotTest() {
     }
 
     @Test
+    fun `notification permission bottom sheet after adding a reminder`() {
+        shadowOf(targetContext.getSystemService<NotificationManager>()!!).setNotificationsEnabled(false)
+        Prefs.reminderNotifsRequestShown = false
+        Prefs.notificationsPermissionRequested = false
+
+        withScheduleRemindersFragment { fragment ->
+            fragment.binding.floatingActionButtonAdd.performClick()
+            advanceRobolectricLooper()
+
+            fragment.addEditReminderDialog.positiveButton.performClick()
+            advanceRobolectricLooperUntil {
+                fragment.permissionsBottomSheet?.permissionsFragment?.view != null &&
+                    fragment.reminderCount == 1
+            }
+            captureScreen("notificationPermissionBottomSheet")
+        }
+    }
+
+    @Test
     fun `standalone activity host with system bars`() =
         withStandaloneScheduleReminders { activity ->
             activity.simulateSystemBars()
@@ -317,4 +343,18 @@ class ReviewRemindersScreenshotTest : ScreenshotTest() {
             ?.setExpanded(false, false)
         advanceRobolectricLooper()
     }
+
+    private val ScheduleRemindersFragment.addEditReminderDialog: AddEditReminderDialog
+        get() = childFragmentManager.fragments.filterIsInstance<AddEditReminderDialog>().single()
+
+    private val ScheduleRemindersFragment.permissionsBottomSheet: PermissionsBottomSheet?
+        get() = childFragmentManager.fragments.filterIsInstance<PermissionsBottomSheet>().singleOrNull()
+
+    /** The number of reminders in the list */
+    private val ScheduleRemindersFragment.reminderCount: Int
+        get() = binding.recyclerView.adapter!!.itemCount
+
+    /** The content the sheet hosts, once it has been committed */
+    private val PermissionsBottomSheet.permissionsFragment: PermissionsFragment?
+        get() = childFragmentManager.fragments.filterIsInstance<PermissionsFragment>().singleOrNull()
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersScreenshotTest.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
 import androidx.test.core.app.ActivityScenario
 import com.google.android.material.appbar.AppBarLayout
+import com.ichi2.anki.OptionalPermissionSet
 import com.ichi2.anki.R
 import com.ichi2.anki.ScreenshotTest
 import com.ichi2.anki.StudyOptionsActivity
@@ -206,6 +207,17 @@ class ReviewRemindersScreenshotTest : ScreenshotTest() {
                     fragment.reminderCount == 1
             }
             captureScreen("notificationPermissionBottomSheet")
+        }
+    }
+
+    @Test
+    fun `legacy notification permission bottom sheet`() {
+        shadowOf(targetContext.getSystemService<NotificationManager>()!!).setNotificationsEnabled(false)
+        withScheduleRemindersFragment { fragment ->
+            // Capture the legacy content on the suite's SDK; mixing SDKs cannot share the native backend.
+            PermissionsBottomSheet.launch(fragment.childFragmentManager, OptionalPermissionSet.LEGACY_NOTIFICATIONS)
+            advanceRobolectricLooper()
+            captureScreen("legacyNotificationPermissionBottomSheet")
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersScreenshotTest.kt
@@ -4,6 +4,7 @@
 package com.ichi2.anki.reviewreminders
 
 import androidx.annotation.IdRes
+import androidx.core.content.edit
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
 import androidx.test.core.app.ActivityScenario
@@ -24,6 +25,8 @@ import com.ichi2.testutils.scrollToLastPosition
 import com.ichi2.testutils.simulateSystemBars
 import com.ichi2.utils.dp
 import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.robolectric.RuntimeEnvironment
 
@@ -31,6 +34,13 @@ import org.robolectric.RuntimeEnvironment
  * Covers all [FragmentHost] configurations of the fragment.
  */
 class ReviewRemindersScreenshotTest : ScreenshotTest() {
+    @Before
+    @After
+    fun clearReminders() {
+        // The database retains its own SharedPreferences instance across Robolectric test cases.
+        ReviewRemindersDatabase.remindersSharedPrefs.edit { clear() }
+    }
+
     @Test
     fun `settings host`() {
         captureSettingsHost("settingsHost")

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersScreenshotTest.kt
@@ -14,7 +14,6 @@ import com.ichi2.anki.StudyOptionsActivity
 import com.ichi2.anki.common.destinations.StudyOptionsDestination
 import com.ichi2.anki.common.destinations.launchActivity
 import com.ichi2.anki.databinding.FragmentReminderTroubleshootingBinding
-import com.ichi2.anki.databinding.FragmentScheduleRemindersBinding
 import com.ichi2.anki.preferences.PreferencesActivity
 import com.ichi2.anki.preferences.PreferencesFragment
 import com.ichi2.anki.reviewreminders.ScheduleRemindersFragment.FragmentHost
@@ -159,7 +158,7 @@ class ReviewRemindersScreenshotTest : ScreenshotTest() {
         insertReminders(count = 12)
         withScheduleRemindersFragment { fragment ->
             fragment.requireActivity().simulateSystemBars()
-            val binding = FragmentScheduleRemindersBinding.bind(fragment.requireView())
+            val binding = fragment.binding
             // scrolled to the end: the last reminder must clear the navigation bar band
             binding.recyclerView.scrollToLastPosition()
             advanceRobolectricLooper()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersScreenshotTest.kt
@@ -51,6 +51,8 @@ class ReviewRemindersScreenshotTest : ScreenshotTest() {
 
     @Test
     fun `settings host`() {
+        // overflow the list: the toolbar only collapses once the list can scroll
+        insertReminders(count = 12)
         captureSettingsHost("settingsHost")
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersScreenshotTest.kt
@@ -157,9 +157,9 @@ class ReviewRemindersScreenshotTest : ScreenshotTest() {
     @Test
     fun `standalone activity host with system bars and a scrollable list`() {
         insertReminders(count = 12)
-        withStandaloneScheduleReminders { activity ->
-            activity.simulateSystemBars()
-            val binding = FragmentScheduleRemindersBinding.bind(activity.fragment!!.requireView())
+        withScheduleRemindersFragment { fragment ->
+            fragment.requireActivity().simulateSystemBars()
+            val binding = FragmentScheduleRemindersBinding.bind(fragment.requireView())
             // scrolled to the end: the last reminder must clear the navigation bar band
             binding.recyclerView.scrollToLastPosition()
             advanceRobolectricLooper()
@@ -258,6 +258,10 @@ class ReviewRemindersScreenshotTest : ScreenshotTest() {
             scenario.onActivity { activity -> block(activity) }
         }
     }
+
+    /** Launches [ScheduleRemindersFragment] in its own activity, exposing the fragment */
+    private fun withScheduleRemindersFragment(block: (ScheduleRemindersFragment) -> Unit) =
+        withStandaloneScheduleReminders { activity -> block(activity.fragment as ScheduleRemindersFragment) }
 
     /** Collapses the settings host's toolbar, as when the list has been scrolled */
     private fun FragmentManager.collapseToolbar() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersScreenshotTest.kt
@@ -157,6 +157,19 @@ class ReviewRemindersScreenshotTest : ScreenshotTest() {
         }
 
     @Test
+    fun `enabled and disabled global and deck reminders`() {
+        val deckScope = ReviewReminderScope.DeckSpecific(addDeck("Japanese::Vocabulary"))
+        insertReminder(ReviewReminderTime(8, 0))
+        insertReminder(ReviewReminderTime(9, 30), enabled = false)
+        insertReminder(ReviewReminderTime(18, 15), scope = deckScope)
+        insertReminder(ReviewReminderTime(21, 45), scope = deckScope, enabled = false)
+
+        withStandaloneScheduleReminders {
+            captureScreen("globalAndDeckReminders_enabledAndDisabled")
+        }
+    }
+
+    @Test
     fun `standalone activity host with system bars`() =
         withStandaloneScheduleReminders { activity ->
             activity.simulateSystemBars()
@@ -201,6 +214,16 @@ class ReviewRemindersScreenshotTest : ScreenshotTest() {
             advanceRobolectricLooper()
             captureScreen("standaloneActivityHost_troubleshooting_systemBars")
         }
+    }
+
+    private fun insertReminder(
+        time: ReviewReminderTime,
+        scope: ReviewReminderScope = ReviewReminderScope.Global,
+        enabled: Boolean = true,
+    ) = runBlocking {
+        ReviewRemindersDatabase.insertReminder(
+            ReviewReminder.createReviewReminder(time = time, scope = scope, enabled = enabled),
+        )
     }
 
     /** Inserts [count] reminders so the list has content to render behind the simulated bars */

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/DialogFragmentUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/DialogFragmentUtils.kt
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.testutils
+
+import android.widget.Button
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+import com.ichi2.utils.positiveButton
+
+/** The positive button of the [AlertDialog] shown by a [DialogFragment] */
+val DialogFragment.positiveButton: Button
+    get() = (requireDialog() as AlertDialog).positiveButton


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: GPT-6

## Fixes
* Part of #21753

## Approach
* Should cover both review reminders present on the screen and not present (empty ScheduleReminders view)
* (maybe) The permission-requesting bottom sheet
* What a review reminder looks like when the associated deck is deleted

## How Has This Been Tested?
These are tests

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
