### PR TITLE
refactor/fix: prep for `nosuggest:type` field filter

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -195,6 +195,7 @@ open class AnkiDroidApp :
         setupLifecycleLogging()
         activityAgnosticDialogs = ActivityAgnosticDialogs.register(this)
         setupTextToSpeech()
+        setupCustomFieldFilters()
     }
 
     /**
@@ -428,6 +429,17 @@ open class AnkiDroidApp :
     private fun setupTextToSpeech() {
         setup("setupTextToSpeech") {
             TtsVoices.launchBuildLocalesJob()
+        }
+    }
+
+    /**
+     * Applies AnkiDroid-specific implementations of field filters
+     *
+     * @see com.ichi2.anki.model.FieldFilter
+     * @see com.ichi2.anki.model.FieldFilters
+     */
+    private fun setupCustomFieldFilters() {
+        setup("setupCustomFieldFilters") {
             // enable {{tts-voices:}} field filter
             TtsVoicesFieldFilter.ensureApplied()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/TtsVoices.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/TtsVoices.kt
@@ -24,6 +24,8 @@ package com.ichi2.anki
 
 import android.speech.tts.TextToSpeech
 import android.speech.tts.Voice
+import com.ichi2.anki.TtsVoices.availableLocaleData
+import com.ichi2.anki.TtsVoices.availableLocales
 import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.i18n.normalize
@@ -273,7 +275,7 @@ object TtsVoices {
 /**
  * `{{tts-voices:}}` A filter which lists all available TTS Voices for the current engine
  */
-class TtsVoicesFieldFilter : TemplateManager.FieldFilter() {
+class TtsVoicesFieldFilter : TemplateManager.FieldFilter {
     // modified from libAnki: tts.py: on_tts_voices
     override fun apply(
         fieldText: String,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
@@ -1,18 +1,4 @@
-/*
- *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 package com.ichi2.anki.cardviewer
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
@@ -17,6 +17,8 @@ import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 /**
+ * Handles 'Type the answer' for the old study screen
+ *
  * @param useInputTag use an `<input>` tag to allow for HTML styling
  * @param autoFocus Whether the user wants to focus "type in answer"
  */
@@ -75,21 +77,13 @@ class TypeAnswer(
         correct = null
         val q = card.question(col)
         val m = PATTERN.matcher(q)
-        var clozeIdx = 0
         if (!m.find()) {
             return
         }
-        var fldTag = m.group(1)!!
-        // if it's a cloze, extract data
-        if (fldTag.startsWith("cloze:")) {
-            // get field and cloze position
-            clozeIdx = card.ord + 1
-            fldTag = fldTag.split(":").toTypedArray()[1]
-        }
-        if (fldTag.startsWith("nc:")) {
-            combining = false
-            fldTag = fldTag.split(":").toTypedArray()[1]
-        }
+        val parsed = TypeAnswerModifiers.parse(m.group(1)!!)
+        combining = parsed.combining
+        val fldTag = parsed.fieldName
+        val clozeIdx = if (parsed.cloze) card.ord + 1 else 0
         // loop through fields for a match
         for (fld in card.noteType(col).fields) {
             val name = fld.name

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswerModifiers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswerModifiers.kt
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.cardviewer
+
+/**
+ * Represents modifiers for `[[type:...]]`
+ *
+ * Examples:
+ * - `[[type:nc:Field]]`
+ * - `[[type:cloze:Field]]`
+ */
+internal data class TypeAnswerModifiers(
+    val fieldName: String,
+    val combining: Boolean,
+    val cloze: Boolean,
+) {
+    companion object {
+        /**
+         * Represents the known modifiers in a [[type: ]] declaration, and remaining data
+         */
+        fun parse(rawField: String): TypeAnswerModifiers {
+            var remaining = rawField
+            var combining = true
+            var cloze = false
+            while (true) {
+                when {
+                    remaining.startsWith("cloze:") -> {
+                        cloze = true
+                        remaining = remaining.removePrefix("cloze:")
+                    }
+                    remaining.startsWith("nc:") -> {
+                        combining = false
+                        remaining = remaining.removePrefix("nc:")
+                    }
+                    else -> return TypeAnswerModifiers(
+                        fieldName = remaining,
+                        combining = combining,
+                        cloze = cloze,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/model/FieldFilters.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/model/FieldFilters.kt
@@ -1,18 +1,4 @@
-/*
- *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 package com.ichi2.anki.model
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TypeAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TypeAnswer.kt
@@ -17,6 +17,7 @@ package com.ichi2.anki.previewer
 
 import android.os.LocaleList
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.cardviewer.TypeAnswerModifiers
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.libanki.Card
 import com.ichi2.anki.libanki.Field
@@ -32,7 +33,6 @@ import org.jetbrains.annotations.VisibleForTesting
  * @see [imeHintLocales]
  * */
 @NeedsTest("combining and non combining answers are properly parsed")
-@NeedsTest("cloze and non cloze 'type in the answer' cards are properly parsed")
 class TypeAnswer private constructor(
     private val text: String,
     /** whether combining characters should be compared. Defined by the presence of the
@@ -75,40 +75,31 @@ class TypeAnswer private constructor(
             val match = typeAnsRe.find(text) ?: return null
             val rawField = match.groups[1]?.value ?: return null
 
-            var combining = true
-            val typeAnsFieldName =
-                if (rawField.startsWith("cloze:")) {
-                    rawField.split(":")[1]
-                } else if (rawField.startsWith("nc:")) {
-                    combining = false
-                    rawField.split(":")[1]
-                } else {
-                    rawField
-                }
+            val modifiers = TypeAnswerModifiers.parse(rawField)
             val fields = withCol { card.noteType(this).fields }
-            val typeAnswerField = fields.firstOrNull { it.name == typeAnsFieldName } ?: return null
-            val expectedAnswer = getExpectedTypeInAnswer(card, rawField = rawField, fieldName = typeAnsFieldName)
+            val typeAnswerField = fields.firstOrNull { it.name == modifiers.fieldName } ?: return null
+            val expectedAnswer = getExpectedTypeInAnswer(card, isCloze = modifiers.cloze, fieldName = modifiers.fieldName)
 
             return TypeAnswer(
                 text = text,
-                combining = combining,
+                combining = modifiers.combining,
                 field = typeAnswerField,
                 expectedAnswer = expectedAnswer,
             )
         }
 
         /**
-         * @param rawField the content (x) of a `{{type:x}}` placeholder
+         * @param isCloze whether the placeholder was a `cloze:` type filter
          * @param fieldName the name of the field in the card template
          */
         @NeedsTest("cloze type-in-answer are properly parsed")
         private suspend fun getExpectedTypeInAnswer(
             card: Card,
-            rawField: String,
+            isCloze: Boolean,
             fieldName: String,
         ): String {
             val expected = withCol { card.note(this@withCol).getItem(fieldName) }
-            return if (rawField.startsWith("cloze:")) {
+            return if (isCloze) {
                 val clozeIdx = card.ord + 1
                 withCol {
                     extractClozeForTyping(expected, clozeIdx)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -14,6 +14,7 @@ import android.view.WindowManager
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.webkit.WebView
+import android.widget.EditText
 import android.widget.FrameLayout
 import android.widget.LinearLayout
 import androidx.appcompat.app.AlertDialog
@@ -55,6 +56,7 @@ import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.preferences.reviewer.ViewerAction
 import com.ichi2.anki.previewer.CardViewerActivity
 import com.ichi2.anki.previewer.CardViewerFragment
+import com.ichi2.anki.previewer.TypeAnswer
 import com.ichi2.anki.previewer.setFrameStyle
 import com.ichi2.anki.previewer.stdHtml
 import com.ichi2.anki.reviewer.BindingMap
@@ -260,6 +262,17 @@ class ReviewerFragment :
         val isHtmlTypeAnswerEnabled = Prefs.isHtmlTypeAnswerEnabled
         lifecycleScope.launch {
             val autoFocusTypeAnswer = Prefs.autoFocusTypeAnswer
+
+            /**
+             * Sync `imeHintLocales` on the answer `EditText` to match [typeInAnswer].
+             * Returns `true` if anything changed (caller should `restartInput()`).
+             */
+            fun EditText.syncTypeAnswerProperties(typeInAnswer: TypeAnswer): Boolean {
+                if (imeHintLocales == typeInAnswer.imeHintLocales) return false
+                imeHintLocales = typeInAnswer.imeHintLocales
+                return true
+            }
+
             lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.typeAnswerFlow.collect { typeInAnswer ->
                     if (typeInAnswer == null) {
@@ -278,8 +291,7 @@ class ReviewerFragment :
 
                     binding.typeAnswerContainer.isVisible = true
                     binding.typeAnswerEditText.apply {
-                        if (imeHintLocales != typeInAnswer.imeHintLocales) {
-                            imeHintLocales = typeInAnswer.imeHintLocales
+                        if (syncTypeAnswerProperties(typeInAnswer)) {
                             context?.getSystemService<InputMethodManager>()?.restartInput(this)
                         }
                         if (autoFocusTypeAnswer) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/TypeAnswerModifiersTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/TypeAnswerModifiersTest.kt
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.cardviewer
+
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+
+class TypeAnswerModifiersTest {
+    @Test
+    fun `parses bare field`() {
+        val parsed = TypeAnswerModifiers.parse("Back")
+        assertThat(parsed, equalTo(TypeAnswerModifiers("Back", combining = true, cloze = false)))
+    }
+
+    @Test
+    fun `parses nc only`() {
+        val parsed = TypeAnswerModifiers.parse("nc:Back")
+        assertThat(parsed, equalTo(TypeAnswerModifiers("Back", combining = false, cloze = false)))
+    }
+
+    @Test
+    fun `parses cloze only`() {
+        val parsed = TypeAnswerModifiers.parse("cloze:Text")
+        assertThat(parsed, equalTo(TypeAnswerModifiers("Text", combining = true, cloze = true)))
+    }
+
+    @Test
+    fun `parses chained modifiers`() {
+        val parsed = TypeAnswerModifiers.parse("cloze:nc:Text")
+        assertThat(parsed, equalTo(TypeAnswerModifiers("Text", combining = false, cloze = true)))
+    }
+
+    @Test
+    fun `parses chained modifiers in either order`() {
+        val parsed = TypeAnswerModifiers.parse("nc:cloze:Text")
+        assertThat(parsed, equalTo(TypeAnswerModifiers("Text", combining = false, cloze = true)))
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/model/FieldFilterChainTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/model/FieldFilterChainTest.kt
@@ -1,18 +1,4 @@
-/*
- *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 package com.ichi2.anki.model
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/previewer/TypeAnswerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/previewer/TypeAnswerTest.kt
@@ -1,18 +1,5 @@
-/*
- *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
- *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.ichi2.anki.previewer
 
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/AnkiDroid/src/test/java/com/ichi2/anki/previewer/TypeAnswerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/previewer/TypeAnswerTest.kt
@@ -7,10 +7,12 @@ import com.ichi2.anki.libanki.Card
 import com.ichi2.testutils.JvmTest
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.not
 import org.junit.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.runner.RunWith
+import kotlin.test.assertNotNull
 
 @RunWith(AndroidJUnit4::class)
 class TypeAnswerTest : JvmTest() {
@@ -25,6 +27,17 @@ class TypeAnswerTest : JvmTest() {
             val result = assertDoesNotThrow { typeAnswer.answerFilter("") }
             assertThat(result, containsString("$ ls"))
             assertThat(result, not(containsString("[[type:Back]]")))
+        }
+
+    @Test
+    fun `chained modifiers are parsed`() =
+        runTest {
+            val card = addClozeNote("{{c1::hello}} world").firstCard()
+
+            val typeAnswer = TypeAnswer.getInstance(card, "[[type:cloze:nc:Text]]")
+
+            assertNotNull(typeAnswer, "chained 'cloze' and 'nc' modifiers")
+            assertThat(typeAnswer.expectedAnswer, equalTo("hello"))
         }
 
     companion object {

--- a/libanki/src/main/java/com/ichi2/anki/libanki/TemplateManager.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/TemplateManager.kt
@@ -292,8 +292,8 @@ class TemplateManager {
      * Custom filters can check `filterName` to decide whether it should modify
      * `fieldText` or not before returning it
      */
-    abstract class FieldFilter {
-        abstract fun apply(
+    interface FieldFilter {
+        fun apply(
             fieldText: String,
             fieldName: String,
             filterName: String,


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7
> Assisted-by: Claude Fable 5.1 - splitting out commits, some tests

## Fixes
* Split from https://github.com/ankidroid/Anki-Android/pull/21097
* Part of https://github.com/ankidroid/Anki-Android/issues/10352

## Approach
Various refactors split out from the above PR

And a minor fix for a field: `[[type:cloze:nc:Field]]`

## How Has This Been Tested?
⚠️ The PR that this was split out of was tested

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)