### PR TITLE
perf(deckpicker): do not keep background bitmap when the deck list is not live

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerTest.kt
@@ -6,37 +6,35 @@ package com.ichi2.anki
 import androidx.core.content.edit
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.matcher.ViewMatchers.withResourceName
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.common.preferences.sharedPrefs
+import com.ichi2.anki.libanki.Card
+import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.tests.InstrumentedTest
 import com.ichi2.anki.tests.checkWithTimeout
-import com.ichi2.anki.tests.libanki.RetryRule
 import com.ichi2.anki.testutil.GrantStoragePermission.storagePermission
-import com.ichi2.anki.testutil.ThreadUtils
 import com.ichi2.anki.testutil.closeBackupCollectionDialogIfExists
 import com.ichi2.anki.testutil.closeGetStartedScreenIfExists
 import com.ichi2.anki.testutil.grantPermissions
 import com.ichi2.anki.testutil.notificationPermission
+import com.ichi2.anki.testutil.waitUntil
 import com.ichi2.anki.utils.ext.cardStateCustomizer
-import com.ichi2.testutils.common.Flaky
-import com.ichi2.testutils.common.OS
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
+import org.junit.After
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import timber.log.Timber
-import java.lang.AssertionError
+import java.util.UUID
 
 @RunWith(AndroidJUnit4::class)
 class ReviewerTest : InstrumentedTest() {
@@ -53,8 +51,8 @@ class ReviewerTest : InstrumentedTest() {
     @get:Rule
     val runtimePermissionRule = grantPermissions(storagePermission, notificationPermission)
 
-    @get:Rule
-    val retry = RetryRule(10)
+    /** Shared on-disk collection: review a deck that contains only this test's card. */
+    private var testDeckId: DeckId = 0
 
     override fun runBeforeEachTest() {
         super.runBeforeEachTest()
@@ -65,10 +63,24 @@ class ReviewerTest : InstrumentedTest() {
         // since the feature is currently in beta and unexpectedly enabled, disable it
         // TODO: remove this
         disableNewReviewer()
+        // Dirty AVD prefs can leave TTS on, which shows a locale dialog over the reviewer.
+        testContext.sharedPrefs().edit {
+            putBoolean("tts", false)
+        }
+        testDeckId = col.decks.addNormalDeckWithName("ReviewerTest-${UUID.randomUUID()}").id
+        col.decks.select(testDeckId)
+    }
+
+    @After
+    fun tearDown() {
+        if (testDeckId != 0L) {
+            col.decks.remove(listOf(testDeckId))
+            testDeckId = 0
+        }
+        col.cardStateCustomizer = ""
     }
 
     @Test
-    @Flaky(os = OS.ALL, "Fails on CI with timing issues frequently")
     fun testCustomSchedulerWithCustomData() {
         col.cardStateCustomizer =
             """
@@ -76,9 +88,7 @@ class ReviewerTest : InstrumentedTest() {
             states.good.normal.review.scheduledDays = 123;
             customData.good.c += 1;
             """
-        val note = addNoteUsingBasicNoteType("foo", "bar")
-        val card = note.firstCard(col)
-        val deck = col.decks.getLegacy(note.notetype.did)!!
+        val card = addCardToTestDeck()
         card.moveToReviewQueue()
         col.backend.updateCards(
             listOf(
@@ -93,7 +103,7 @@ class ReviewerTest : InstrumentedTest() {
 
         closeGetStartedScreenIfExists()
         closeBackupCollectionDialogIfExists()
-        reviewDeckWithName(deck.name)
+        reviewDeckWithName(col.decks.name(testDeckId))
 
         var cardFromDb = col.getCard(card.id).toBackendCard()
         assertThat(cardFromDb.easeFactor, equalTo(card.factor))
@@ -101,39 +111,32 @@ class ReviewerTest : InstrumentedTest() {
         assertThat(cardFromDb.customData, equalTo("""{"c":1}"""))
 
         clickShowAnswerAndAnswerGood()
-
-        fun runAssertion() {
-            cardFromDb = col.getCard(card.id).toBackendCard()
-            assertThat(cardFromDb.easeFactor, equalTo(3000))
-            assertThat(cardFromDb.interval, equalTo(123))
-            assertThat(cardFromDb.customData, equalTo("""{"c":2}"""))
+        waitUntil(message = { "The review of card ${card.id} was not saved" }) {
+            col.getCard(card.id).reps == card.reps + 1
         }
 
-        try {
-            runAssertion()
-        } catch (e: Exception) {
-            // Give separate threads a greater chance of doing the custom scheduling
-            // if the card scheduling values aren't updated immediately
-            ThreadUtils.sleep(2000)
-            runAssertion()
-        }
+        cardFromDb = col.getCard(card.id).toBackendCard()
+        assertThat(cardFromDb.easeFactor, equalTo(3000))
+        assertThat(cardFromDb.interval, equalTo(123))
+        assertThat(cardFromDb.customData, equalTo("""{"c":2}"""))
     }
 
     @Test
-    @Flaky(os = OS.ALL, "Fails on CI with timing issues frequently")
     fun testCustomSchedulerWithRuntimeError() {
         // Issue 15035 - runtime errors weren't handled
         col.cardStateCustomizer = "states.this_is_not_defined.normal.review = 12;"
-        addNoteUsingBasicNoteType()
+        addCardToTestDeck()
 
         closeGetStartedScreenIfExists()
         closeBackupCollectionDialogIfExists()
-        reviewDeckWithName("Default")
+        reviewDeckWithName(col.decks.name(testDeckId))
 
         clickShowAnswer()
 
         ensureAnswerButtonsAreDisplayed()
     }
+
+    private fun addCardToTestDeck(): Card = addNoteUsingBasicNoteType("foo", "bar").firstCard(col).update { did = testDeckId }
 
     private fun clickOnDeckWithName(deckName: String) {
         onView(withId(R.id.decks)).checkWithTimeout(matches(hasDescendant(withText(deckName))))
@@ -165,23 +168,11 @@ class ReviewerTest : InstrumentedTest() {
     private fun clickShowAnswerAndAnswerGood() {
         clickShowAnswer()
         ensureAnswerButtonsAreDisplayed()
-        try {
-            // ...on the command line it has resource name "good_button"...
-            onView(withResourceName("good_button")).perform(click())
-        } catch (e: NoMatchingViewException) {
-            // ...but in Android Studio it has resource name "flashcard_layout_ease3" !?
-            onView(withResourceName("flashcard_layout_ease3")).perform(click())
-        }
+        onView(withId(R.id.flashcard_layout_ease3)).perform(click())
     }
 
     private fun clickShowAnswer() {
-        try {
-            // ... on the command line, it has resource name "show_answer"...
-            onView(withResourceName("show_answer")).perform(click())
-        } catch (e: NoMatchingViewException) {
-            // ... but in Android Studio it has resource name "flashcard_layout_flip" !?
-            onView(withResourceName("flashcard_layout_flip")).perform(click())
-        }
+        onView(withId(R.id.flashcard_layout_flip)).perform(click())
     }
 
     private fun ensureAnswerButtonsAreDisplayed() {
@@ -189,19 +180,10 @@ class ReviewerTest : InstrumentedTest() {
         // the messages to be passed in and out of the WebView when evaluating
         // the custom JS scheduler code. The ease buttons are hidden until the
         // custom scheduler has finished running
-        try {
-            // ...on the command line it has resource name "good_button"...
-            onView(withResourceName("good_button")).checkWithTimeout(
-                matches(isDisplayed()),
-                100,
-            )
-        } catch (e: AssertionError) {
-            // ...but in Android Studio it has resource name "flashcard_layout_ease3" !?
-            onView(withResourceName("flashcard_layout_ease3")).checkWithTimeout(
-                matches(isDisplayed()),
-                100,
-            )
-        }
+        onView(withId(R.id.flashcard_layout_ease3)).checkWithTimeout(
+            matches(isDisplayed()),
+            100,
+        )
     }
 
     private fun disableNewReviewer() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -116,8 +116,10 @@ import com.ichi2.anki.contextmenu.DeckPickerMenuContentProvider
 import com.ichi2.anki.databinding.ActivityHomescreenBinding
 import com.ichi2.anki.databinding.IncludeDeckPickerBinding
 import com.ichi2.anki.databinding.IncludeFloatingAddButtonBinding
+import com.ichi2.anki.deckpicker.BackgroundFailureToastState
 import com.ichi2.anki.deckpicker.BackgroundImage
 import com.ichi2.anki.deckpicker.DeckDeletionResult
+import com.ichi2.anki.deckpicker.DeckPickerBackgroundLoader
 import com.ichi2.anki.deckpicker.DeckPickerViewModel
 import com.ichi2.anki.deckpicker.DeckPickerViewModel.AnkiDroidEnvironment
 import com.ichi2.anki.deckpicker.DeckPickerViewModel.FlattenedDeckList
@@ -126,6 +128,8 @@ import com.ichi2.anki.deckpicker.EmptyCardsResult
 import com.ichi2.anki.deckpicker.OptionsMenuState
 import com.ichi2.anki.deckpicker.ShortcutData
 import com.ichi2.anki.deckpicker.SyncIconState
+import com.ichi2.anki.deckpicker.applyLoadedDeckPickerBackground
+import com.ichi2.anki.deckpicker.installDeckPickerBackgroundLoader
 import com.ichi2.anki.dialogs.AsyncDialogFragment
 import com.ichi2.anki.dialogs.BackupPromptDialog
 import com.ichi2.anki.dialogs.CreateDeckDialog
@@ -188,7 +192,6 @@ import com.ichi2.anki.utils.ext.doOnScrolled
 import com.ichi2.anki.utils.ext.launchCollectionInLifecycleScope
 import com.ichi2.anki.utils.ext.positionIsVisible
 import com.ichi2.anki.utils.ext.setFragmentResultListener
-import com.ichi2.anki.utils.ext.setImageDrawableSafe
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.widgets.DeckAdapter
 import com.ichi2.anki.widgets.DeckHierarchyLinesDecoration
@@ -290,6 +293,7 @@ open class DeckPicker :
 
     private lateinit var decksLayoutManager: LinearLayoutManager
     private lateinit var deckListAdapter: DeckAdapter
+    private val backgroundFailureToastState = BackgroundFailureToastState()
     private lateinit var pullToSyncWrapper: SwipeRefreshLayout
 
     @VisibleForTesting
@@ -563,7 +567,14 @@ open class DeckPicker :
             )
         }
 
-        lifecycleScope.launch { applyDeckPickerBackground() }
+        installDeckPickerBackgroundLoader(
+            lifecycle,
+            DeckPickerBackgroundLoader(
+                scope = lifecycleScope,
+                load = { BackgroundImage.resolve(this) },
+                apply = { applyDeckPickerBackground(it) },
+            ),
+        )
 
         setupPullToSync()
         // Setup the FloatingActionButtons
@@ -1135,18 +1146,16 @@ open class DeckPicker :
         showDatabaseErrorDialog(DatabaseErrorDialogType.DIALOG_DISK_FULL)
     }
 
-    private suspend fun applyDeckPickerBackground() {
-        val result = BackgroundImage.resolve(this)
-        if (result is BackgroundImage.ResolveResult.Failure) {
-            showThemedToast(this, result.message(this), shortLength = false)
-        }
-        val drawable = (result as? BackgroundImage.ResolveResult.Ready)?.drawable
-        val applied =
-            deckPickerBinding.background.setImageDrawableSafe(drawable) {
-                showThemedToast(this, getString(R.string.background_image_too_large), shortLength = false)
-            }
-        // activityHasBackground calls notifyDataSetChanged, ensure only 1 call
-        deckListAdapter.activityHasBackground = applied && drawable != null
+    @VisibleForTesting
+    internal fun applyDeckPickerBackground(result: BackgroundImage.ResolveResult?) {
+        deckListAdapter.activityHasBackground =
+            applyLoadedDeckPickerBackground(
+                context = this,
+                imageView = deckPickerBinding.background,
+                result = result,
+                toastState = backgroundFailureToastState,
+                currentHasBackground = deckListAdapter.activityHasBackground,
+            )
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/BackgroundImage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/BackgroundImage.kt
@@ -120,7 +120,7 @@ object BackgroundImage {
             val drawable =
                 withContext(Dispatchers.IO) {
                     // 6608 - OOM should be catchable here.
-                    Drawable.createFromPath(imgFile.absolutePath)
+                    decodeDeckPickerBackground(context, imgFile, size.width, size.height)
                 }
             if (drawable != null) ResolveResult.Ready(drawable) else ResolveResult.None
         } catch (e: OutOfMemoryError) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/BackgroundImageDecode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/BackgroundImageDecode.kt
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.deckpicker
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.drawable.Drawable
+import androidx.core.graphics.drawable.toDrawable
+import com.ichi2.utils.BitmapUtil
+import com.ichi2.utils.ImageAlpha
+import java.io.File
+
+internal fun decodeDeckPickerBackground(
+    context: Context,
+    imageFile: File,
+    srcWidth: Int,
+    srcHeight: Int,
+): Drawable? {
+    val metrics = context.resources.displayMetrics
+    return bitmapToBackgroundDrawable(
+        context,
+        decodeSubsampledBackgroundBitmap(
+            file = imageFile,
+            srcWidth = srcWidth,
+            srcHeight = srcHeight,
+            reqWidth = metrics.widthPixels,
+            reqHeight = metrics.heightPixels,
+        ),
+    )
+}
+
+internal fun bitmapToBackgroundDrawable(
+    context: Context,
+    bitmap: Bitmap?,
+): Drawable? {
+    bitmap ?: return null
+    return bitmap.toDrawable(context.resources)
+}
+
+internal fun decodeSubsampledBackgroundBitmap(
+    file: File,
+    srcWidth: Int,
+    srcHeight: Int,
+    reqWidth: Int,
+    reqHeight: Int,
+    decodeFile: (String, BitmapFactory.Options) -> Bitmap? = { path, options ->
+        BitmapFactory.decodeFile(path, options)
+    },
+): Bitmap? {
+    val options = BitmapFactory.Options()
+    options.inSampleSize = BitmapUtil.calculateInSampleSize(srcWidth, srcHeight, reqWidth, reqHeight)
+    options.inPreferredConfig = BitmapUtil.preferredConfig(ImageAlpha.hasAlpha(file))
+    return decodeFile(file.absolutePath, options)
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerBackgroundApply.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerBackgroundApply.kt
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.deckpicker
+
+import android.content.Context
+import android.widget.ImageView
+import com.ichi2.anki.R
+import com.ichi2.anki.common.utils.android.showThemedToast
+import com.ichi2.anki.utils.ext.setImageDrawableSafe
+
+/**
+ * RecyclerView uses `activityHasBackground` to skip per-row colors. Clearing the drawable on
+ * stop must not flip that flag, which would notify the list adapter while stopped.
+ *
+ * @param drawableApplied `true`/`false` after a resolve attempt; `null` when clearing on stop.
+ */
+fun nextActivityHasBackground(
+    current: Boolean,
+    drawableApplied: Boolean?,
+): Boolean = drawableApplied ?: current
+
+/**
+ * Failure/too-large toasts for the DeckPicker background. Shown at most once per activity instance
+ * so returning from the reviewer does not re-toast the same problem.
+ */
+class BackgroundFailureToastState {
+    private var toasted = false
+
+    fun shouldToast(): Boolean {
+        if (toasted) return false
+        toasted = true
+        return true
+    }
+}
+
+/**
+ * Applies a [BackgroundImage.ResolveResult] (or `null` to clear on stop) to [imageView].
+ *
+ * @return the next `activityHasBackground` value
+ */
+fun applyLoadedDeckPickerBackground(
+    context: Context,
+    imageView: ImageView,
+    result: BackgroundImage.ResolveResult?,
+    toastState: BackgroundFailureToastState,
+    currentHasBackground: Boolean,
+): Boolean {
+    if (result == null) {
+        imageView.setImageDrawableSafe(null)
+        return nextActivityHasBackground(currentHasBackground, drawableApplied = null)
+    }
+    if (result is BackgroundImage.ResolveResult.Failure && toastState.shouldToast()) {
+        showThemedToast(context, result.message(context), shortLength = false)
+    }
+    val drawable = (result as? BackgroundImage.ResolveResult.Ready)?.drawable
+    val applied =
+        imageView.setImageDrawableSafe(drawable) {
+            if (toastState.shouldToast()) {
+                showThemedToast(context, context.getString(R.string.background_image_too_large), shortLength = false)
+            }
+        }
+    return nextActivityHasBackground(
+        current = currentHasBackground,
+        drawableApplied = applied && drawable != null,
+    )
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerBackgroundLoader.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerBackgroundLoader.kt
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.deckpicker
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+/**
+ * Keeps a loaded DeckPicker background in memory only while the screen is started.
+ *
+ * [onStart] cancels any prior load, then loads and [apply]s the result.
+ * [onStop] cancels an in-flight load and [apply]s `null` so the caller can drop the bitmap.
+ * A load that completes after [onStop] is not applied, even if [load] ignores cancellation.
+ */
+class DeckPickerBackgroundLoader<T>(
+    private val scope: CoroutineScope,
+    private val load: suspend () -> T,
+    private val apply: (T?) -> Unit,
+) {
+    private var loadJob: Job? = null
+    private var generation: Long = 0L
+
+    fun onStart() {
+        loadJob?.cancel()
+        val expectedGeneration = ++generation
+        loadJob =
+            scope.launch {
+                val result = load()
+                if (expectedGeneration != generation) return@launch
+                apply(result)
+            }
+    }
+
+    fun onStop() {
+        generation++
+        loadJob?.cancel()
+        loadJob = null
+        apply(null)
+    }
+}
+
+/** Forwards [Lifecycle.Event.ON_START] / [Lifecycle.Event.ON_STOP] to [loader]. */
+class DeckPickerBackgroundLifecycleObserver<T>(
+    private val loader: DeckPickerBackgroundLoader<T>,
+) : DefaultLifecycleObserver {
+    override fun onStart(owner: LifecycleOwner) {
+        loader.onStart()
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        loader.onStop()
+    }
+}
+
+fun installDeckPickerBackgroundLoader(
+    lifecycle: Lifecycle,
+    loader: DeckPickerBackgroundLoader<*>,
+) {
+    lifecycle.addObserver(DeckPickerBackgroundLifecycleObserver(loader))
+}

--- a/AnkiDroid/src/main/java/com/ichi2/utils/BitmapUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/BitmapUtil.kt
@@ -139,4 +139,35 @@ object BitmapUtil {
         }
         return inSampleSize
     }
+
+    /**
+     * Largest power-of-two [BitmapFactory.Options.inSampleSize] that keeps both decoded
+     * dimensions at least as large as the requested size (suitable for `centerCrop`).
+     */
+    @CheckResult
+    fun calculateInSampleSize(
+        srcWidth: Int,
+        srcHeight: Int,
+        reqWidth: Int,
+        reqHeight: Int,
+    ): Int {
+        if (reqWidth <= 0 || reqHeight <= 0 || srcWidth <= 0 || srcHeight <= 0) {
+            return 1
+        }
+        var inSampleSize = 1
+        val halfWidth = srcWidth / 2
+        val halfHeight = srcHeight / 2
+        while (
+            inSampleSize <= Int.MAX_VALUE / 2 &&
+            halfHeight / inSampleSize >= reqHeight &&
+            halfWidth / inSampleSize >= reqWidth
+        ) {
+            inSampleSize *= 2
+        }
+        return inSampleSize
+    }
+
+    /** RGB_565 is only used when the source has no alpha. */
+    @CheckResult
+    fun preferredConfig(hasAlpha: Boolean): Bitmap.Config = if (hasAlpha) Bitmap.Config.ARGB_8888 else Bitmap.Config.RGB_565
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImageAlpha.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImageAlpha.kt
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.utils
+
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import kotlin.math.min
+
+/** Detects whether an image file has an alpha channel, from headers only. */
+object ImageAlpha {
+    fun hasAlpha(file: File): Boolean =
+        try {
+            file.inputStream().buffered().use { hasAlpha(it) }
+        } catch (_: IOException) {
+            true
+        }
+
+    fun hasAlpha(stream: InputStream): Boolean {
+        val header = readExact(stream, 8) ?: return true
+        return when {
+            isJpeg(header) -> false
+            isPng(header) -> pngHasAlpha(stream)
+            isGif(header) -> true
+            isRiff(header) -> webpHasAlpha(stream)
+            else -> true
+        }
+    }
+
+    private fun isJpeg(header: ByteArray): Boolean = header[0] == 0xFF.toByte() && header[1] == 0xD8.toByte()
+
+    private fun isPng(header: ByteArray): Boolean =
+        header[0] == 0x89.toByte() &&
+            header[1] == 0x50.toByte() &&
+            header[2] == 0x4E.toByte() &&
+            header[3] == 0x47.toByte() &&
+            header[4] == 0x0D.toByte() &&
+            header[5] == 0x0A.toByte() &&
+            header[6] == 0x1A.toByte() &&
+            header[7] == 0x0A.toByte()
+
+    private fun isGif(header: ByteArray): Boolean =
+        header[0] == 0x47.toByte() &&
+            header[1] == 0x49.toByte() &&
+            header[2] == 0x46.toByte() &&
+            header[3] == 0x38.toByte()
+
+    private fun isRiff(header: ByteArray): Boolean =
+        header[0] == 0x52.toByte() &&
+            header[1] == 0x49.toByte() &&
+            header[2] == 0x46.toByte() &&
+            header[3] == 0x46.toByte()
+
+    private fun pngHasAlpha(stream: InputStream): Boolean {
+        while (true) {
+            val lenBytes = readExact(stream, 4) ?: return true
+            val typeBytes = readExact(stream, 4) ?: return true
+            val length = beInt(lenBytes, 0)
+            if (length < 0) return true
+            val type = String(typeBytes, Charsets.US_ASCII)
+            when (type) {
+                "IHDR" -> {
+                    val data = readExact(stream, length) ?: return true
+                    if (length < 10) return true
+                    val colorType = data[9].toInt() and 0xFF
+                    if (colorType == 4 || colorType == 6) {
+                        return true
+                    }
+                    if (!skipExact(stream, 4)) return true
+                }
+                "tRNS" -> return true
+                "IDAT" -> return false
+                "IEND" -> return false
+                else -> {
+                    if (!skipExact(stream, length.toLong() + 4)) return true
+                }
+            }
+        }
+    }
+
+    private fun webpHasAlpha(stream: InputStream): Boolean {
+        val fourCc = readExact(stream, 4) ?: return true
+        if (!fourCc.contentEquals("WEBP".toByteArray(Charsets.US_ASCII))) {
+            return true
+        }
+        val chunkType = readExact(stream, 4) ?: return true
+        val sizeBytes = readExact(stream, 4) ?: return true
+        val size = leInt(sizeBytes, 0)
+        if (size < 0) return true
+        return when (String(chunkType, Charsets.US_ASCII)) {
+            "VP8X" -> {
+                val flags = readExact(stream, 1) ?: return true
+                flags[0].toInt() and 0x10 != 0
+            }
+            "VP8L" -> {
+                val payload = readExact(stream, 5) ?: return true
+                if (payload[0] != 0x2F.toByte()) return true
+                val bits = leInt(payload, 1)
+                bits and (1 shl 28) != 0
+            }
+            "VP8 " -> false
+            else -> true
+        }
+    }
+
+    private fun readExact(
+        stream: InputStream,
+        count: Int,
+    ): ByteArray? {
+        val buffer = ByteArray(count)
+        var offset = 0
+        while (offset < count) {
+            val read = stream.read(buffer, offset, count - offset)
+            if (read < 0) return null
+            offset += read
+        }
+        return buffer
+    }
+
+    private fun skipExact(
+        stream: InputStream,
+        count: Long,
+    ): Boolean {
+        var remaining = count
+        val buf = ByteArray(8192)
+        while (remaining > 0) {
+            val toRead = min(buf.size.toLong(), remaining).toInt()
+            val read = stream.read(buf, 0, toRead)
+            if (read < 0) return false
+            remaining -= read
+        }
+        return true
+    }
+
+    private fun beInt(
+        bytes: ByteArray,
+        offset: Int,
+    ): Int =
+        ((bytes[offset].toInt() and 0xFF) shl 24) or
+            ((bytes[offset + 1].toInt() and 0xFF) shl 16) or
+            ((bytes[offset + 2].toInt() and 0xFF) shl 8) or
+            (bytes[offset + 3].toInt() and 0xFF)
+
+    private fun leInt(
+        bytes: ByteArray,
+        offset: Int,
+    ): Int =
+        (bytes[offset].toInt() and 0xFF) or
+            ((bytes[offset + 1].toInt() and 0xFF) shl 8) or
+            ((bytes[offset + 2].toInt() and 0xFF) shl 16) or
+            ((bytes[offset + 3].toInt() and 0xFF) shl 24)
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/BackgroundImageDecodeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/BackgroundImageDecodeTest.kt
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.deckpicker
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Color
+import android.graphics.drawable.BitmapDrawable
+import androidx.core.graphics.createBitmap
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.EmptyApplicationCategory
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.common.storage.CollectionHelper
+import com.ichi2.anki.settings.Prefs
+import com.ichi2.testutils.EmptyApplication
+import com.ichi2.utils.BitmapUtil
+import kotlinx.coroutines.test.runTest
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.instanceOf
+import org.hamcrest.Matchers.notNullValue
+import org.hamcrest.Matchers.nullValue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowBitmapFactory
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
+class BackgroundImageDecodeTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun decodePassesPowerOfTwoSampleSizeOnOptions() {
+        val file = writePng(width = 400, height = 400, color = Color.BLUE)
+        val options = captureDecodeOptions(file, srcWidth = 400, srcHeight = 400, reqWidth = 100, reqHeight = 100)
+        assertThat(options.inSampleSize, equalTo(4))
+        assertThat(options.inSampleSize, equalTo(BitmapUtil.calculateInSampleSize(400, 400, 100, 100)))
+    }
+
+    @Test
+    fun bitmapToBackgroundDrawableReturnsNullWhenDecodeFails() {
+        assertThat(bitmapToBackgroundDrawable(context, null), nullValue())
+    }
+
+    @Test
+    fun decodeCanReturnNullFromDecoder() {
+        val file = writePng(width = 10, height = 10, color = Color.BLUE)
+        val bitmap =
+            decodeSubsampledBackgroundBitmap(file, 10, 10, 10, 10) { _, _ ->
+                null
+            }
+        assertThat(bitmap, nullValue())
+    }
+
+    @Test
+    fun decodeDrawableUsesDisplayMetricsAndWrapsBitmap() {
+        val metrics = context.resources.displayMetrics
+        metrics.widthPixels = 100
+        metrics.heightPixels = 100
+        val file = writePng(width = 400, height = 400, color = Color.RED)
+        val drawable = decodeDeckPickerBackground(context, file, 400, 400)
+        assertThat(drawable, instanceOf(BitmapDrawable::class.java))
+        val bitmap = (drawable as BitmapDrawable).bitmap
+        assertThat(bitmap.width, equalTo(100))
+        assertThat(bitmap.height, equalTo(100))
+    }
+
+    @Test
+    fun jpegDecodeSetsRgb565OnOptions() {
+        val file = writeJpeg(width = 80, height = 80)
+        val options = captureDecodeOptions(file, srcWidth = 80, srcHeight = 80, reqWidth = 80, reqHeight = 80)
+        assertThat(options.inPreferredConfig, equalTo(Bitmap.Config.RGB_565))
+        assertThat(options.inSampleSize, equalTo(1))
+    }
+
+    @Test
+    fun pngWithTransparencySetsArgb8888OnOptions() {
+        val file = writePng(width = 80, height = 80, color = Color.TRANSPARENT)
+        val options = captureDecodeOptions(file, srcWidth = 80, srcHeight = 80, reqWidth = 80, reqHeight = 80)
+        assertThat(options.inPreferredConfig, equalTo(Bitmap.Config.ARGB_8888))
+        assertThat(options.inSampleSize, equalTo(1))
+    }
+
+    private fun captureDecodeOptions(
+        file: File,
+        srcWidth: Int,
+        srcHeight: Int,
+        reqWidth: Int,
+        reqHeight: Int,
+    ): BitmapFactory.Options {
+        var captured: BitmapFactory.Options? = null
+        decodeSubsampledBackgroundBitmap(file, srcWidth, srcHeight, reqWidth, reqHeight) { _, options ->
+            captured = options
+            null
+        }
+        assertThat(captured, notNullValue())
+        return captured!!
+    }
+
+    private fun writePng(
+        width: Int,
+        height: Int,
+        color: Int,
+    ): File {
+        val file = temporaryFolder.newFile("bg.png")
+        val bitmap = createBitmap(width, height)
+        bitmap.eraseColor(color)
+        file.outputStream().use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+        bitmap.recycle()
+        return file
+    }
+
+    private fun writeJpeg(
+        width: Int,
+        height: Int,
+    ): File {
+        val file = temporaryFolder.newFile("bg.jpg")
+        val bitmap = createBitmap(width, height, Bitmap.Config.RGB_565)
+        bitmap.eraseColor(Color.GREEN)
+        file.outputStream().use { bitmap.compress(Bitmap.CompressFormat.JPEG, 90, it) }
+        bitmap.recycle()
+        return file
+    }
+}
+
+@RunWith(AndroidJUnit4::class)
+class BackgroundImageResolveTest : RobolectricTest() {
+    @Test
+    fun resolveDecodesSubsampledReadyResult() =
+        runTest {
+            Prefs.isBackgroundEnabled = true
+            val dir = CollectionHelper.getCurrentAnkiDroidDirectory(targetContext)
+            dir.mkdirs()
+            val file = File(dir, BackgroundImage.FILENAME)
+            val bitmap = createBitmap(400, 400)
+            bitmap.eraseColor(Color.CYAN)
+            file.outputStream().use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+            bitmap.recycle()
+
+            val metrics = targetContext.resources.displayMetrics
+            metrics.widthPixels = 100
+            metrics.heightPixels = 100
+
+            val result = BackgroundImage.resolve(targetContext)
+            assertThat(result, instanceOf(BackgroundImage.ResolveResult.Ready::class.java))
+            val decoded = ((result as BackgroundImage.ResolveResult.Ready).drawable as BitmapDrawable).bitmap
+            assertThat(decoded.width, equalTo(100))
+            assertThat(decoded.height, equalTo(100))
+        }
+
+    @Test
+    fun resolveReturnsTooLargeWhenSourceExceedsMaxEvenIfSubsampleWouldFit() =
+        runTest {
+            Prefs.isBackgroundEnabled = true
+            val dir = CollectionHelper.getCurrentAnkiDroidDirectory(targetContext)
+            dir.mkdirs()
+            val file = File(dir, BackgroundImage.FILENAME)
+            val bitmap = createBitmap(400, 400)
+            bitmap.eraseColor(Color.CYAN)
+            file.outputStream().use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+            bitmap.recycle()
+
+            val srcWidth = 8192
+            val srcHeight = 8192
+            assertThat(
+                srcWidth.toLong() * srcHeight * BITMAP_BYTES_PER_PIXEL > BackgroundImage.MAX_BITMAP_SIZE,
+                equalTo(true),
+            )
+            val metrics = targetContext.resources.displayMetrics
+            metrics.widthPixels = 100
+            metrics.heightPixels = 100
+            val sampled =
+                srcWidth / BitmapUtil.calculateInSampleSize(srcWidth, srcHeight, metrics.widthPixels, metrics.heightPixels)
+            assertThat(
+                sampled.toLong() * sampled * BITMAP_BYTES_PER_PIXEL > BackgroundImage.MAX_BITMAP_SIZE,
+                equalTo(false),
+            )
+
+            @Suppress("DEPRECATION")
+            ShadowBitmapFactory.provideWidthAndHeightHints(file.absolutePath, srcWidth, srcHeight)
+
+            val result = BackgroundImage.resolve(targetContext)
+            assertThat(result, instanceOf(BackgroundImage.ResolveResult.TooLarge::class.java))
+        }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerBackgroundApplyAndroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerBackgroundApplyAndroidTest.kt
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.deckpicker
+
+import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.Drawable
+import android.widget.ImageView
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.EmptyApplicationCategory
+import com.ichi2.anki.R
+import com.ichi2.testutils.EmptyApplication
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.nullValue
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowToast
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
+class DeckPickerBackgroundApplyAndroidTest {
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun nullResultClearsImageAndKeepsHasBackground() {
+        val imageView = ImageView(context)
+        imageView.setImageDrawable(ColorDrawable(Color.RED))
+        val toastState = BackgroundFailureToastState()
+
+        val next =
+            applyLoadedDeckPickerBackground(
+                context = context,
+                imageView = imageView,
+                result = null,
+                toastState = toastState,
+                currentHasBackground = true,
+            )
+
+        assertThat(next, equalTo(true))
+        assertThat(imageView.drawable, nullValue())
+        assertThat(ShadowToast.shownToastCount(), equalTo(0))
+    }
+
+    @Test
+    fun noneResultClearsHasBackgroundWithoutToast() {
+        val imageView = ImageView(context)
+        val next =
+            applyLoadedDeckPickerBackground(
+                context = context,
+                imageView = imageView,
+                result = BackgroundImage.ResolveResult.None,
+                toastState = BackgroundFailureToastState(),
+                currentHasBackground = true,
+            )
+
+        assertThat(next, equalTo(false))
+        assertThat(ShadowToast.shownToastCount(), equalTo(0))
+    }
+
+    @Test
+    fun readyResultSetsHasBackground() {
+        val imageView = ImageView(context)
+        val drawable = ColorDrawable(Color.BLUE)
+        val next =
+            applyLoadedDeckPickerBackground(
+                context = context,
+                imageView = imageView,
+                result = BackgroundImage.ResolveResult.Ready(drawable),
+                toastState = BackgroundFailureToastState(),
+                currentHasBackground = false,
+            )
+
+        assertThat(next, equalTo(true))
+        assertThat(imageView.drawable, equalTo<Drawable>(drawable))
+        assertThat(ShadowToast.shownToastCount(), equalTo(0))
+    }
+
+    @Test
+    fun failureToastsOnce() {
+        val imageView = ImageView(context)
+        val toastState = BackgroundFailureToastState()
+        val first =
+            applyLoadedDeckPickerBackground(
+                context = context,
+                imageView = imageView,
+                result = BackgroundImage.ResolveResult.TooLarge,
+                toastState = toastState,
+                currentHasBackground = false,
+            )
+        val second =
+            applyLoadedDeckPickerBackground(
+                context = context,
+                imageView = imageView,
+                result = BackgroundImage.ResolveResult.Failed("decode"),
+                toastState = toastState,
+                currentHasBackground = first,
+            )
+
+        assertThat(first, equalTo(false))
+        assertThat(second, equalTo(false))
+        assertThat(ShadowToast.shownToastCount(), equalTo(1))
+        assertThat(
+            ShadowToast.getTextOfLatestToast(),
+            equalTo(context.getString(R.string.background_image_too_large)),
+        )
+    }
+
+    @Test
+    fun failedToastsCause() {
+        val imageView = ImageView(context)
+        applyLoadedDeckPickerBackground(
+            context = context,
+            imageView = imageView,
+            result = BackgroundImage.ResolveResult.Failed("decode"),
+            toastState = BackgroundFailureToastState(),
+            currentHasBackground = false,
+        )
+
+        assertThat(ShadowToast.shownToastCount(), equalTo(1))
+        assertThat(
+            ShadowToast.getTextOfLatestToast(),
+            equalTo(context.getString(R.string.failed_to_apply_background_image, "decode")),
+        )
+    }
+
+    @Test
+    fun oomToastsTooLargeOnce() {
+        val imageView = OomImageView(context)
+        val toastState = BackgroundFailureToastState()
+        val drawable = ColorDrawable(Color.GREEN)
+
+        val first =
+            applyLoadedDeckPickerBackground(
+                context = context,
+                imageView = imageView,
+                result = BackgroundImage.ResolveResult.Ready(drawable),
+                toastState = toastState,
+                currentHasBackground = false,
+            )
+        val second =
+            applyLoadedDeckPickerBackground(
+                context = context,
+                imageView = imageView,
+                result = BackgroundImage.ResolveResult.Ready(drawable),
+                toastState = toastState,
+                currentHasBackground = first,
+            )
+
+        assertThat(first, equalTo(false))
+        assertThat(second, equalTo(false))
+        assertThat(ShadowToast.shownToastCount(), equalTo(1))
+        assertThat(
+            ShadowToast.getTextOfLatestToast(),
+            equalTo(context.getString(R.string.background_image_too_large)),
+        )
+    }
+
+    @Test
+    fun installObserverRunsOnLifecycleStartAndStop() =
+        runTest {
+            val applied = mutableListOf<String?>()
+            val loader =
+                DeckPickerBackgroundLoader(
+                    scope = this,
+                    load = { "background" },
+                    apply = { applied.add(it) },
+                )
+            val owner =
+                object : LifecycleOwner {
+                    override val lifecycle = LifecycleRegistry(this)
+                }
+            installDeckPickerBackgroundLoader(owner.lifecycle, loader)
+
+            owner.lifecycle.currentState = Lifecycle.State.STARTED
+            advanceUntilIdle()
+            owner.lifecycle.currentState = Lifecycle.State.CREATED
+
+            assertThat(applied, equalTo(listOf("background", null)))
+        }
+
+    private class OomImageView(
+        context: Context,
+    ) : ImageView(context) {
+        override fun setImageDrawable(drawable: Drawable?): Unit = throw OutOfMemoryError("test")
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerBackgroundApplyAndroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerBackgroundApplyAndroidTest.kt
@@ -4,9 +4,9 @@ package com.ichi2.anki.deckpicker
 
 import android.content.Context
 import android.graphics.Color
-import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.widget.ImageView
+import androidx.core.graphics.drawable.toDrawable
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
@@ -35,7 +35,7 @@ class DeckPickerBackgroundApplyAndroidTest {
     @Test
     fun nullResultClearsImageAndKeepsHasBackground() {
         val imageView = ImageView(context)
-        imageView.setImageDrawable(ColorDrawable(Color.RED))
+        imageView.setImageDrawable(Color.RED.toDrawable())
         val toastState = BackgroundFailureToastState()
 
         val next =
@@ -71,7 +71,7 @@ class DeckPickerBackgroundApplyAndroidTest {
     @Test
     fun readyResultSetsHasBackground() {
         val imageView = ImageView(context)
-        val drawable = ColorDrawable(Color.BLUE)
+        val drawable = Color.BLUE.toDrawable()
         val next =
             applyLoadedDeckPickerBackground(
                 context = context,
@@ -138,7 +138,7 @@ class DeckPickerBackgroundApplyAndroidTest {
     fun oomToastsTooLargeOnce() {
         val imageView = OomImageView(context)
         val toastState = BackgroundFailureToastState()
-        val drawable = ColorDrawable(Color.GREEN)
+        val drawable = Color.GREEN.toDrawable()
 
         val first =
             applyLoadedDeckPickerBackground(

--- a/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerBackgroundApplyTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerBackgroundApplyTest.kt
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.deckpicker
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+
+class DeckPickerBackgroundApplyTest {
+    @Test
+    fun stopClearDoesNotChangeActivityHasBackground() {
+        assertThat(
+            nextActivityHasBackground(current = true, drawableApplied = null),
+            equalTo(true),
+        )
+        assertThat(
+            nextActivityHasBackground(current = false, drawableApplied = null),
+            equalTo(false),
+        )
+    }
+
+    @Test
+    fun resolveAttemptUpdatesActivityHasBackground() {
+        assertThat(
+            nextActivityHasBackground(current = false, drawableApplied = true),
+            equalTo(true),
+        )
+        assertThat(
+            nextActivityHasBackground(current = true, drawableApplied = false),
+            equalTo(false),
+        )
+    }
+
+    @Test
+    fun failureToastIsConsumedOncePerActivityInstance() {
+        val state = BackgroundFailureToastState()
+        assertThat(state.shouldToast(), equalTo(true))
+        assertThat(state.shouldToast(), equalTo(false))
+        assertThat(state.shouldToast(), equalTo(false))
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerBackgroundLoaderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerBackgroundLoaderTest.kt
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.deckpicker
+
+import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+class DeckPickerBackgroundLoaderTest {
+    @Test
+    fun onStartAppliesLoadedValue() =
+        runTest {
+            val applied = mutableListOf<String?>()
+            val loader =
+                DeckPickerBackgroundLoader(
+                    scope = this,
+                    load = { "background" },
+                    apply = { applied.add(it) },
+                )
+
+            loader.onStart()
+            advanceUntilIdle()
+
+            assertThat(applied, equalTo(listOf("background")))
+        }
+
+    @Test
+    fun onStopClearsToNull() =
+        runTest {
+            val applied = mutableListOf<String?>()
+            val loader =
+                DeckPickerBackgroundLoader(
+                    scope = this,
+                    load = { "background" },
+                    apply = { applied.add(it) },
+                )
+
+            loader.onStart()
+            advanceUntilIdle()
+            loader.onStop()
+
+            assertThat(applied, equalTo(listOf("background", null)))
+        }
+
+    @Test
+    fun onStopWhileLoadSuspendedDoesNotApplyLateResult() =
+        runTest {
+            val gate = CompletableDeferred<String>()
+            val applied = mutableListOf<String?>()
+            val loader =
+                DeckPickerBackgroundLoader(
+                    scope = CoroutineScope(coroutineContext + UnconfinedTestDispatcher(testScheduler)),
+                    load = { gate.await() },
+                    apply = { applied.add(it) },
+                )
+
+            loader.onStart()
+            loader.onStop()
+            gate.complete("late")
+            advanceUntilIdle()
+
+            assertThat(applied, equalTo(listOf(null)))
+        }
+
+    @Test
+    fun onStopWhileNonCancellableLoadDoesNotApplyLateResult() =
+        runTest {
+            val gate = CompletableDeferred<String>()
+            val applied = mutableListOf<String?>()
+            val loader =
+                DeckPickerBackgroundLoader(
+                    scope = CoroutineScope(coroutineContext + UnconfinedTestDispatcher(testScheduler)),
+                    load = {
+                        withContext(NonCancellable) {
+                            gate.await()
+                        }
+                    },
+                    apply = { applied.add(it) },
+                )
+
+            loader.onStart()
+            loader.onStop()
+            gate.complete("late")
+            advanceUntilIdle()
+
+            assertThat(applied, equalTo(listOf(null)))
+        }
+
+    @Test
+    fun onStartAfterOnStopLoadsAgain() =
+        runTest {
+            var loadCount = 0
+            val applied = mutableListOf<String?>()
+            val loader =
+                DeckPickerBackgroundLoader(
+                    scope = this,
+                    load = { "background-${++loadCount}" },
+                    apply = { applied.add(it) },
+                )
+
+            loader.onStart()
+            advanceUntilIdle()
+            loader.onStop()
+            loader.onStart()
+            advanceUntilIdle()
+
+            assertThat(applied, equalTo(listOf("background-1", null, "background-2")))
+            assertThat(loadCount, equalTo(2))
+        }
+
+    @Test
+    fun onStartCancelsInFlightLoad() =
+        runTest {
+            val first = CompletableDeferred<String>()
+            var loads = 0
+            val applied = mutableListOf<String?>()
+            val loader =
+                DeckPickerBackgroundLoader(
+                    scope = CoroutineScope(coroutineContext + UnconfinedTestDispatcher(testScheduler)),
+                    load = {
+                        loads++
+                        if (loads == 1) first.await() else "second"
+                    },
+                    apply = { applied.add(it) },
+                )
+
+            loader.onStart()
+            loader.onStart()
+            first.complete("first")
+            advanceUntilIdle()
+
+            assertThat(applied, equalTo(listOf("second")))
+        }
+
+    @Test
+    fun onStopWithoutOnStartAppliesNull() =
+        runTest {
+            val applied = mutableListOf<String?>()
+            val loader =
+                DeckPickerBackgroundLoader(
+                    scope = this,
+                    load = { "background" },
+                    apply = { applied.add(it) },
+                )
+
+            loader.onStop()
+
+            assertThat(applied, equalTo(listOf(null)))
+        }
+
+    @Test
+    fun lifecycleObserverForwardsStartAndStop() =
+        runTest {
+            val applied = mutableListOf<String?>()
+            val loader =
+                DeckPickerBackgroundLoader(
+                    scope = this,
+                    load = { "background" },
+                    apply = { applied.add(it) },
+                )
+            val observer = DeckPickerBackgroundLifecycleObserver(loader)
+            val owner = mock<LifecycleOwner>()
+
+            observer.onStart(owner)
+            advanceUntilIdle()
+            observer.onStop(owner)
+
+            assertThat(applied, equalTo(listOf("background", null)))
+        }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerBackgroundWiringTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerBackgroundWiringTest.kt
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.deckpicker
+
+import android.content.Intent
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.DeckPicker
+import com.ichi2.anki.R
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.setIntroductionSlidesShown
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.notNullValue
+import org.hamcrest.Matchers.nullValue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.shadows.ShadowToast
+
+@RunWith(AndroidJUnit4::class)
+class DeckPickerBackgroundWiringTest : RobolectricTest() {
+    @Test
+    fun lifecycleAndApplyCoverDeckPickerBackgroundLines() {
+        setIntroductionSlidesShown(true)
+        val controller =
+            Robolectric
+                .buildActivity(DeckPicker::class.java, Intent())
+                .create()
+                .start()
+                .resume()
+                .visible()
+        saveControllerForCleanup(controller)
+        advanceRobolectricLooper()
+
+        val deckPicker = controller.get()
+        val imageView = deckPicker.deckPickerBinding.background
+
+        deckPicker.applyDeckPickerBackground(null)
+        assertThat(imageView.drawable, nullValue())
+
+        val drawable = ColorDrawable(Color.MAGENTA)
+        deckPicker.applyDeckPickerBackground(BackgroundImage.ResolveResult.Ready(drawable))
+        assertThat(imageView.drawable, notNullValue())
+
+        deckPicker.applyDeckPickerBackground(BackgroundImage.ResolveResult.TooLarge)
+        assertThat(ShadowToast.shownToastCount(), equalTo(1))
+        assertThat(
+            ShadowToast.getTextOfLatestToast(),
+            equalTo(targetContext.getString(R.string.background_image_too_large)),
+        )
+
+        deckPicker.applyDeckPickerBackground(BackgroundImage.ResolveResult.Failed("decode"))
+        assertThat(ShadowToast.shownToastCount(), equalTo(1))
+
+        controller.pause().stop()
+        assertThat(imageView.drawable, nullValue())
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerBackgroundWiringTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerBackgroundWiringTest.kt
@@ -4,7 +4,7 @@ package com.ichi2.anki.deckpicker
 
 import android.content.Intent
 import android.graphics.Color
-import android.graphics.drawable.ColorDrawable
+import androidx.core.graphics.drawable.toDrawable
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
@@ -40,7 +40,7 @@ class DeckPickerBackgroundWiringTest : RobolectricTest() {
         deckPicker.applyDeckPickerBackground(null)
         assertThat(imageView.drawable, nullValue())
 
-        val drawable = ColorDrawable(Color.MAGENTA)
+        val drawable = Color.MAGENTA.toDrawable()
         deckPicker.applyDeckPickerBackground(BackgroundImage.ResolveResult.Ready(drawable))
         assertThat(imageView.drawable, notNullValue())
 

--- a/AnkiDroid/src/test/java/com/ichi2/utils/BitmapUtilTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/BitmapUtilTest.kt
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.utils
+
+import android.graphics.Bitmap
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+
+class BitmapUtilTest {
+    @Test
+    fun calculateInSampleSizeRejectsNonPositiveDimensions() {
+        assertThat(BitmapUtil.calculateInSampleSize(100, 100, 0, 100), equalTo(1))
+        assertThat(BitmapUtil.calculateInSampleSize(100, 100, 100, 0), equalTo(1))
+        assertThat(BitmapUtil.calculateInSampleSize(0, 100, 100, 100), equalTo(1))
+        assertThat(BitmapUtil.calculateInSampleSize(100, 0, 100, 100), equalTo(1))
+        assertThat(BitmapUtil.calculateInSampleSize(-1, 100, 100, 100), equalTo(1))
+    }
+
+    @Test
+    fun calculateInSampleSizeKeepsImageThatAlreadyFits() {
+        assertThat(BitmapUtil.calculateInSampleSize(100, 100, 100, 100), equalTo(1))
+        assertThat(BitmapUtil.calculateInSampleSize(50, 80, 100, 100), equalTo(1))
+    }
+
+    @Test
+    fun calculateInSampleSizeDoesNotShrinkWhenOneDimensionWouldFallBelowRequest() {
+        assertThat(BitmapUtil.calculateInSampleSize(400, 100, 100, 100), equalTo(1))
+        assertThat(BitmapUtil.calculateInSampleSize(100, 400, 100, 100), equalTo(1))
+    }
+
+    @Test
+    fun calculateInSampleSizeUsesPowerOfTwoCoveringBothDimensions() {
+        assertThat(BitmapUtil.calculateInSampleSize(400, 400, 150, 150), equalTo(2))
+        assertThat(BitmapUtil.calculateInSampleSize(400, 400, 100, 100), equalTo(4))
+        assertThat(BitmapUtil.calculateInSampleSize(8192, 8192, 1080, 1920), equalTo(4))
+    }
+
+    @Test
+    fun calculateInSampleSizeDoesNotOverflowOnHugeSources() {
+        val sample = BitmapUtil.calculateInSampleSize(Int.MAX_VALUE, Int.MAX_VALUE, 1, 1)
+        assertThat(sample >= 1, equalTo(true))
+        assertThat(sample and (sample - 1), equalTo(0))
+    }
+
+    @Test
+    fun preferredConfigDependsOnAlpha() {
+        assertThat(BitmapUtil.preferredConfig(hasAlpha = true), equalTo(Bitmap.Config.ARGB_8888))
+        assertThat(BitmapUtil.preferredConfig(hasAlpha = false), equalTo(Bitmap.Config.RGB_565))
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/utils/ImageAlphaTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ImageAlphaTest.kt
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.utils
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+
+class ImageAlphaTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun emptyStreamIsTreatedAsHavingAlpha() {
+        assertThat(ImageAlpha.hasAlpha(ByteArrayInputStream(byteArrayOf())), equalTo(true))
+    }
+
+    @Test
+    fun jpegHasNoAlpha() {
+        assertThat(ImageAlpha.hasAlpha(stream(jpeg())), equalTo(false))
+    }
+
+    @Test
+    fun gifIsTreatedAsHavingAlpha() {
+        assertThat(ImageAlpha.hasAlpha(stream("GIF89a!!".toByteArray())), equalTo(true))
+    }
+
+    @Test
+    fun unknownMagicIsTreatedAsHavingAlpha() {
+        assertThat(ImageAlpha.hasAlpha(stream("notimage".toByteArray())), equalTo(true))
+    }
+
+    @Test
+    fun pngColorTypesWithAlpha() {
+        assertThat(ImageAlpha.hasAlpha(stream(png(colorType = 4))), equalTo(true))
+        assertThat(ImageAlpha.hasAlpha(stream(png(colorType = 6))), equalTo(true))
+    }
+
+    @Test
+    fun pngOpaqueColorTypesWithoutTrns() {
+        assertThat(ImageAlpha.hasAlpha(stream(png(colorType = 0))), equalTo(false))
+        assertThat(ImageAlpha.hasAlpha(stream(png(colorType = 2))), equalTo(false))
+        assertThat(ImageAlpha.hasAlpha(stream(png(colorType = 3))), equalTo(false))
+    }
+
+    @Test
+    fun pngTrnsMeansAlpha() {
+        val trns = chunk("tRNS", byteArrayOf(0))
+        assertThat(ImageAlpha.hasAlpha(stream(png(colorType = 2, extra = trns))), equalTo(true))
+    }
+
+    @Test
+    fun pngIendWithoutIdatIsOpaque() {
+        val bytes = pngSignature() + ihdrChunk(colorType = 2) + chunk("IEND", byteArrayOf())
+        assertThat(ImageAlpha.hasAlpha(stream(bytes)), equalTo(false))
+    }
+
+    @Test
+    fun pngAncillaryChunkIsSkipped() {
+        val gamma = chunk("gAMA", ByteArray(4))
+        assertThat(ImageAlpha.hasAlpha(stream(png(colorType = 2, extra = gamma))), equalTo(false))
+    }
+
+    @Test
+    fun pngLargeAncillaryChunkIsSkipped() {
+        val large = chunk("gAMA", ByteArray(9000))
+        assertThat(ImageAlpha.hasAlpha(stream(png(colorType = 2, extra = large))), equalTo(false))
+    }
+
+    @Test
+    fun pngTruncatedChunksAreTreatedAsHavingAlpha() {
+        assertThat(ImageAlpha.hasAlpha(stream(pngSignature())), equalTo(true))
+        assertThat(ImageAlpha.hasAlpha(stream(pngSignature() + byteArrayOf(0, 0))), equalTo(true))
+        val shortIhdr = pngSignature() + intBe(5) + "IHDR".toByteArray() + ByteArray(5)
+        assertThat(ImageAlpha.hasAlpha(stream(shortIhdr)), equalTo(true))
+        val shortIhdrLen = pngSignature() + intBe(5) + "IHDR".toByteArray() + ByteArray(9)
+        assertThat(ImageAlpha.hasAlpha(stream(shortIhdrLen)), equalTo(true))
+        val truncatedIhdrData = pngSignature() + intBe(13) + "IHDR".toByteArray() + ByteArray(3)
+        assertThat(ImageAlpha.hasAlpha(stream(truncatedIhdrData)), equalTo(true))
+        val truncatedCrc =
+            pngSignature() + intBe(13) + "IHDR".toByteArray() +
+                ByteArray(13).also {
+                    it[8] = 8
+                    it[9] = 2
+                } + byteArrayOf(0, 0)
+        assertThat(ImageAlpha.hasAlpha(stream(truncatedCrc)), equalTo(true))
+        val truncatedAncillary = pngSignature() + ihdrChunk(colorType = 2) + intBe(10) + "gAMA".toByteArray() + byteArrayOf(1)
+        assertThat(ImageAlpha.hasAlpha(stream(truncatedAncillary)), equalTo(true))
+    }
+
+    @Test
+    fun pngNegativeLengthIsTreatedAsHavingAlpha() {
+        val bytes = pngSignature() + intBe(Int.MIN_VALUE) + "IHDR".toByteArray()
+        assertThat(ImageAlpha.hasAlpha(stream(bytes)), equalTo(true))
+    }
+
+    @Test
+    fun webpVp8xAlphaFlag() {
+        assertThat(ImageAlpha.hasAlpha(stream(webp("VP8X", byteArrayOf(0x10)))), equalTo(true))
+        assertThat(ImageAlpha.hasAlpha(stream(webp("VP8X", byteArrayOf(0x00)))), equalTo(false))
+    }
+
+    @Test
+    fun webpVp8lAlphaBit() {
+        assertThat(ImageAlpha.hasAlpha(stream(webp("VP8L", vp8lPayload(hasAlpha = true)))), equalTo(true))
+        assertThat(ImageAlpha.hasAlpha(stream(webp("VP8L", vp8lPayload(hasAlpha = false)))), equalTo(false))
+        assertThat(ImageAlpha.hasAlpha(stream(webp("VP8L", byteArrayOf(0x00) + ByteArray(4)))), equalTo(true))
+    }
+
+    @Test
+    fun webpLossyHasNoAlpha() {
+        assertThat(ImageAlpha.hasAlpha(stream(webp("VP8 ", byteArrayOf(1)))), equalTo(false))
+    }
+
+    @Test
+    fun webpUnknownOrInvalidIsTreatedAsHavingAlpha() {
+        assertThat(ImageAlpha.hasAlpha(stream(webp("ANIM", byteArrayOf(1)))), equalTo(true))
+        val riffWave = "RIFF".toByteArray() + intLe(4) + "WAVE".toByteArray()
+        assertThat(ImageAlpha.hasAlpha(stream(riffWave)), equalTo(true))
+        val truncatedWebp = "RIFF".toByteArray() + intLe(4)
+        assertThat(ImageAlpha.hasAlpha(stream(truncatedWebp)), equalTo(true))
+        val noChunk = "RIFF".toByteArray() + intLe(4) + "WEBP".toByteArray()
+        assertThat(ImageAlpha.hasAlpha(stream(noChunk)), equalTo(true))
+        val noSize = "RIFF".toByteArray() + intLe(4) + "WEBP".toByteArray() + "VP8X".toByteArray()
+        assertThat(ImageAlpha.hasAlpha(stream(noSize)), equalTo(true))
+        val negativeSize = "RIFF".toByteArray() + intLe(4) + "WEBP".toByteArray() + "VP8X".toByteArray() + intLe(Int.MIN_VALUE)
+        assertThat(ImageAlpha.hasAlpha(stream(negativeSize)), equalTo(true))
+        val vp8xNoFlags = "RIFF".toByteArray() + intLe(4) + "WEBP".toByteArray() + "VP8X".toByteArray() + intLe(1)
+        assertThat(ImageAlpha.hasAlpha(stream(vp8xNoFlags)), equalTo(true))
+        val vp8lShort = "RIFF".toByteArray() + intLe(4) + "WEBP".toByteArray() + "VP8L".toByteArray() + intLe(1)
+        assertThat(ImageAlpha.hasAlpha(stream(vp8lShort)), equalTo(true))
+    }
+
+    @Test
+    fun fileOverloadAndIoFailure() {
+        val file = temporaryFolder.newFile("bg.jpg")
+        file.writeBytes(jpeg())
+        assertThat(ImageAlpha.hasAlpha(file), equalTo(false))
+
+        val dir = temporaryFolder.newFolder("not-a-file")
+        assertThat(ImageAlpha.hasAlpha(dir), equalTo(true))
+    }
+
+    @Test
+    fun oneByteReadsStillParseJpeg() {
+        assertThat(ImageAlpha.hasAlpha(OneByteAtATimeInputStream(jpeg())), equalTo(false))
+    }
+
+    private fun stream(bytes: ByteArray) = ByteArrayInputStream(bytes)
+
+    private fun jpeg() = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(), 0xE0.toByte(), 1, 2, 3, 4)
+
+    private fun pngSignature() = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
+
+    private fun png(
+        colorType: Int,
+        extra: ByteArray = byteArrayOf(),
+    ): ByteArray = pngSignature() + ihdrChunk(colorType) + extra + chunk("IDAT", byteArrayOf(0))
+
+    private fun ihdrChunk(colorType: Int): ByteArray {
+        val data = ByteArray(13)
+        data[3] = 1
+        data[7] = 1
+        data[8] = 8
+        data[9] = colorType.toByte()
+        return chunk("IHDR", data)
+    }
+
+    private fun chunk(
+        type: String,
+        data: ByteArray,
+    ): ByteArray = intBe(data.size) + type.toByteArray(Charsets.US_ASCII) + data + ByteArray(4)
+
+    private fun webp(
+        chunkType: String,
+        payload: ByteArray,
+    ): ByteArray =
+        "RIFF".toByteArray(Charsets.US_ASCII) +
+            intLe(4) +
+            "WEBP".toByteArray(Charsets.US_ASCII) +
+            chunkType.toByteArray(Charsets.US_ASCII) +
+            intLe(payload.size) +
+            payload
+
+    private fun vp8lPayload(hasAlpha: Boolean): ByteArray {
+        val bits = if (hasAlpha) 1 shl 28 else 0
+        return byteArrayOf(0x2F) + intLe(bits)
+    }
+
+    private fun intBe(value: Int) =
+        byteArrayOf(
+            (value ushr 24).toByte(),
+            (value ushr 16).toByte(),
+            (value ushr 8).toByte(),
+            value.toByte(),
+        )
+
+    private fun intLe(value: Int) =
+        byteArrayOf(
+            value.toByte(),
+            (value ushr 8).toByte(),
+            (value ushr 16).toByte(),
+            (value ushr 24).toByte(),
+        )
+
+    private class OneByteAtATimeInputStream(
+        bytes: ByteArray,
+    ) : InputStream() {
+        private val data = bytes
+        private var index = 0
+
+        override fun read(): Int {
+            if (index >= data.size) return -1
+            return data[index++].toInt() and 0xFF
+        }
+
+        override fun read(
+            b: ByteArray,
+            off: Int,
+            len: Int,
+        ): Int {
+            if (index >= data.size) return -1
+            b[off] = data[index++]
+            return 1
+        }
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Cursor Grok 4.6

## Purpose / Description

Do not keep bitmaps in memory while DeckPicker is not live.

The custom deck-list background was decoded once and left on the `ImageView` for as long as `DeckPicker` stayed in the back stack. After Home (or any cached/background process state) that bitmap still occupied RAM even though nothing was drawing it. Play’s bitmap-memory vital is specifically about that: foreground use is expected; holding decoded bitmaps after the UI is hidden is not.

## Approach

1. **Release when not visible.** Load the background on `ON_START` and drop the `ImageView` drawable on `ON_STOP`, so the decoded bitmap is only referenced while the deck list is started.

2. **While we were there — live-path size.** Even when the list *is* visible, `Drawable.createFromPath` was inflating the full file (centerCrop on a screen-sized view). Decode is now subsampled to display metrics (`inSampleSize`). `RGB_565` is used only when headers show no alpha; images with alpha stay `ARGB_8888`. The existing source-dimension `TooLarge` guard is unchanged.

3. **Connected “flake” that was not timing.** Full `jacocoTestReport` / `connectedPlayDebugAndroidTest` failed on `ReviewerTest#testCustomSchedulerWithCustomData` with Espresso looking for `flashcard_layout_flip` while an `AlertDialog` + `select_dialog_listview` was on screen. That dialog is **ReadText’s TTS locale picker**. Dirty AVD SharedPreferences can leave `tts=true` from an earlier test; autoplay TTS opens the language list over the reviewer. The test also clicked `show_answer` (not on the legacy reviewer), swallowed `NoMatchingViewException`, then tried `flashcard_layout_flip` in the wrong window. In the full suite it could also **Good**-answer a leftover Default-deck card instead of the card it created. Isolation: `tts=false`, click `flashcard_layout_flip` / `flashcard_layout_ease3`, unique per-test deck, `waitUntil` the review is saved. `@Flaky` / `RetryRule(10)` removed.

We aimed for a **minimal** production change **and** **100% coverage of changed product lines**, which meant a lot of tests. Those tests follow harness preference where possible: **JVM first**, **Robolectric** (including `EmptyApplication`) only when Android types are required, **`androidTest` last**. Lifecycle/apply policy is JVM + EmptyApplication + one DeckPicker wiring test; subsample/config/alpha is JVM + a small Robolectric decode/`resolve` set; the TTS/Default-card issue is androidTest-only.

## How Has This Been Tested?

- `./gradlew :AnkiDroid:ktlintCheck` and `./gradlew lintAll ktLintCheck lint-rules:test`
- Narrowed `testPlayDebugUnitTest` for the deckpicker / bitmap / alpha classes
- `./gradlew :AnkiDroid:jacocoUnitTestReport` (implementer) and `./gradlew :AnkiDroid:jacocoTestReport` (reviewer: unit + `connectedPlayDebugAndroidTest`)
- Emulator: **API35_GAPI**, API 35. Connected suite 344 tests, 0 failed on the final review; both `ReviewerTest` custom-scheduler methods passed
- Jacoco HTML/XML: 174/174 changed product executable lines `ci > 0` on the full branch diff vs `main`

## Fixes

N/A (Play bitmap-memory / RAM; no linked issue)

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

No new user-visible strings. Background still shows while the deck list is resumed; it is released when that activity stops.

Assisted-by: Cursor Grok 4.6