### PR TITLE
feat: Worked on improving the preview new cards dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -586,7 +586,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
                 EXTEND_REV -> res.getString(R.string.custom_study_rev_extend)
                 STUDY_FORGOT -> res.getString(R.string.custom_study_forgotten)
                 STUDY_AHEAD -> res.getString(R.string.custom_study_ahead_description)
-                STUDY_PREVIEW -> res.getString(R.string.custom_study_preview_description)
+                STUDY_PREVIEW -> res.getString(R.string.custom_study_preview)
                 STUDY_TAGS -> res.getString(R.string.custom_study_tags)
                 null -> ""
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -286,7 +286,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
 
         binding.detailsText1.text = text1
         // 'review ahead' has a dialog title, so the empty label would only add a blank line
-        binding.detailsText1.isVisible = contextMenuOption != STUDY_AHEAD
+        binding.detailsText1.isVisible = contextMenuOption != STUDY_AHEAD && contextMenuOption != STUDY_PREVIEW
         binding.detailsText2.text = text2
 
         binding.cardsStateSelectorLayout.isVisible = contextMenuOption == STUDY_TAGS
@@ -326,7 +326,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
             if (contextMenuOption == EXTEND_NEW || contextMenuOption == EXTEND_REV) {
                 inputType = EditorInfo.TYPE_CLASS_NUMBER or EditorInfo.TYPE_NUMBER_FLAG_SIGNED
             }
-            if (contextMenuOption == STUDY_AHEAD) {
+            if (contextMenuOption == STUDY_AHEAD || contextMenuOption == STUDY_PREVIEW) {
                 inputType = EditorInfo.TYPE_CLASS_NUMBER
                 filters += arrayOf(InputFilter.LengthFilter(5), NonLeadingZeroInputFilter)
                 setSuffixText(defaultValue.toInt())
@@ -335,7 +335,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
         val positiveBtnLabel =
             if (contextMenuOption == STUDY_TAGS) {
                 TR.sentenceCase.chooseTags
-            } else if (contextMenuOption == STUDY_AHEAD) {
+            } else if (contextMenuOption == STUDY_AHEAD || contextMenuOption == STUDY_PREVIEW) {
                 getString(R.string.dialog_positive_create)
             } else {
                 getString(R.string.dialog_ok)
@@ -349,7 +349,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
             AlertDialog
                 .Builder(requireActivity())
                 .apply {
-                    if (contextMenuOption == STUDY_AHEAD) {
+                    if (contextMenuOption == STUDY_AHEAD || contextMenuOption == STUDY_PREVIEW) {
                         title(text = contextMenuOption.getTitle(resources))
                     }
                 }.customView(
@@ -421,7 +421,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
                 }
                 launchCustomStudy(contextMenuOption, n)
             }
-            if (contextMenuOption == STUDY_AHEAD) {
+            if (contextMenuOption == STUDY_AHEAD || contextMenuOption == STUDY_PREVIEW) {
                 // the stored default may match no cards
                 searchJob = launchCatchingTask { updateCreateButtonState(dialog, userInputValue) }
             }
@@ -429,7 +429,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
 
         binding.detailsEditText2.doAfterTextChanged {
             val value = userInputValue
-            if (contextMenuOption != STUDY_AHEAD) {
+            if (contextMenuOption != STUDY_AHEAD && contextMenuOption != STUDY_PREVIEW) {
                 dialog.positiveButton.isEnabled = value != null && value != 0
                 return@doAfterTextChanged
             }
@@ -448,6 +448,18 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
         binding.detailsEditText2Layout.suffixText = resources.getQuantityString(R.plurals.set_due_date_label_suffix, days)
     }
 
+    /** Whether the deck has new cards added in the last [days] days */
+    private suspend fun hasPreviewCards(days: Int): Boolean =
+        withCol {
+            val search =
+                listOf(
+                    SearchNode.newBuilder().setDeck(decks.name(viewModel.deckId)).build(),
+                    "is:new",
+                    "added:$days",
+                )
+            findCards(buildSearchString(search)).isNotEmpty()
+        }
+
     /** Enables 'Create' only if some cards would be reviewed ahead by [days] */
     private suspend fun updateCreateButtonState(
         dialog: AlertDialog,
@@ -458,7 +470,11 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
             dialog.positiveButton.isEnabled = false
             return
         }
-        val hasCards = hasCardsDueWithin(days)
+        val hasCards =
+            when (selectedSubDialog) {
+                STUDY_PREVIEW -> hasPreviewCards(days)
+                else -> hasCardsDueWithin(days)
+            }
         binding.detailsEditText2Layout.error = if (hasCards) null else TR.customStudyNoCardsMatchedTheCriteriaYou()
         dialog.positiveButton.isEnabled = hasCards
     }
@@ -570,7 +586,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
                 EXTEND_REV -> res.getString(R.string.custom_study_rev_extend)
                 STUDY_FORGOT -> res.getString(R.string.custom_study_forgotten)
                 STUDY_AHEAD -> res.getString(R.string.custom_study_ahead_description)
-                STUDY_PREVIEW -> res.getString(R.string.custom_study_preview)
+                STUDY_PREVIEW -> res.getString(R.string.custom_study_preview_description)
                 STUDY_TAGS -> res.getString(R.string.custom_study_tags)
                 null -> ""
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -33,11 +33,13 @@ import anki.scheduler.CustomStudyRequest.Cram.CramKind
 import anki.scheduler.copy
 import anki.scheduler.customStudyRequest
 import anki.search.SearchNode
+import anki.search.searchNode
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.asyncIO
+import com.ichi2.anki.browser.search.CardState
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
@@ -448,14 +450,18 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
         binding.detailsEditText2Layout.suffixText = resources.getQuantityString(R.plurals.set_due_date_label_suffix, days)
     }
 
-    /** Whether the deck has new cards added in the last [days] days */
+    /**
+     * Whether the deck has new cards added in the last [days] days.
+     *
+     * Upstream: https://github.com/ankitects/anki/blob/main/qt/aqt/customstudy.py
+     */
     private suspend fun hasPreviewCards(days: Int): Boolean =
         withCol {
             val search =
                 listOf(
-                    SearchNode.newBuilder().setDeck(decks.name(viewModel.deckId)).build(),
-                    "is:new",
-                    "added:$days",
+                    searchNode { deck = decks.name(viewModel.deckId) },
+                    CardState.New.toSearchNode(),
+                    searchNode { addedInDays = days },
                 )
             findCards(buildSearchString(search)).isNotEmpty()
         }

--- a/AnkiDroid/src/main/res/layout/fragment_custom_study.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_custom_study.xml
@@ -31,7 +31,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="start"
-        android:layout_marginBottom="16dip"
+        android:layout_marginBottom="4dip"
         android:layout_marginStart="4dip"
         android:layout_weight="4"
         android:gravity="start|center"

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -37,8 +37,7 @@
     <string name="custom_study_rev_extend">Increase/decrease (“-3”) today’s review limit by</string>
     <string name="custom_study_forgotten">Review cards forgotten in last x days:</string>
     <string name="custom_study_ahead_description">Review cards due in the next:</string>
-    <string name="custom_study_preview">Preview new cards added in the last x days:</string>
-    <string name="custom_study_preview_description">Preview new cards added in the last:</string>
+    <string name="custom_study_preview">Preview new cards added in the last:</string>
     <string name="custom_study_tags">Select x cards from the deck:</string>
 
     <string name="storage_full_title">Storage full</string>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -38,6 +38,7 @@
     <string name="custom_study_forgotten">Review cards forgotten in last x days:</string>
     <string name="custom_study_ahead_description">Review cards due in the next:</string>
     <string name="custom_study_preview">Preview new cards added in the last x days:</string>
+    <string name="custom_study_preview_description">Preview new cards added in the last:</string>
     <string name="custom_study_tags">Select x cards from the deck:</string>
 
     <string name="storage_full_title">Storage full</string>

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,6 +28,8 @@ org.gradle.configuration-cache.parallel=true
 
 # Enable file system watching (should reduce disk IO and increase incremental build speed).
 org.gradle.vfs.watch=true
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true
 
 # Enable Kotlin support for Android test fixtures
 android.experimental.enableTestFixturesKotlinSupport=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,8 +28,6 @@ org.gradle.configuration-cache.parallel=true
 
 # Enable file system watching (should reduce disk IO and increase incremental build speed).
 org.gradle.vfs.watch=true
-# Enabled parallel sync for Gradle 9.4+
-org.gradle.tooling.parallel=true
 
 # Enable Kotlin support for Android test fixtures
 android.experimental.enableTestFixturesKotlinSupport=true


### PR DESCRIPTION
https://github.com/user-attachments/assets/d14d06c0-39e6-4dda-bd02-964723c55851

## Purpose / Description
Improves the **"Preview new cards"** Custom Study dialog.

Specifically:

- Adds a proper dialog title (**"Preview new cards"**).
- Updates description text to **"Preview new cards added in the last:"**.
- Adds dynamic **"day" / "days"** unit suffix to the input box.
- Changes the positive action button label from **"OK"** to **"Create"**.
- Implements real-time criteria validation: if no cards match the entered timeframe, a red error message (**"No cards matched the criteria you provided."**) is displayed in the text field and the **"Create"** button is disabled, avoiding unnecessary error dialogs after submission.
- Polishes layout spacing between description text and the input field.

## Fixes
* Fixes #21779

## Approach
1. **UI Polish & String Updates**:
   - Changed `custom_study_preview` text to "Preview new cards added in the last:" in `03-dialogs.xml` and wired it up to `STUDY_PREVIEW` in `CustomStudyDialog.kt`.
   - Updated `buildInputDialog` in `CustomStudyDialog.kt` to set the dialog title for `STUDY_PREVIEW` using `contextMenuOption.getTitle(...)` ("Preview new cards").
   - Updated `positiveBtnLabel` to use `R.string.dialog_positive_create` ("Create") for `STUDY_PREVIEW`.
   - Adjusted `android:layout_marginBottom` in `fragment_custom_study.xml` from `16dip` to `4dip` to reduce vertical distance between description text and input box.

2. **Suffix Unit & Validation Logic**:
   - Configured `detailsEditText2` to apply `setSuffixText(...)` (`R.plurals.set_due_date_label_suffix`) dynamically for `STUDY_PREVIEW` both initially and inside `doAfterTextChanged`.
   - Added `hasPreviewCards(days: Int)` helper using Anki search query `is:new added:x` for the selected deck.
   - Updated `updateCreateButtonState(...)` and `setOnShowListener` to check `hasPreviewCards` on launch and on text change, disabling "Create" and showing error layout if no matching cards are found.

## How Has This Been Tested?
## Phone tested on: Techno spark 30c
- **Manual Verification**:
  - Opened the "Preview new cards" dialog from the DeckPicker context menu.
  - Confirmed the title **"Preview new cards"**, description text **"Preview new cards added in the last:"**, button label **"Create"**, and input suffix **"day"/"days"** render properly.
  - Tested typing different numbers (`1` -> `1 day`, `5` -> `5 days`, `0` -> `"Minimum value is 1"` error).
  - Tested entering a duration with no new cards added -> confirmed red warning text *"No cards matched the criteria you provided."* displays and **"Create"** button is disabled.