### PR TITLE
fix(sentence-case): add 'Creating backup…'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1453,7 +1453,7 @@ open class DeckPicker :
 
     private fun createBackup() {
         launchCatchingTask {
-            withProgress(message = TR.profilesCreatingBackup()) {
+            withProgress(message = TR.sentenceCase.creatingBackup) {
                 performBackupInBackground(true)
             }
             showThemedToast(this@DeckPicker, TR.profilesBackupCreated(), false)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
@@ -118,6 +118,12 @@ class SentenceCaseTest : RobolectricTest() {
                     assertThat("syncMediaLogTitle", TR.syncMediaLogTitle(), equalTo("Media Sync Log"))
                     assertThat(TR.sentenceCase.mediaSyncLog, equalTo("Media sync log"))
 
+                    // Anki Desktop uses '...', our resources use the ellipsis character
+                    assertThat("profilesCreatingBackup", TR.profilesCreatingBackup(), equalTo("Creating Backup..."))
+                    assertThat(TR.sentenceCase.creatingBackup, equalTo("Creating backup…"))
+                    assertThat("Creating Backup...".toSentenceCase(this, R.string.sentence_creating_backup), equalTo("Creating backup…"))
+                    assertThat("Creating Backup…".toSentenceCase(this, R.string.sentence_creating_backup), equalTo("Creating backup…"))
+
                     assertThat("Toggle Suspend".toSentenceCase(this, R.string.sentence_toggle_suspend), equalTo("Toggle suspend"))
                     assertThat("Ook? Ook?".toSentenceCase(this, R.string.sentence_toggle_suspend), equalTo("Ook? Ook?"))
                 }

--- a/anki-common/src/main/kotlin/com/ichi2/anki/ui/internationalization/SentenceCase.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/ui/internationalization/SentenceCase.kt
@@ -34,8 +34,7 @@ fun String.toSentenceCase(
     @StringRes resId: Int,
 ): String {
     val resString = context.getString(resId)
-    // lowercase both for the comparison: sentence case doesn't mean all words are lowercase
-    if (this.equals(resString, ignoreCase = true)) return resString
+    if (this.matchesSentenceCaseResource(resString)) return resString
     return this
 }
 
@@ -44,9 +43,18 @@ fun String.toSentenceCase(
     @StringRes resId: Int,
 ): String {
     val resString = resources.getString(resId)
-    // lowercase both for the comparison: sentence case doesn't mean all words are lowercase
-    if (this.equals(resString, ignoreCase = true)) return resString
+    if (this.matchesSentenceCaseResource(resString)) return resString
     return this
+}
+
+/**
+ * Whether this string is [resString], ignoring the differences which `sentence-case.xml` exists to fix
+ */
+private fun String.matchesSentenceCaseResource(resString: String): Boolean {
+    // TranslationTypo: our resources must use the ellipsis character
+    val normalized = this.replace("...", "\u2026")
+    // lowercase both for the comparison: sentence case doesn't mean all words are lowercase
+    return normalized.equals(resString, ignoreCase = true)
 }
 
 /**
@@ -359,6 +367,9 @@ object SentenceCase {
 
     context(_: Context)
     val keepEditing get() = TR.addingKeepEditing().toSentenceCase(R.string.sentence_keep_editing)
+
+    context(_: Context)
+    val creatingBackup get() = TR.profilesCreatingBackup().toSentenceCase(R.string.sentence_creating_backup)
 }
 
 /**

--- a/anki-common/src/main/res/values/sentence-case.xml
+++ b/anki-common/src/main/res/values/sentence-case.xml
@@ -85,4 +85,5 @@ undoActionUndone()
     <string name="sentence_copy_to_clipboard">Copy to clipboard</string>
     <string name="sentence_no_flag">No flag</string>
     <string name="sentence_keep_editing">Keep editing</string>
+    <string name="sentence_creating_backup">Creating backup…</string>
 </resources>


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Assisted-by: Claude Fable 5.1

## Purpose / Description
Handle the sentence cased backend via fixing the ellipsis.

## Fixes
* Fixes #15760 🚀

## Approach
Special-case rewriting `...` to `…`

## How Has This Been Tested?
Unit tested

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)