### PR TITLE
fix(card-browser): keep the list above the keyboard

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -38,7 +38,9 @@ import androidx.core.view.MenuHost
 import androidx.core.view.MenuHostHelper
 import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsCompat.Type.displayCutout
+import androidx.core.view.WindowInsetsCompat.Type.ime
+import androidx.core.view.WindowInsetsCompat.Type.systemBars
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
 import androidx.core.widget.doAfterTextChanged
@@ -482,13 +484,10 @@ class CardBrowserFragment :
         val browserScroller = root.findViewById<RecyclerFastScroller>(R.id.browser_scroller)
         val toolbarContainer = root.findViewById<View?>(R.id.toolbar_container)
         ViewCompat.setOnApplyWindowInsetsListener(root) { v, insets ->
-            val bars =
-                insets.getInsets(
-                    WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout(),
-                )
+            val bars = insets.getInsets(systemBars() or displayCutout() or ime())
             v.updatePadding(left = bars.left, right = bars.right)
             toolbarContainer?.updatePadding(top = bars.top)
-            // The bottom of the safe area is above the navigation bar and rounded display corners.
+            // The bottom of the safe area is above the navigation bar, rounded display corners and keyboard.
             // When scrolled to the bottom of the scrollbar should be aligned with the last row.
             // Embedded content already ends above the bottom navigation, including its system-bar inset.
             val safeAreaBottom =
@@ -540,7 +539,7 @@ class CardBrowserFragment :
 
                 fun isKeyboardVisible(view: View?): Boolean =
                     view?.let {
-                        ViewCompat.getRootWindowInsets(it)?.isVisible(WindowInsetsCompat.Type.ime())
+                        ViewCompat.getRootWindowInsets(it)?.isVisible(ime())
                     } ?: false
 
                 override fun onCreateMenu(

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserScreenshotTest.kt
@@ -10,6 +10,7 @@ import androidx.core.view.RoundedCornerCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsCompat.Type.displayCutout
+import androidx.core.view.WindowInsetsCompat.Type.ime
 import androidx.core.view.WindowInsetsCompat.Type.navigationBars
 import androidx.core.view.WindowInsetsCompat.Type.statusBars
 import androidx.recyclerview.widget.RecyclerView
@@ -128,6 +129,25 @@ class CardBrowserScreenshotTest : ScreenshotTest() {
         }
 
     @Test
+    fun cardBrowserKeyboardScrolledToBottom() =
+        withCardBrowser(noteCount = 50) { browser ->
+            requireNotNull(browser.cardBrowserFragment.searchItem).expandActionView()
+            advanceRobolectricLooper()
+            browser.simulateKeyboard()
+
+            val list = browser.findViewById<RecyclerView>(R.id.card_browser_list)
+            list.scrollToPosition(49)
+            while (list.canScrollVertically(1)) list.scrollBy(0, 50)
+            advanceRobolectricLooper()
+
+            // keep the auto-hiding fast scroller visible for the capture
+            browser.findViewById<RecyclerFastScroller>(R.id.browser_scroller).show(animate = false)
+            advanceRobolectricLooper()
+
+            captureScreen("keyboard_scrolled_to_bottom")
+        }
+
+    @Test
     fun multiselect() =
         runTest {
             val browser = getBrowserWithNotes(noteCount = 1)
@@ -164,6 +184,35 @@ class CardBrowserScreenshotTest : ScreenshotTest() {
             FrameLayout.LayoutParams(
                 FrameLayout.LayoutParams.MATCH_PARENT,
                 navBarHeight.toPx(targetContext),
+                Gravity.BOTTOM,
+            ),
+        )
+    }
+
+    /** As [simulateNavigationBar], but with the keyboard open over it */
+    private fun CardBrowser.simulateKeyboard() {
+        val keyboardHeight = 300.dp
+        val insets =
+            with(targetContext) {
+                WindowInsetsCompat
+                    .Builder()
+                    .setInsets(statusBars(), insetsOf(top = 24.dp))
+                    .setInsets(navigationBars(), insetsOf(bottom = 48.dp))
+                    .setInsets(ime(), insetsOf(bottom = keyboardHeight))
+                    .build()
+            }
+        ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
+
+        val decor = window.decorView as ViewGroup
+        val keyboardOverlay =
+            View(this).apply {
+                setBackgroundColor(0x80000000.toInt())
+            }
+        decor.addView(
+            keyboardOverlay,
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                keyboardHeight.toPx(targetContext),
                 Gravity.BOTTOM,
             ),
         )


### PR DESCRIPTION

> [!NOTE]
> Assisted-by: Claude Fable 5.1

## Fixes
* Fixes #21796

## Approach
Edge-to-edge disabled `adjustResize`. Fix this by including the ime inset in the bottom safe area.

## How Has This Been Tested?
<img width="3318" height="2483" alt="keyboard_scrolled_to_bottom_compare" src="https://github.com/user-attachments/assets/0ec577d3-d967-472a-8a16-ba6abdc13f9f" />

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)