### PR TITLE
fix(deck-picker): stop obscuring content when keyboard visible 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -54,6 +54,7 @@ import androidx.core.view.OnReceiveContentListener
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsCompat.Type.displayCutout
+import androidx.core.view.WindowInsetsCompat.Type.ime
 import androidx.core.view.WindowInsetsCompat.Type.navigationBars
 import androidx.core.view.WindowInsetsCompat.Type.systemBars
 import androidx.core.view.isVisible
@@ -647,6 +648,17 @@ open class DeckPicker :
 
     /** Applied edge-to-edge insets for the screen */
     private fun setupEdgeToEdge() {
+        /**
+         * The view the deck list rests above: the FAB, or the 'Studied X cards' line while the
+         * FAB is hidden (searching)
+         */
+        fun listAnchor(): View =
+            if (floatingActionButtonBinding.fabMain.isVisible) {
+                floatingActionButtonBinding.fabMain
+            } else {
+                deckPickerBinding.reviewSummaryTextView
+            }
+
         fun setRecyclerViewBottomPaddingAbove(target: View) {
             val recyclerView = deckPickerBinding.decks
             if (recyclerView.height == 0 || target.height == 0) return
@@ -667,6 +679,8 @@ open class DeckPicker :
         // Bottom padding is used. wrap_content meant margin wasn't viable
         ViewCompat.setOnApplyWindowInsetsListener(deckPickerBinding.root) { deckPickerInclude, insets ->
             val bars = insets.getInsets(systemBars() or displayCutout())
+            // edge-to-edge disables adjustResize: the keyboard is cleared via the ime inset
+            val withKeyboard = insets.getInsets(systemBars() or displayCutout() or ime())
             // BottomFadeFrameLayout handles contrast for bottom nav; let the system draw
             // its own scrim when the nav bar is on the side (no manual fade applies there)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -677,13 +691,16 @@ open class DeckPicker :
                 left = bars.left,
                 right = if (fragmented) 0 else bars.right,
             )
-            deckPickerBinding.reviewSummaryTextView.updatePadding(bottom = bars.bottom)
+            deckPickerBinding.reviewSummaryTextView.updatePadding(bottom = withKeyboard.bottom)
 
             val bottomNavView = findViewById<View?>(R.id.bottom_navigation)
             val bottomNavOffset = if (bottomNavView?.isVisible == true) BOTTOM_NAV_HEIGHT_DP.dp.toPx(this) else 0
-            floatingActionButtonBinding.root.updatePadding(bottom = bars.bottom + bottomNavOffset)
+            // the keyboard covers the bottom navigation: clear whichever is taller
+            floatingActionButtonBinding.root.updatePadding(
+                bottom = maxOf(bars.bottom + bottomNavOffset, withKeyboard.bottom),
+            )
 
-            setRecyclerViewBottomPaddingAbove(floatingActionButtonBinding.fabMain)
+            setRecyclerViewBottomPaddingAbove(listAnchor())
             insets
         }
         floatingActionButtonBinding.fabMain.addOnLayoutChangeListener { v, _, _, _, _, _, _, _, _ ->
@@ -692,6 +709,8 @@ open class DeckPicker :
         deckPickerBinding.reviewSummaryTextView.addOnLayoutChangeListener { view, _, _, _, _, _, _, _, _ ->
             // exclude paddingBottom: it holds the edge-to-edge inset, which is already applied
             raiseFabAboveSummary(view.height - view.paddingBottom)
+            // a hidden FAB has no layout passes to follow: the list rests above the summary line
+            if (listAnchor() === view) setRecyclerViewBottomPaddingAbove(view)
         }
         // The summary is hidden until the collection loads.
         // Assume the summary takes up a single line, so it does not 'jump' up on load

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserInsetsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserInsetsTest.kt
@@ -8,6 +8,8 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.ui.RecyclerFastScroller
 import com.ichi2.testutils.dispatchInsets
+import com.ichi2.testutils.lastItemView
+import com.ichi2.testutils.scrollToLastPosition
 import com.ichi2.utils.dp
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.allOf
@@ -75,7 +77,7 @@ class CardBrowserInsetsTest : RobolectricTest() {
             )
 
             // scroll to the end and re-lay-out so the fast scroller re-positions
-            browser.cardList.scrollToPosition(49)
+            browser.cardList.scrollToLastPosition()
             browser.layoutForTest()
 
             // at the bottom: the track is trimmed by the inset, aligning with the handle & last row
@@ -100,13 +102,12 @@ class CardBrowserInsetsTest : RobolectricTest() {
 
             // scroll to the end, then back up by part of the inset so the last row's bottom sits
             // between its resting line and the bottom of the screen
-            list.scrollToPosition(49)
+            list.scrollToLastPosition()
             browser.layoutForTest()
             list.scrollBy(0, -navBarBottom / 2)
             browser.layoutForTest()
 
-            val layoutManager = list.layoutManager!!
-            val lastRowBottom = layoutManager.getDecoratedBottom(layoutManager.findViewByPosition(49)!!)
+            val lastRowBottom = list.layoutManager!!.getDecoratedBottom(list.lastItemView)
             assertThat(
                 "the last row's bottom is on screen, below its resting line",
                 lastRowBottom,
@@ -127,12 +128,11 @@ class CardBrowserInsetsTest : RobolectricTest() {
             val handle = scroller.handle
             val list = browser.cardList
 
-            list.scrollToPosition(49)
+            list.scrollToLastPosition()
             browser.layoutForTest()
             assertThat("list is fully scrolled", list.canScrollVertically(1), equalTo(false))
 
-            val layoutManager = list.layoutManager!!
-            val lastRowBottom = layoutManager.getDecoratedBottom(layoutManager.findViewByPosition(49)!!)
+            val lastRowBottom = list.layoutManager!!.getDecoratedBottom(list.lastItemView)
             val restingLine = scroller.height - navBarBottom
             assertThat("the last row rests above the safe area", lastRowBottom, equalTo(restingLine))
             assertThat("the track's bottom rests on the same line", track.bottom, equalTo(restingLine))
@@ -199,7 +199,7 @@ class CardBrowserInsetsTest : RobolectricTest() {
             assertThat("no bottom buffer is reserved", browser.cardList.paddingBottom, equalTo(0))
             assertThat("the handle may reach the parent's bottom", browser.fastScroller.handleBottomInset, equalTo(0))
 
-            browser.cardList.scrollToPosition(49)
+            browser.cardList.scrollToLastPosition()
             browser.layoutForTest()
             assertThat("list is fully scrolled", browser.cardList.canScrollVertically(1), equalTo(false))
             assertThat(

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserScreenshotTest.kt
@@ -16,6 +16,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.ui.RecyclerFastScroller
 import com.ichi2.testutils.HIDDEN_GESTURE_BAR
 import com.ichi2.testutils.insetsOf
+import com.ichi2.testutils.scrollToEnd
 import com.ichi2.testutils.simulateSystemBars
 import com.ichi2.utils.dp
 import org.junit.Test
@@ -48,9 +49,7 @@ class CardBrowserScreenshotTest : ScreenshotTest() {
             browser.simulateNavigationBar()
 
             val list = browser.findViewById<RecyclerView>(R.id.card_browser_list)
-            list.scrollToPosition(49)
-            while (list.canScrollVertically(1)) list.scrollBy(0, 50)
-            advanceRobolectricLooper()
+            list.scrollToEnd()
 
             // keep the auto-hiding fast scroller visible for the capture
             browser.findViewById<RecyclerFastScroller>(R.id.browser_scroller).show(animate = false)
@@ -72,9 +71,7 @@ class CardBrowserScreenshotTest : ScreenshotTest() {
             browser.simulateSideNavigationBar()
 
             val list = browser.findViewById<RecyclerView>(R.id.card_browser_list)
-            list.scrollToPosition(49)
-            while (list.canScrollVertically(1)) list.scrollBy(0, 50)
-            advanceRobolectricLooper()
+            list.scrollToEnd()
 
             // keep the auto-hiding fast scroller visible for the capture
             browser.findViewById<RecyclerFastScroller>(R.id.browser_scroller).show(animate = false)
@@ -98,9 +95,7 @@ class CardBrowserScreenshotTest : ScreenshotTest() {
             browser.simulateGestureNavigationBar()
 
             val list = browser.findViewById<RecyclerView>(R.id.card_browser_list)
-            list.scrollToPosition(49)
-            while (list.canScrollVertically(1)) list.scrollBy(0, 50)
-            advanceRobolectricLooper()
+            list.scrollToEnd()
 
             // keep the auto-hiding fast scroller visible for the capture
             browser.findViewById<RecyclerFastScroller>(R.id.browser_scroller).show(animate = false)
@@ -116,9 +111,7 @@ class CardBrowserScreenshotTest : ScreenshotTest() {
             browser.simulateSystemBars(navBarBottom = HIDDEN_GESTURE_BAR, bottomCornerRadius = 34.dp)
 
             val list = browser.findViewById<RecyclerView>(R.id.card_browser_list)
-            list.scrollToPosition(49)
-            while (list.canScrollVertically(1)) list.scrollBy(0, 50)
-            advanceRobolectricLooper()
+            list.scrollToEnd()
 
             // keep the auto-hiding fast scroller visible for the capture
             browser.findViewById<RecyclerFastScroller>(R.id.browser_scroller).show(animate = false)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerScreenshotTest.kt
@@ -4,13 +4,18 @@
 package com.ichi2.anki
 
 import android.content.Intent
+import android.view.View
 import androidx.core.content.edit
 import androidx.recyclerview.widget.RecyclerView
+import com.ichi2.anki.android.view.locationInWindow
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.widgets.DeckAdapter
 import com.ichi2.testutils.BackupManagerTestUtilities
+import com.ichi2.testutils.lastItemView
+import com.ichi2.testutils.scrollToEnd
+import com.ichi2.testutils.simulateKeyboard
 import kotlinx.coroutines.flow.first
 import org.junit.After
 import org.junit.Before
@@ -54,6 +59,25 @@ class DeckPickerScreenshotTest : ScreenshotTest() {
         withDeckPicker(deckCount = 30) { deckPicker ->
             deckPicker.simulateEdgeToEdge()
             captureScreen("edgeToEdge_30_decks")
+        }
+
+    /** Ensure that 'studied today' overlaying a deck name works when the IME is open */
+    @Test
+    fun keyboard_studied_line_overlaying_deck_name() =
+        withDeckPicker(deckCount = 30) { deckPicker ->
+            deckPicker.searchWithKeyboard()
+            deckPicker.scrollLastDeckOntoStudiedLine()
+
+            captureScreen("keyboard_studied_line_overlaying_deck_name")
+        }
+
+    @Test
+    fun keyboard_open_scrolled_to_bottom() =
+        withDeckPicker(deckCount = 30) { deckPicker ->
+            deckPicker.searchWithKeyboard()
+            deckPicker.deckPickerBinding.decks.scrollToEnd()
+
+            captureScreen("keyboard_open_scrolled_to_bottom")
         }
 
     @Test
@@ -138,6 +162,32 @@ class DeckPickerScreenshotTest : ScreenshotTest() {
 
             captureScreen("hierarchy_lines_many_siblings")
         }
+
+    /** Expands the deck search, hiding the FAB, and opens the keyboard over the navigation bar */
+    private fun DeckPicker.searchWithKeyboard() {
+        requireNotNull(searchDecksIcon).expandActionView()
+        advanceRobolectricLooper()
+        // settles layout: the list's bottom padding follows the summary line's layout pass
+        simulateKeyboard()
+    }
+
+    /** Scrolls to the end, then back so the last deck's name is centered on the 'Studied' line */
+    private fun DeckPicker.scrollLastDeckOntoStudiedLine() {
+        val list = deckPickerBinding.decks
+        list.scrollToEnd()
+        val lastDeck = list.lastItemView
+        val studiedLine = deckPickerBinding.reviewSummaryTextView
+        list.scrollBy(0, lastDeck.contentCenterYInWindow - studiedLine.contentCenterYInWindow)
+        advanceRobolectricLooper()
+    }
+
+    /**
+     * The vertical center of the receiver's content, relative to its window.
+     *
+     * Padding is excluded: the 'Studied' line's bottom padding holds the keyboard inset.
+     */
+    private val View.contentCenterYInWindow: Int
+        get() = locationInWindow().y + paddingTop + (height - paddingTop - paddingBottom) / 2
 
     private fun enableBottomNavigation() {
         Prefs.sharedPrefs.edit { putBoolean(Prefs.key(R.string.dev_bottom_nav_key), true) }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesScreenshotTest.kt
@@ -16,6 +16,7 @@ import com.ichi2.anki.settings.Prefs
 import com.ichi2.testutils.HIDDEN_GESTURE_BAR
 import com.ichi2.testutils.ext.clear
 import com.ichi2.testutils.launchForFullHeightScreenshot
+import com.ichi2.testutils.scrollToEnd
 import com.ichi2.testutils.simulateSystemBars
 import com.ichi2.utils.dp
 import org.junit.After
@@ -91,9 +92,7 @@ class PreferencesScreenshotTest : ScreenshotTest() {
         val mainFragment = fragment as PreferencesFragment
         val settingsFragment = mainFragment.childFragmentManager.findFragmentById(R.id.settings_container) as SettingsFragment
         val list = settingsFragment.listView
-        list.scrollToPosition(list.adapter!!.itemCount - 1)
-        while (list.canScrollVertically(1)) list.scrollBy(0, 50)
-        advanceRobolectricLooper()
+        list.scrollToEnd()
     }
 
     /** Replaces content which changes between runs, so it does not appear in diffs */

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersScreenshotTest.kt
@@ -21,6 +21,7 @@ import com.ichi2.anki.reviewreminders.ScheduleRemindersFragment.FragmentHost
 import com.ichi2.anki.utils.ConfigAwareSingleFragmentActivity
 import com.ichi2.anki.withDeckPicker
 import com.ichi2.testutils.BackupManagerTestUtilities
+import com.ichi2.testutils.scrollToLastPosition
 import com.ichi2.testutils.simulateSystemBars
 import com.ichi2.utils.dp
 import kotlinx.coroutines.runBlocking
@@ -160,7 +161,7 @@ class ReviewRemindersScreenshotTest : ScreenshotTest() {
             activity.simulateSystemBars()
             val binding = FragmentScheduleRemindersBinding.bind(activity.fragment!!.requireView())
             // scrolled to the end: the last reminder must clear the navigation bar band
-            binding.recyclerView.scrollToPosition(binding.recyclerView.adapter!!.itemCount - 1)
+            binding.recyclerView.scrollToLastPosition()
             advanceRobolectricLooper()
             captureScreen("standaloneActivityHost_systemBars_scrolledToEnd")
         }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/InsetsUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/InsetsUtils.kt
@@ -191,3 +191,35 @@ fun Activity.simulateSystemBars(
     }
     advanceRobolectricLooper()
 }
+
+/**
+ * Injects insets to simulate the keyboard open over the navigation bar, as on an edge-to-edge
+ * device.
+ *
+ * A translucent band marks where the keyboard would sit, so content drawn underneath it can be
+ * seen.
+ *
+ * @param keyboardHeight the height of the keyboard, measured from the bottom of the screen
+ * @param navBarBottom the height of the navigation bar, which the keyboard covers
+ */
+fun Activity.simulateKeyboard(
+    keyboardHeight: Dp = 300.dp,
+    navBarBottom: Dp = 48.dp,
+) {
+    val context: Context = this
+    val insets =
+        WindowInsetsCompat
+            .Builder()
+            .setInsets(statusBars(), insetsOf(top = 24.dp))
+            .setInsets(navigationBars(), insetsOf(bottom = navBarBottom))
+            .setInsets(ime(), insetsOf(bottom = keyboardHeight))
+            .build()
+    ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
+
+    val decor = window.decorView as ViewGroup
+    decor.addView(
+        View(this).apply { setBackgroundColor(0x80000000.toInt()) },
+        FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, keyboardHeight.toPx(context), Gravity.BOTTOM),
+    )
+    advanceRobolectricLooper()
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/RecyclerViewUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/RecyclerViewUtils.kt
@@ -15,11 +15,35 @@
  */
 package com.ichi2.testutils
 
+import android.view.View
 import androidx.recyclerview.widget.RecyclerView
+import com.ichi2.anki.RobolectricTest.Companion.advanceRobolectricLooper
 
 object RecyclerViewUtils {
     inline fun <reified VH : RecyclerView.ViewHolder?> viewHolderAt(
         recyclerView: RecyclerView,
         position: Int,
     ): VH = recyclerView.findViewHolderForAdapterPosition(position) as VH
+}
+
+/** The adapter position of the last item */
+val RecyclerView.lastPosition: Int
+    get() = adapter!!.itemCount - 1
+
+/** The laid-out view of the last item, which must be on screen */
+val RecyclerView.lastItemView: View
+    get() = layoutManager!!.findViewByPosition(lastPosition)!!
+
+/**
+ * Requests a scroll to the last item. Layout is left to the caller.
+ *
+ * @see scrollToEnd
+ */
+fun RecyclerView.scrollToLastPosition() = scrollToPosition(lastPosition)
+
+/** Scrolls until the last item is fully visible and the list can scroll no further, then settles layout */
+fun RecyclerView.scrollToEnd() {
+    scrollToLastPosition()
+    while (canScrollVertically(1)) scrollBy(0, 50)
+    advanceRobolectricLooper()
 }


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Fable 5.1

## Purpose / Description
The deck list now scrolls fully, rather than being obscured


## Fixes
* Fixes #21798

## Approach
`adjustResize` was disabled, so `ime()` needed to be in the insets.


## How Has This Been Tested?
<img width="3318" height="2483" alt="keyboard_open_scrolled_to_bottom_compare" src="https://github.com/user-attachments/assets/0eac3a9b-5a50-495e-8247-81ce513734f4" />

<img width="3318" height="2483" alt="keyboard_studied_line_overlaying_deck_name_compare" src="https://github.com/user-attachments/assets/d25618a9-d2d3-49b1-8a2d-89006d44da8f" />


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)