### PR TITLE
fix(card-template-editor): keep all content above the keyboard

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -103,6 +103,7 @@ import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.startup.ensureStorageIsReady
 import com.ichi2.anki.ui.ResizablePaneManager
 import com.ichi2.anki.ui.internationalization.sentenceCase
+import com.ichi2.anki.utils.doOnApplyWindowInsets
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
 import com.ichi2.anki.utils.ext.doOnTabSelected
 import com.ichi2.anki.utils.ext.showDialogFragment
@@ -764,17 +765,20 @@ open class CardTemplateEditor : AnkiActivity(R.layout.activity_card_template_edi
                 }
             binding.editText.addTextChangedListener(templateEditorWatcher)
 
-            ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, insets ->
+            binding.root.doOnApplyWindowInsets { view, insets, initial ->
                 // Hide the template tabs to make room for a full software keyboard. A physical
                 // keyboard can report a visible IME with only a navigation strip (or zero height).
-                binding.bottomNavigation.isVisible = insets.getInsets(ime()).bottom <= binding.bottomNavigation.minimumHeight
+                val softwareKeyboardVisible = insets.getInsets(ime()).bottom > binding.bottomNavigation.minimumHeight
+                binding.bottomNavigation.isVisible = !softwareKeyboardVisible
+                val bottomInset = insets.getInsets(systemBars() or displayCutout() or ime()).bottom
+                view.updatePadding(
+                    bottom = if (softwareKeyboardVisible) bottomInset else 0,
+                )
                 // When fragmented, the activity insets the editor pane instead.
-                // The bottom navigation insets itself, so it is not padded here.
                 if (!templateEditor.fragmented) {
                     val bars = insets.getInsets(systemBars() or displayCutout())
                     binding.scrollView.updatePadding(left = bars.left, right = bars.right)
                 }
-                insets
             }
             // the view is added to the pager after the insets were dispatched, so request them again
             binding.root.doOnAttach { ViewCompat.requestApplyInsets(it) }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorScreenshotTest.kt
@@ -10,14 +10,16 @@ import android.widget.FrameLayout
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsCompat.Type.displayCutout
+import androidx.core.view.WindowInsetsCompat.Type.ime
 import androidx.core.view.WindowInsetsCompat.Type.navigationBars
 import androidx.core.view.WindowInsetsCompat.Type.statusBars
 import androidx.test.core.app.ActivityScenario
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.ichi2.testutils.dispatchInsets
 import com.ichi2.testutils.insetsOf
-import com.ichi2.utils.Dp
+import com.ichi2.testutils.windowInsetsOf
 import com.ichi2.utils.dp
+import org.junit.Assert.assertFalse
 import org.junit.Test
 import org.robolectric.RuntimeEnvironment
 
@@ -69,12 +71,42 @@ class CardTemplateEditorScreenshotTest : ScreenshotTest() {
                 // gesture navigation shows only a 48dp strip
                 PhysicalKeyboardIme.GESTURES -> dispatchInsets(navBarBottom = 24.dp, imeBottom = 48.dp)
                 // the user may still opt into the software keyboard
-                PhysicalKeyboardIme.SOFTWARE_KEYBOARD -> dispatchInsets(navBarBottom = 24.dp, imeBottom = 240.dp)
+                PhysicalKeyboardIme.SOFTWARE_KEYBOARD -> {
+                    dispatchInsets(navBarBottom = 24.dp, imeBottom = 240.dp)
+                    addOverlay(FrameLayout.LayoutParams.MATCH_PARENT, 240.dp.toPx(targetContext), Gravity.BOTTOM)
+                }
             }
             advanceRobolectricLooper()
+            // TODO: with the software keyboard open, this landscape viewport is too short for a
+            // complete line of the template.
             captureScreen("physical_keyboard_${ime.name.lowercase()}")
         }
     }
+
+    /** The entire template scrolls above the keyboard while the template controls are hidden. */
+    @Test
+    fun keyboard() =
+        withCardTemplateEditor(noteType = getCurrentDatabaseNoteTypeCopy("Basic (and reversed card)")) {
+            mainBinding.cardTemplateEditorPager.setCurrentItem(1, false)
+            advanceRobolectricLooper()
+            val binding = currentFragment!!.binding
+            binding.editText.append(
+                (1..40).joinToString(separator = "\n", prefix = "\n", postfix = "\n<!-- End of template -->") { "<!-- Line $it -->" },
+            )
+            binding.editText.setSelection(binding.editText.length())
+            advanceRobolectricLooper()
+            val keyboard = simulateKeyboard()
+            advanceRobolectricLooper()
+            binding.scrollView.scrollTo(0, binding.scrollView.getChildAt(0).bottom)
+            advanceRobolectricLooper()
+            assertFalse("The keyboard hides the template controls", binding.bottomNavigation.isShown)
+            captureScreen("keyboard")
+
+            (window.decorView as ViewGroup).removeView(keyboard)
+            dispatchInsets(navBarBottom = 48.dp)
+            advanceRobolectricLooper()
+            captureScreen("keyboard_closed")
+        }
 
     @SuppressLint("RtlHardcoded") // insets and cutouts are physical: not layout-direction relative
     private fun CardTemplateEditor.simulateSideNavigationBar() {
@@ -91,16 +123,29 @@ class CardTemplateEditorScreenshotTest : ScreenshotTest() {
             }
         ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
         advanceRobolectricLooper()
-        addOverlay(navBarWidth, Gravity.LEFT)
-        addOverlay(cutoutWidth, Gravity.RIGHT)
+        addOverlay(navBarWidth.toPx(targetContext), FrameLayout.LayoutParams.MATCH_PARENT, Gravity.LEFT)
+        addOverlay(cutoutWidth.toPx(targetContext), FrameLayout.LayoutParams.MATCH_PARENT, Gravity.RIGHT)
+    }
+
+    private fun CardTemplateEditor.simulateKeyboard(): View {
+        val keyboardHeight = 300.dp
+        val insets =
+            WindowInsetsCompat
+                .Builder(windowInsetsOf(navBarBottom = 48.dp, imeBottom = keyboardHeight))
+                .setVisible(ime(), true)
+                .build()
+        ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
+        return addOverlay(FrameLayout.LayoutParams.MATCH_PARENT, keyboardHeight.toPx(targetContext), Gravity.BOTTOM)
     }
 
     private fun CardTemplateEditor.addOverlay(
-        width: Dp,
+        width: Int,
+        height: Int,
         gravity: Int,
-    ) {
+    ): View {
         val decor = window.decorView as ViewGroup
         val overlay = View(this).apply { setBackgroundColor(0x80000000.toInt()) }
-        decor.addView(overlay, FrameLayout.LayoutParams(width.toPx(targetContext), FrameLayout.LayoutParams.MATCH_PARENT, gravity))
+        decor.addView(overlay, FrameLayout.LayoutParams(width, height, gravity))
+        return overlay
     }
 }


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: GPT-6 - all

## Fixes
* Fixes #21795

## Approach
Apply keyboard insets to the bottom navigation so all content is visible

Add regression coverage for phones, tablets and switching cards.

## How Has This Been Tested?
Phyiscal test on an API 37 emulator

Screenshot tests: [snipped due to edits; see output below]

<!--
<img width="7744" height="1664" alt="tablet_physical_keyboard_software_keyboard_compare" src="https://github.com/user-attachments/assets/d4d42b0f-d538-4553-8c3e-f7a9bad2f6b2" />

<img width="7744" height="1664" alt="tablet_keyboard_compare" src="https://github.com/user-attachments/assets/da54540f-e1e5-464f-a571-210c83a72774" />
<img width="7272" height="1160" alt="physical_keyboard_software_keyboard_compare" src="https://github.com/user-attachments/assets/8125d78e-e912-4706-b072-829ad381403a" />
<img width="3318" height="2483" alt="keyboard_compare" src="https://github.com/user-attachments/assets/2aebd734-8563-4c6f-9ea4-0799b7990998" />

-->

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->