### PR TITLE
fix(note-types): keep controls above the keyboard

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt
@@ -25,6 +25,7 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsCompat.Type.displayCutout
+import androidx.core.view.WindowInsetsCompat.Type.ime
 import androidx.core.view.WindowInsetsCompat.Type.systemBars
 import androidx.core.view.isVisible
 import androidx.core.view.updateMargins
@@ -168,7 +169,7 @@ class ManageNotetypes : AnkiActivity(R.layout.activity_manage_note_types) {
 
     private fun applyInsets() {
         ViewCompat.setOnApplyWindowInsetsListener(binding.rootLayout) { _, insets ->
-            val constraints = insets.getInsets(systemBars() or displayCutout())
+            val constraints = insets.getInsets(systemBars() or displayCutout() or ime())
             Timber.d("Applying insets: $constraints")
             binding.appBarLayout.updatePadding(left = constraints.left, top = constraints.top, right = constraints.right)
             binding.noteTypesList.updatePadding(left = constraints.left, right = constraints.right, bottom = constraints.bottom)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/notetype/ManageNotetypesScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/notetype/ManageNotetypesScreenshotTest.kt
@@ -1,27 +1,79 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 package com.ichi2.anki.notetype
 
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
 import androidx.test.core.app.ActivityScenario
+import com.ichi2.anki.R
 import com.ichi2.anki.ScreenshotTest
+import com.ichi2.testutils.dispatchInsets
+import com.ichi2.utils.dp
 import org.junit.Test
 
 class ManageNotetypesScreenshotTest : ScreenshotTest() {
     @Test
-    fun base_and_selected() {
-        val intent = ManageNoteTypesDestination().toIntent(targetContext)
-        ActivityScenario.launch<ManageNotetypes>(intent).use { scenario ->
-            scenario.onActivity { activity ->
-                captureScreen("base")
+    fun keyboard_scrolled_to_bottom() =
+        runTest {
+            ensureCollectionLoadIsSynchronous()
+            repeat(10) { addStandardNoteType("Note type $it", arrayOf("front", "back"), "", "") }
+            withManageNoteTypes { activity ->
+                activity.binding.toolbar.menu
+                    .findItem(R.id.search_item)
+                    .expandActionView()
+                advanceRobolectricLooper()
+                activity.simulateKeyboard()
+                advanceRobolectricLooper()
 
-                activity.binding.appBarLayout.isLifted = true
-                captureScreen("appbar_lifted")
-                activity.binding.appBarLayout.isLifted = false
+                val list = activity.binding.noteTypesList
+                list.scrollToPosition(list.adapter!!.itemCount - 1)
+                while (list.canScrollVertically(1)) list.scrollBy(0, 50)
+                advanceRobolectricLooper()
+                captureScreen("keyboard_scrolled_to_bottom")
 
-                // enable multi select mode by selecting the first entry
                 val currentState = activity.viewModel.state.value
-                activity.viewModel.onItemLongClick(currentState.noteTypes[0])
-                captureScreen("multi_select_mode")
+                activity.viewModel.onItemLongClick(currentState.noteTypes.last())
+                advanceRobolectricLooper()
+                captureScreen("keyboard_multi_select_mode")
             }
         }
+
+    @Test
+    fun base_and_selected() =
+        withManageNoteTypes { activity ->
+            captureScreen("base")
+
+            activity.binding.appBarLayout.isLifted = true
+            captureScreen("appbar_lifted")
+            activity.binding.appBarLayout.isLifted = false
+
+            // enable multi select mode by selecting the first entry
+            val currentState = activity.viewModel.state.value
+            activity.viewModel.onItemLongClick(currentState.noteTypes[0])
+            captureScreen("multi_select_mode")
+        }
+
+    private fun withManageNoteTypes(block: (ManageNotetypes) -> Unit) {
+        val intent = ManageNoteTypesDestination().toIntent(targetContext)
+        ActivityScenario.launch<ManageNotetypes>(intent).use { scenario ->
+            scenario.onActivity(block)
+        }
+    }
+
+    /** Shows the keyboard's bounds as a translucent overlay. */
+    private fun ManageNotetypes.simulateKeyboard() {
+        val keyboardHeight = 300.dp
+        dispatchInsets(navBarBottom = 48.dp, imeBottom = keyboardHeight)
+        val decor = window.decorView as ViewGroup
+        val overlay = View(this).apply { setBackgroundColor(0x80000000.toInt()) }
+        decor.addView(
+            overlay,
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                keyboardHeight.toPx(this),
+                Gravity.BOTTOM,
+            ),
+        )
     }
 }


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: GPT-6 - all

## Fixes
* Fixes #21797

## Approach
Add `ime()` to the insets

## How Has This Been Tested?
Screenshot tests, brief test on my API 37 Pixel 9 Pro

<img width="3318" height="2483" alt="keyboard_multi_select_mode_compare" src="https://github.com/user-attachments/assets/ba6ebfe9-7723-495a-bb04-c9835b7152f9" />
<img width="3318" height="2483" alt="keyboard_scrolled_to_bottom_compare" src="https://github.com/user-attachments/assets/329acbc7-0295-4cb0-a13a-70bf39ef5ad9" />


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)