### PR TITLE
fix(sentece-case): "Keep editing"

### DIFF
--- a/AnkiDroid/jacoco.gradle.kts
+++ b/AnkiDroid/jacoco.gradle.kts
@@ -211,7 +211,7 @@ fun includeUnitTestCoverage(
     project: Project,
     classDir: String,
 ) {
-    report.sourceDirectories.from(project.files("${project.projectDir}/src/main/java"))
+    report.sourceDirectories.from(project.files("src/main/java"))
     report.classDirectories.from(
         project.files(
             project.fileTree(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DiscardChangesDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DiscardChangesDialog.kt
@@ -17,8 +17,9 @@ package com.ichi2.anki.dialogs
 
 import android.content.Context
 import androidx.appcompat.app.AlertDialog
-import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.utils.message
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.neutralButton
@@ -31,9 +32,9 @@ object DiscardChangesDialog {
     fun showDialog(
         context: Context,
         positiveButtonText: String = context.getString(R.string.discard),
-        negativeButtonText: String = CollectionManager.TR.addingKeepEditing(),
+        negativeButtonText: String = with(context) { TR.sentenceCase.keepEditing },
         neutralButtonText: String? = null,
-        message: String = CollectionManager.TR.cardTemplatesDiscardChanges(),
+        message: String = TR.cardTemplatesDiscardChanges(),
         negativeMethod: () -> Unit = {},
         neutralMethod: (() -> Unit)? = null,
         positiveMethod: () -> Unit,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
@@ -85,6 +85,7 @@ class SentenceCaseTest : RobolectricTest() {
                     assertThat(TR.sentenceCase.emptyCards, equalTo("Empty cards"))
                     assertThat(TR.sentenceCase.flagCard, equalTo("Flag card"))
                     assertThat(TR.sentenceCase.noFlag, equalTo("No flag"))
+                    assertThat(TR.sentenceCase.keepEditing, equalTo("Keep editing"))
                     assertThat(TR.sentenceCase.copyToClipboard, equalTo("Copy to clipboard"))
                     assertThat(TR.sentenceCase.frontTemplate, equalTo("Front template"))
                     assertThat(TR.sentenceCase.backTemplate, equalTo("Back template"))

--- a/anki-common/src/main/kotlin/com/ichi2/anki/ui/internationalization/SentenceCase.kt
+++ b/anki-common/src/main/kotlin/com/ichi2/anki/ui/internationalization/SentenceCase.kt
@@ -356,6 +356,9 @@ object SentenceCase {
 
     context(_: Context)
     val noFlag get() = TR.browsingNoFlag().toSentenceCase(R.string.sentence_no_flag)
+
+    context(_: Context)
+    val keepEditing get() = TR.addingKeepEditing().toSentenceCase(R.string.sentence_keep_editing)
 }
 
 /**

--- a/anki-common/src/main/res/values/sentence-case.xml
+++ b/anki-common/src/main/res/values/sentence-case.xml
@@ -84,4 +84,5 @@ undoActionUndone()
     <string name="sentence_answer_good" maxLength="41">Answer good</string>
     <string name="sentence_copy_to_clipboard">Copy to clipboard</string>
     <string name="sentence_no_flag">No flag</string>
+    <string name="sentence_keep_editing">Keep editing</string>
 </resources>


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: GPT-6

## Purpose / Description
I noticed this while testing - simple sentence case move.

I wanted to move `SentenceCaseTest` to a common test, but `RobolectricTest` needed to come along with it - I'll save this for when the testing is a little less tangled.

## Fixes
* Part of #15760

## Approach
* Standard sentence case extraction
* Then a refactoring for a testing architecture change I backed out of

## How Has This Been Tested?
<img width="959" height="488" alt="image" src="https://github.com/user-attachments/assets/30014d44-bb7a-443d-8678-93e73197be91" />

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)