### PR TITLE
refactor(profiles): type ProfileItem.id as ProfileId

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/profiles/ProfileItem.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/profiles/ProfileItem.kt
@@ -4,10 +4,11 @@
 package com.ichi2.anki.preferences.profiles
 
 import com.ichi2.anki.common.utils.firstGraphemeOrNull
+import com.ichi2.anki.multiprofile.ProfileId
 
 /** UI model for a row in the profile list. */
 data class ProfileItem(
-    val id: String,
+    val id: ProfileId,
     val name: String,
 ) {
     /** Uppercased first character of the name, shown in the avatar circle. */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/profiles/SwitchProfilesScreen.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/profiles/SwitchProfilesScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.ichi2.anki.R
+import com.ichi2.anki.multiprofile.ProfileId
 import com.ichi2.anki.multiprofile.ProfileName
 import com.ichi2.compose.theme.AnkiDroidTheme
 import com.ichi2.compose.theme.dimensions
@@ -83,7 +84,7 @@ fun SwitchProfilesScreen(
             modifier = Modifier.fillMaxSize(),
             contentPadding = contentPadding,
         ) {
-            items(profiles, key = { it.id }) { profile ->
+            items(profiles, key = { it.id.value }) { profile ->
                 ProfileRow(
                     profile = profile,
                     onEditClick = { onEditProfile(profile) },
@@ -170,8 +171,8 @@ private fun SwitchProfilesScreenPreview() {
         SwitchProfilesScreen(
             profiles =
                 listOf(
-                    ProfileItem(id = "default", name = "Default"),
-                    ProfileItem(id = "work", name = "Work"),
+                    ProfileItem(id = ProfileId.DEFAULT, name = "Default"),
+                    ProfileItem(id = ProfileId("p_work"), name = "Work"),
                 ),
             isAddProfileDialogVisible = false,
             onNavigateUp = {},

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/profiles/ProfileItemTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/profiles/ProfileItemTest.kt
@@ -3,11 +3,12 @@
 
 package com.ichi2.anki.preferences.profiles
 
+import com.ichi2.anki.multiprofile.ProfileId
 import org.junit.Test
 import kotlin.test.assertEquals
 
 class ProfileItemTest {
-    private fun initialOf(name: String) = ProfileItem(id = "id", name = name).initial
+    private fun initialOf(name: String) = ProfileItem(id = ProfileId.DEFAULT, name = name).initial
 
     @Test
     fun `initial is the uppercased first letter`() {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

<!---
Uncomment this section if AI tools were used. New contributors may not use AI tools. See:
https://github.com/ankidroid/Anki-Android/blob/main/AI_POLICY.md
> [!NOTE]
> Assisted-by: ___
--->

## Purpose / Description
UI model carried the profile id as a String while the domain layer uses the ProfileId value class, which is also what ProfileManager.getAllProfiles() keys on. Typing it removes the conversion the list will otherwise need.

## Fixes
* Part of  #18117

## Approach
simple refactor

## How Has This Been Tested?
Not needed imo minimal code change build should do it

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->