### PR TITLE
feat(profiles): populate the switch profile list

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -91,6 +91,10 @@ open class AnkiDroidApp :
     @LegacyNotifications("The widget triggers notifications by posting null to this, but we plan to stop relying on the widget")
     private val notifications = MutableLiveData<Void?>()
 
+    /** Manager for the active profile, null if the profile environment failed to load. */
+    var profileManager: ProfileManager? = null
+        private set
+
     lateinit var activityAgnosticDialogs: ActivityAgnosticDialogs
     val sharedPrefsLastDeckIdRepository = SharedPreferencesLastDeckIdRepository()
 
@@ -125,7 +129,8 @@ open class AnkiDroidApp :
      * WebView exists, and every preference read must already be namespaced.
      */
     override fun attachBaseContext(base: Context) {
-        super.attachBaseContext(ProfileManager.createOrNull(base)?.activeProfileContext ?: base)
+        profileManager = ProfileManager.createOrNull(base)
+        super.attachBaseContext(profileManager?.activeProfileContext ?: base)
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -49,6 +49,7 @@ import com.ichi2.anki.logging.FragmentLifecycleLogger
 import com.ichi2.anki.logging.LogType
 import com.ichi2.anki.logging.ProductionCrashReportingTree
 import com.ichi2.anki.logging.RobolectricDebugTree
+import com.ichi2.anki.multiprofile.ProfileManager
 import com.ichi2.anki.navigation.initializeNavigator
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.preferences.SharedPreferencesProvider
@@ -119,6 +120,15 @@ open class AnkiDroidApp :
     }
 
     /**
+     * Runs before [onCreate] and before any ContentProvider, which is what the
+     * profile environment needs: WebView data directories must be set before any
+     * WebView exists, and every preference read must already be namespaced.
+     */
+    override fun attachBaseContext(base: Context) {
+        super.attachBaseContext(ProfileManager.createOrNull(base)?.activeProfileContext ?: base)
+    }
+
+    /**
      * On application creation, i.e. when the application process starts.
      * This is called before any activities, services, or receivers are created.
      */
@@ -144,6 +154,9 @@ open class AnkiDroidApp :
             LogType.PRODUCTION -> Timber.plant(ProductionCrashReportingTree())
         }
         Timber.plant(ReminderLogTree(this))
+        ProfileManager.attachError?.let {
+            Timber.w(it, "Failed to load the profile environment, running on the base context")
+        }
         if (BuildConfig.ENABLE_LEAK_CANARY) {
             LeakCanaryConfiguration.setInitialConfigFor(this)
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileManager.kt
@@ -720,6 +720,38 @@ class ProfileManager private constructor(
             )
 
         /**
+         * Failure from the last [createOrNull], if any.
+         *
+         * Timber is not planted during [android.app.Application.attachBaseContext],
+         * so a failure there cannot be logged where it happens.
+         */
+        var attachError: Throwable? = null
+            private set
+
+        /**
+         * Loads the active profile, or returns null when its environment cannot be
+         * loaded.
+         *
+         * Never throws: a failure during [android.app.Application.attachBaseContext]
+         * would stop the app from starting at all, so callers run on the base context
+         * instead. Users with only the Default profile are unaffected either way, since
+         * the wrapper delegates everything to the base context for that profile.
+         */
+        fun createOrNull(base: Context): ProfileManager? =
+            try {
+                attachError = null
+                create(base)
+            } catch (e: Exception) {
+                attachError = e
+                null
+            }
+
+        @VisibleForTesting
+        fun resetForTesting() {
+            attachError = null
+        }
+
+        /**
          * Factory method to safely create and initialize the ProfileManager.
          * Guaranteed to return a ProfileManager with a valid [activeProfileContext].
          *

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/profiles/SwitchProfilesFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/profiles/SwitchProfilesFragment.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.compose.theme.AnkiDroidTheme
 
 /**
@@ -22,7 +23,13 @@ import com.ichi2.compose.theme.AnkiDroidTheme
  * preference_headers.xml launches it by class name.
  */
 class SwitchProfilesFragment : Fragment() {
-    private val viewModel: SwitchProfilesViewModel by viewModels()
+    private val viewModel: SwitchProfilesViewModel by viewModels {
+        SwitchProfilesViewModel.factory(
+            checkNotNull(AnkiDroidApp.instance.profileManager) {
+                "the profile environment failed to load, see ProfileManager.attachError"
+            },
+        )
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/profiles/SwitchProfilesViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/profiles/SwitchProfilesViewModel.kt
@@ -4,6 +4,10 @@
 package com.ichi2.anki.preferences.profiles
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.ichi2.anki.multiprofile.ProfileManager
 import com.ichi2.anki.multiprofile.ProfileName
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -13,11 +17,12 @@ import timber.log.Timber
  * State holder for [SwitchProfilesFragment]. Keeps the dialog visibility out
  * of the view layer so it survives configuration changes.
  */
-class SwitchProfilesViewModel : ViewModel() {
+class SwitchProfilesViewModel(
+    private val profileManager: ProfileManager,
+) : ViewModel() {
     /** Profiles shown in the list. */
-    // TODO: load from ProfileManager.getAllProfiles once ProfileManager is wired into the app
     val profiles: StateFlow<List<ProfileItem>>
-        field = MutableStateFlow<List<ProfileItem>>(emptyList())
+        field = MutableStateFlow(profileManager.profileItems())
 
     val isAddProfileDialogVisible: StateFlow<Boolean>
         field = MutableStateFlow(false)
@@ -34,8 +39,7 @@ class SwitchProfilesViewModel : ViewModel() {
     fun addProfile(name: ProfileName) {
         isAddProfileDialogVisible.value = false
         Timber.i("Add profile confirmed (%d chars)", name.value.length)
-        // TODO: handle profile creation via ProfileManager.createNewProfile once
-        //  ProfileManager is wired into the app
+        // TODO: handle profile creation via ProfileManager.createNewProfile
     }
 
     fun editProfile(profile: ProfileItem) {
@@ -46,5 +50,28 @@ class SwitchProfilesViewModel : ViewModel() {
     fun deleteProfile(profile: ProfileItem) {
         Timber.i("Delete profile requested: %s", profile.id)
         // TODO: implement profile deletion via ProfileManager
+    }
+
+    /** Reloads the list from the registry. */
+    fun refresh() {
+        profiles.value = profileManager.profileItems()
+    }
+
+    companion object {
+        fun factory(profileManager: ProfileManager): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer {
+                    SwitchProfilesViewModel(profileManager)
+                }
+            }
+
+        /**
+         * The registry is backed by SharedPreferences, which has no defined order,
+         * so sort by name to keep the list stable across launches.
+         */
+        private fun ProfileManager.profileItems(): List<ProfileItem> =
+            getAllProfiles()
+                .map { (id, metadata) -> ProfileItem(id = id, name = metadata.displayName.value) }
+                .sortedBy { it.name }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidAppTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidAppTest.kt
@@ -58,6 +58,13 @@ class AnkiDroidAppTest {
     }
 
     @Test
+    fun `the application retains the profile manager`() {
+        val app = ApplicationProvider.getApplicationContext<AnkiDroidApp>()
+
+        assertNotNull(app.profileManager, "callers need the manager to reach the active profile")
+    }
+
+    @Test
     fun `preferences are namespaced for a non-default profile`() {
         val profileId = ProfileId("p_namespaced")
         val base = ApplicationProvider.getApplicationContext<AnkiDroidApp>().baseContext

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidAppTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidAppTest.kt
@@ -15,11 +15,21 @@
  */
 package com.ichi2.anki
 
+import android.content.Context
+import androidx.core.content.edit
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.common.crashreporting.CrashReportService.sendExceptionReport
+import com.ichi2.anki.multiprofile.ProfileContextWrapper
+import com.ichi2.anki.multiprofile.ProfileId
+import com.ichi2.anki.multiprofile.ProfileManager
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.runner.RunWith
+import java.io.File
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 @RunWith(AndroidJUnit4::class)
 class AnkiDroidAppTest {
@@ -34,5 +44,33 @@ class AnkiDroidAppTest {
         // It's meant to be non-null, but it's developer-defined, and we don't want a crash in the reporting dialog
         //noinspection ConstantConditions
         assertDoesNotThrow { sendExceptionReport(message, "AnkiDroidAppTest") }
+    }
+
+    @Test
+    fun `application runs on the profile context`() {
+        val app = ApplicationProvider.getApplicationContext<AnkiDroidApp>()
+
+        assertNull(ProfileManager.attachError)
+        assertTrue(
+            "attachBaseContext must install the profile context",
+            app.baseContext is ProfileContextWrapper,
+        )
+    }
+
+    @Test
+    fun `preferences are namespaced for a non-default profile`() {
+        val profileId = ProfileId("p_namespaced")
+        val base = ApplicationProvider.getApplicationContext<AnkiDroidApp>().baseContext
+        base
+            .getSharedPreferences(ProfileManager.PROFILE_REGISTRY_FILENAME, Context.MODE_PRIVATE)
+            .edit(commit = true) { putString(ProfileManager.KEY_LAST_ACTIVE_PROFILE_ID, profileId.value) }
+
+        val attached = assertNotNull(ProfileManager.createOrNull(base)).activeProfileContext as ProfileContextWrapper
+        attached.getSharedPreferences("settings", Context.MODE_PRIVATE).edit(commit = true) {
+            putString("key", "profile value")
+        }
+
+        val namespaced = File(base.dataDir, "shared_prefs/profile_${profileId.value}_settings.xml")
+        assertTrue("Expected a namespaced prefs file at $namespaced", namespaced.exists())
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/ProfileManagerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/ProfileManagerTest.kt
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.io.File
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 @RunWith(AndroidJUnit4::class)
@@ -54,6 +55,7 @@ class ProfileManagerTest {
     @After
     fun tearDown() {
         unmockkAll()
+        ProfileManager.resetForTesting()
     }
 
     @Test
@@ -61,6 +63,40 @@ class ProfileManagerTest {
         ProfileManager.create(context)
 
         assertEquals("default", prefs.getString(KEY_LAST_ACTIVE_PROFILE_ID, null))
+    }
+
+    @Test
+    fun `createOrNull returns a manager on the active profile context`() {
+        val manager = assertNotNull(ProfileManager.createOrNull(context))
+
+        assertTrue("Expected a profile context", manager.activeProfileContext is ProfileContextWrapper)
+        assertNull(ProfileManager.attachError)
+        assertEquals(context.filesDir.absolutePath, manager.activeProfileContext.filesDir.absolutePath)
+    }
+
+    @Test
+    fun `createOrNull initializes the Default profile on first run`() {
+        ProfileManager.createOrNull(context)
+
+        assertEquals("default", prefs.getString(KEY_LAST_ACTIVE_PROFILE_ID, null))
+    }
+
+    @Test
+    fun `createOrNull returns null when the profile environment cannot be loaded`() {
+        val unusableStorage =
+            object : ContextWrapper(context) {
+                override fun getApplicationContext(): Context? = null
+
+                override fun getSharedPreferences(
+                    name: String,
+                    mode: Int,
+                ): SharedPreferences = throw IllegalStateException("storage unavailable")
+            }
+
+        val manager = ProfileManager.createOrNull(unusableStorage)
+
+        assertNull(manager, "must not brick startup")
+        assertNotNull(ProfileManager.attachError, "Failure must be recorded for later logging")
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/profiles/SwitchProfilesViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/profiles/SwitchProfilesViewModelTest.kt
@@ -3,31 +3,61 @@
 
 package com.ichi2.anki.preferences.profiles
 
+import android.content.Context
+import androidx.core.content.edit
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.multiprofile.ProfileId
+import com.ichi2.anki.multiprofile.ProfileManager
+import com.ichi2.anki.multiprofile.ProfileManager.Companion.PROFILE_REGISTRY_FILENAME
 import com.ichi2.anki.multiprofile.ProfileName
 import com.ichi2.anki.multiprofile.ProfileName.ValidationResult
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
 
+@RunWith(AndroidJUnit4::class)
 class SwitchProfilesViewModelTest {
-    private val viewModel = SwitchProfilesViewModel()
+    private lateinit var context: Context
+    private lateinit var profileManager: ProfileManager
+
+    private val prefs
+        get() = context.getSharedPreferences(PROFILE_REGISTRY_FILENAME, Context.MODE_PRIVATE)
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        prefs.edit(commit = true) { clear() }
+        profileManager = ProfileManager.create(context)
+    }
+
+    private fun viewModel() = SwitchProfilesViewModel(profileManager)
 
     private val validName: ProfileName
         get() = (ProfileName.validate("Work") as ValidationResult.Valid).name
 
+    private fun createProfile(name: String) = profileManager.createNewProfile(nameOf(name))
+
+    private fun nameOf(raw: String) = (ProfileName.validate(raw) as ValidationResult.Valid).name
+
     @Test
     fun `add-profile dialog is hidden initially`() {
-        assertFalse(viewModel.isAddProfileDialogVisible.value)
+        assertFalse(viewModel().isAddProfileDialogVisible.value)
     }
 
     @Test
     fun `showAddProfileDialog makes the dialog visible`() {
+        val viewModel = viewModel()
         viewModel.showAddProfileDialog()
         assertTrue(viewModel.isAddProfileDialogVisible.value)
     }
 
     @Test
     fun `dismissAddProfileDialog hides the dialog`() {
+        val viewModel = viewModel()
         viewModel.showAddProfileDialog()
         viewModel.dismissAddProfileDialog()
         assertFalse(viewModel.isAddProfileDialogVisible.value)
@@ -35,8 +65,44 @@ class SwitchProfilesViewModelTest {
 
     @Test
     fun `addProfile hides the dialog`() {
+        val viewModel = viewModel()
         viewModel.showAddProfileDialog()
         viewModel.addProfile(validName)
         assertFalse(viewModel.isAddProfileDialogVisible.value)
+    }
+
+    @Test
+    fun `the list starts with the Default profile`() {
+        assertEquals(listOf(ProfileId.DEFAULT), viewModel().profiles.value.map { it.id })
+    }
+
+    @Test
+    fun `every registered profile is listed`() {
+        val work = createProfile("Work")
+
+        val listed = viewModel().profiles.value.map { it.id }
+
+        assertEquals(setOf(ProfileId.DEFAULT, work), listed.toSet())
+    }
+
+    @Test
+    fun `profiles are listed by name so the order is stable`() {
+        createProfile("Zebra")
+        createProfile("Alpha")
+
+        val names = viewModel().profiles.value.map { it.name }
+
+        assertEquals(listOf("Alpha", "Default", "Zebra"), names)
+    }
+
+    @Test
+    fun `refresh picks up a profile added after the view model was created`() {
+        val viewModel = viewModel()
+        createProfile("Later")
+
+        assertEquals(1, viewModel.profiles.value.size, "not visible until refreshed")
+        viewModel.refresh()
+
+        assertEquals(listOf("Default", "Later"), viewModel.profiles.value.map { it.name })
     }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

> [!NOTE]
> Assisted-by: Claude Opus 5 (commit 1 of this PR)

## Purpose / Description
- Blocked by #21809 

- The profile screen from #21328 always showed an empty list, because the ViewModel returned a hardcoded emptyList().  #21809 loads the profile during startup but throws the manager away after taking its context, so nothing could reach it. This keeps the manager around and fills the list from the real registry.

## Fixes
* Part of  #18117

## Approach
See commits

## How Has This Been Tested?
Unit test

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->