### PR TITLE
feat: Profiles switch safety

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -524,6 +524,7 @@ dependencies {
     implementation libs.nanohttpd
     implementation libs.kotlinx.serialization.json
     implementation libs.seismic
+    implementation libs.process.phoenix
 
     debugImplementation libs.androidx.fragment.testing.manifest
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -49,6 +49,7 @@ import com.ichi2.anki.logging.FragmentLifecycleLogger
 import com.ichi2.anki.logging.LogType
 import com.ichi2.anki.logging.ProductionCrashReportingTree
 import com.ichi2.anki.logging.RobolectricDebugTree
+import com.ichi2.anki.multiprofile.isPhoenixProcess
 import com.ichi2.anki.navigation.initializeNavigator
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.preferences.SharedPreferencesProvider
@@ -124,6 +125,10 @@ open class AnkiDroidApp :
      */
     @KotlinCleanup("analytics can be moved to attachBaseContext()")
     override fun onCreate() {
+        if (isPhoenixProcess()) {
+            super.onCreate()
+            return
+        }
         initAnkiBackend(debugTraceSqlCalls = false)
         super.onCreate()
         if (!setupAnkiDroidApp()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackendBackups.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackendBackups.kt
@@ -19,6 +19,8 @@ package com.ichi2.anki
 import com.ichi2.anki.CollectionManager.withCol
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 suspend fun performBackupInBackground(force: Boolean = false) {
@@ -44,7 +46,22 @@ fun <Activity> Activity.importColpkg(colpkgPath: String) where Activity : AnkiAc
     }
 }
 
-private suspend fun createBackup(force: Boolean) {
+/**
+ * Held for the whole of a background backup, including the stage the backend
+ * finishes after it has released the collection.
+ *
+ * Waiting on the backend directly does not work from elsewhere: it hands its
+ * running backup to whichever caller asks first, and [createBackup] asks as soon
+ * as the backup starts, so a second caller returns without waiting.
+ */
+val backupLock = Mutex()
+
+private suspend fun createBackup(force: Boolean) =
+    backupLock.withLock {
+        createBackupHoldingLock(force)
+    }
+
+private suspend fun createBackupHoldingLock(force: Boolean) {
     withCol {
         // this two-step approach releases the backend lock after the initial copy
         createBackup(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/AppRestart.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/AppRestart.kt
@@ -3,8 +3,56 @@
 
 package com.ichi2.anki.multiprofile
 
+import android.content.Context
 import androidx.annotation.VisibleForTesting
+import androidx.work.WorkManager
+import androidx.work.await
+import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.backupLock
+import com.ichi2.anki.common.destinations.LauncherDestination
+import com.ichi2.anki.toIntent
+import com.ichi2.anki.worker.UniqueWorkNames
+import com.ichi2.anki.worker.mediaSyncLock
+import com.ichi2.anki.worker.syncLock
+import com.jakewharton.processphoenix.ProcessPhoenix
+import kotlinx.coroutines.sync.Mutex
+import timber.log.Timber
 import java.io.File
+
+/**
+ * Restarts the app once background work has finished and the collection is closed.
+ *
+ * Sync work is cancelled once the sync lock is held, since it carries the current
+ * profile's AnkiWeb key. The work locks stay held until ProcessPhoenix kills this
+ * process, so nothing can start and reopen the collection in the meantime.
+ */
+suspend fun safeRestartApp(context: Context) {
+    Timber.i("Restarting the app")
+    syncLock.holdUnlessThrows {
+        WorkManager.getInstance(context).run {
+            cancelUniqueWork(UniqueWorkNames.SYNC).await()
+            cancelUniqueWork(UniqueWorkNames.SYNC_MEDIA).await()
+        }
+        mediaSyncLock.holdUnlessThrows {
+            backupLock.holdUnlessThrows {
+                CollectionManager.ensureClosed()
+                ProcessPhoenix.triggerRebirth(context, LauncherDestination.toIntent(context))
+            }
+        }
+    }
+}
+
+/** Holds this lock while [block] runs, and keeps holding it unless [block] throws. */
+private suspend inline fun Mutex.holdUnlessThrows(block: () -> Unit) {
+    lock()
+    var returned = false
+    try {
+        block()
+        returned = true
+    } finally {
+        if (!returned) unlock()
+    }
+}
 
 /** True in the short-lived ProcessPhoenix process, which only relaunches the app. */
 fun isPhoenixProcess(): Boolean = isPhoenixProcessName(currentProcessName())

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/AppRestart.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/AppRestart.kt
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Ashish Yadav <mailtoashish693@gmail.com>
+
+package com.ichi2.anki.multiprofile
+
+import androidx.annotation.VisibleForTesting
+import java.io.File
+
+/** True in the short-lived ProcessPhoenix process, which only relaunches the app. */
+fun isPhoenixProcess(): Boolean = isPhoenixProcessName(currentProcessName())
+
+@VisibleForTesting
+internal fun isPhoenixProcessName(name: String?): Boolean = name?.endsWith(":phoenix") == true
+
+private fun currentProcessName(): String? = runCatching { File("/proc/self/cmdline").readText().trim { it <= ' ' } }.getOrNull()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileManager.kt
@@ -145,7 +145,8 @@ class ProfileManager private constructor(
     context(_: ProfileSwitchContext)
     fun switchActiveProfile(newProfileId: ProfileId) {
         Timber.i("Switching profile to ID: $newProfileId")
-        profileRegistry.setLastActiveProfileId(newProfileId)
+        // commit, not apply: the app restarts straight after a switch, and a pending apply() would be lost
+        profileRegistry.setLastActiveProfileId(newProfileId, commit = true)
     }
 
     private fun loadProfileData(profileId: ProfileId) {
@@ -580,8 +581,11 @@ class ProfileManager private constructor(
             return id?.let { ProfileId(it) }
         }
 
-        fun setLastActiveProfileId(id: ProfileId) {
-            globalPrefs.edit { putString(KEY_LAST_ACTIVE_PROFILE_ID, id.value) }
+        fun setLastActiveProfileId(
+            id: ProfileId,
+            commit: Boolean = false,
+        ) {
+            globalPrefs.edit(commit = commit) { putString(KEY_LAST_ACTIVE_PROFILE_ID, id.value) }
         }
 
         fun getWebViewProfileId(): ProfileId? {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileSwitchChecks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileSwitchChecks.kt
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Ashish Yadav <mailtoashish693@gmail.com>
+
+package com.ichi2.anki.multiprofile
+
+import com.ichi2.anki.backupLock
+import com.ichi2.anki.multiprofile.ProfileSwitchGuard.BlockReason
+import com.ichi2.anki.multiprofile.ProfileSwitchGuard.SafetyCheck
+import com.ichi2.anki.worker.mediaSyncLock
+import com.ichi2.anki.worker.syncLock
+import kotlinx.coroutines.sync.Mutex
+
+/**
+ * Blocks a switch while the collection is syncing in the background.
+ *
+ * Only the background sync needs this: a foreground sync holds a modal progress
+ * dialog, so the user cannot reach the switch until it finishes.
+ */
+fun syncCheck() = lockCheck(syncLock, BlockReason.SYNC_IN_PROGRESS)
+
+/** Blocks a switch while media is syncing. */
+fun mediaSyncCheck() = lockCheck(mediaSyncLock, BlockReason.MEDIA_SYNC_IN_PROGRESS)
+
+/** Blocks a switch while a background backup is running. */
+fun backupCheck() = lockCheck(backupLock, BlockReason.BACKUP_IN_PROGRESS)
+
+/**
+ * Reads a lock that the work holds only while it runs, so work that is queued but
+ * waiting, such as a sync waiting for the network, does not block the switch:
+ * there is nothing to interrupt yet, and [safeRestartApp] holds the same lock, so the
+ * work cannot start part way through the restart.
+ *
+ * [safeRestartApp] waits for work that is still running, so a check exists to tell the
+ * user why the switch cannot happen yet rather than for safety.
+ */
+private fun lockCheck(
+    lock: Mutex,
+    reason: BlockReason,
+) = SafetyCheck { reason.takeIf { lock.isLocked } }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileSwitchGuard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileSwitchGuard.kt
@@ -43,8 +43,12 @@ class ProfileSwitchGuard(
         ) : Result()
     }
 
+    // TODO: COLLECTION_BUSY has no check yet: CollectionManager serialises on a
+    //  private queue it does not expose. Closing the collection already waits for a
+    //  running operation, so this is about warning the user rather than about safety.
     enum class BlockReason {
         BACKUP_IN_PROGRESS,
+        SYNC_IN_PROGRESS,
         MEDIA_SYNC_IN_PROGRESS,
         COLLECTION_BUSY,
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
@@ -38,8 +38,15 @@ import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.ext.trySetForeground
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
 import net.ankiweb.rsdroid.Backend
 import timber.log.Timber
+
+/**
+ * Held while a media sync runs. A profile switch holds it until the process dies,
+ * so a media sync cannot start part way through a restart.
+ */
+val mediaSyncLock = Mutex()
 
 class SyncMediaWorker(
     context: Context,
@@ -55,7 +62,10 @@ class SyncMediaWorker(
 
     override suspend fun doWork(): Result {
         Timber.v("SyncMediaWorker::doWork")
+        return mediaSyncLock.withLockUnlessSwitching { doWorkHoldingLock() }
+    }
 
+    private suspend fun doWorkHoldingLock(): Result {
         try {
             val auth =
                 syncAuth {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncWorker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncWorker.kt
@@ -39,8 +39,15 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
 import timber.log.Timber
 import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Held while a background collection sync runs. A profile switch holds it until
+ * the process dies, so a sync cannot start part way through a restart.
+ */
+val syncLock = Mutex()
 
 /**
  * Syncs collection and media in the background.
@@ -70,6 +77,10 @@ class SyncWorker(
 
     override suspend fun doWork(): Result {
         Timber.v("SyncWorker::doWork")
+        return syncLock.withLockUnlessSwitching { doWorkHoldingLock() }
+    }
+
+    private suspend fun doWorkHoldingLock(): Result {
         trySetForeground(getForegroundInfo())
 
         val hkey =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/worker/WithLockUnlessSwitching.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/worker/WithLockUnlessSwitching.kt
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Ashish Yadav <mailtoashish693@gmail.com>
+
+package com.ichi2.anki.worker
+
+import androidx.work.ListenableWorker.Result
+import kotlinx.coroutines.sync.Mutex
+import timber.log.Timber
+
+/**
+ * Runs [block] holding this lock. If a profile switch holds it, the work is dropped
+ * rather than rescheduled, since it carries the AnkiWeb key of the profile being left.
+ */
+internal suspend fun Mutex.withLockUnlessSwitching(block: suspend () -> Result): Result {
+    if (!tryLock()) {
+        Timber.i("Background work dropped: a profile switch is restarting the app")
+        return Result.failure()
+    }
+    try {
+        return block()
+    } finally {
+        unlock()
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupMetaTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupMetaTest.kt
@@ -38,6 +38,7 @@ class ActivityStartupMetaTest : RobolectricTest() {
                 .filter { !it.startsWith("org.acra") }
                 .filter { !it.startsWith("leakcanary.internal") }
                 .filter { it != "com.canhub.cropper.CropImageActivity" }
+                .filter { it != "com.jakewharton.processphoenix.PhoenixActivity" }
                 .toTypedArray()
         MatcherAssert.assertThat(testedActivityClassNames, Matchers.containsInAnyOrder(*manifestActivityNames))
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/AppRestartTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/AppRestartTest.kt
@@ -3,15 +3,193 @@
 
 package com.ichi2.anki.multiprofile
 
+import android.app.Application
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import androidx.core.content.IntentCompat
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.work.WorkInfo
+import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.IntentHandler
 import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.backupLock
+import com.ichi2.anki.worker.UniqueWorkNames
+import com.ichi2.anki.worker.mediaSyncLock
+import com.ichi2.anki.worker.syncLock
+import com.jakewharton.processphoenix.PhoenixActivity
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
 class AppRestartTest : RobolectricTest() {
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    private val backgroundWorkLocks get() = listOf(syncLock, mediaSyncLock, backupLock)
+
+    @After
+    override fun tearDown() {
+        backgroundWorkLocks.filter { it.isLocked }.forEach { it.unlock() }
+        super.tearDown()
+    }
+
+    private fun startedActivities() = shadowOf(context as Application)
+
+    /** The intent ProcessPhoenix relaunches once it has killed this process. */
+    private fun relaunchIntent(): Intent? {
+        val phoenix = startedActivities().nextStartedActivity ?: return null
+        assertEquals(PhoenixActivity::class.java.name, phoenix.component?.className)
+        return IntentCompat.getParcelableArrayListExtra(phoenix, "phoenix_restart_intents", Intent::class.java)?.single()
+    }
+
+    @Test
+    fun `restart relaunches the launcher in a cleared task through ProcessPhoenix`() =
+        runTest {
+            safeRestartApp(context)
+
+            val intent = assertNotNull(relaunchIntent(), "ProcessPhoenix must be handed the relaunch")
+            assertEquals(IntentHandler::class.java.name, intent.component?.className)
+            assertTrue(intent.categories.contains(Intent.CATEGORY_LAUNCHER))
+            assertTrue(intent.flags and Intent.FLAG_ACTIVITY_CLEAR_TASK != 0, "the old profile's activities must not survive")
+        }
+
+    @Test
+    fun `restart closes the collection before handing over to ProcessPhoenix`() =
+        runTest {
+            CollectionManager.ensureOpen()
+
+            safeRestartApp(context)
+
+            assertFalse(CollectionManager.isOpenUnsafe(), "the process is killed next, and a write in flight could corrupt it")
+        }
+
+    @Test
+    fun `restart cancels sync work queued for the profile being left`() =
+        runTest {
+            context.enqueueWaiting(UniqueWorkNames.SYNC)
+            context.enqueueWaiting(UniqueWorkNames.SYNC_MEDIA)
+
+            safeRestartApp(context)
+
+            assertEquals(WorkInfo.State.CANCELLED, context.workState(UniqueWorkNames.SYNC), "it carries this profile's AnkiWeb key")
+            assertEquals(WorkInfo.State.CANCELLED, context.workState(UniqueWorkNames.SYNC_MEDIA), "it carries this profile's AnkiWeb key")
+        }
+
+    @Test
+    fun `restart cancels a media sync enqueued by a sync that is still finishing`() =
+        runTest {
+            syncLock.lock()
+            val restart = launch { safeRestartApp(context) }
+            advanceUntilIdle()
+
+            // SyncWorker enqueues the media sync before it releases syncLock
+            context.enqueueWaiting(UniqueWorkNames.SYNC_MEDIA)
+
+            syncLock.unlock()
+            restart.join()
+
+            assertEquals(
+                WorkInfo.State.CANCELLED,
+                context.workState(UniqueWorkNames.SYNC_MEDIA),
+                "it carries this profile's AnkiWeb key",
+            )
+        }
+
+    @Test
+    fun `restart cancels a media sync instead of waiting for it to finish`() =
+        runTest {
+            mediaSyncLock.lock()
+            context.enqueueWaiting(UniqueWorkNames.SYNC_MEDIA)
+            val restart = launch { safeRestartApp(context) }
+            advanceUntilIdle()
+
+            assertEquals(
+                WorkInfo.State.CANCELLED,
+                context.workState(UniqueWorkNames.SYNC_MEDIA),
+                "otherwise the restart sits through a media sync it is about to cancel",
+            )
+
+            mediaSyncLock.unlock()
+            restart.join()
+        }
+
+    @Test
+    fun `a cancelled restart releases only the locks it took`() =
+        runTest {
+            backupLock.lock()
+            val restart = launch { safeRestartApp(context) }
+            advanceUntilIdle()
+
+            restart.cancelAndJoin()
+
+            assertFalse(syncLock.isLocked, "a cancelled restart must not leave syncing blocked")
+            assertFalse(mediaSyncLock.isLocked, "a cancelled restart must not leave media syncing blocked")
+            assertTrue(backupLock.isLocked, "the backup that is still writing holds it")
+        }
+
+    @Test
+    fun `restart keeps the locks until the process is killed`() =
+        runTest {
+            safeRestartApp(context)
+
+            backgroundWorkLocks.forEach { assertTrue(it.isLocked, "work must not start before ProcessPhoenix kills the process") }
+        }
+
+    @Test
+    fun `restart releases the locks if it cannot hand over to ProcessPhoenix`() =
+        runTest {
+            val refusesActivities =
+                object : ContextWrapper(context) {
+                    override fun startActivity(intent: Intent) = throw IllegalStateException("cannot start activities")
+                }
+
+            assertFailsWith<IllegalStateException> { safeRestartApp(refusesActivities) }
+
+            backgroundWorkLocks.forEach { assertFalse(it.isLocked, "a failed restart must not leave sync and backup blocked") }
+        }
+
+    private suspend fun TestScope.assertRestartWaitsFor(
+        lock: Mutex,
+        why: String,
+    ) {
+        lock.lock()
+        val restart = launch { safeRestartApp(context) }
+
+        advanceUntilIdle()
+        assertNull(startedActivities().peekNextStartedActivity(), why)
+
+        lock.unlock()
+        restart.join()
+        assertNotNull(relaunchIntent(), "the restart must go ahead once the work has finished")
+    }
+
+    @Test
+    fun `restart waits for a backup that is still writing`() =
+        runTest { assertRestartWaitsFor(backupLock, "killing the process mid-write can leave a truncated backup") }
+
+    @Test
+    fun `restart waits for a sync that started after the checks passed`() =
+        runTest { assertRestartWaitsFor(syncLock, "a sync can start between the checks and the restart") }
+
+    @Test
+    fun `restart waits for a media sync that started after the checks passed`() =
+        runTest { assertRestartWaitsFor(mediaSyncLock, "a media sync can start between the checks and the restart") }
+
     @Test
     fun `only the ProcessPhoenix process is recognised as it`() {
         assertTrue(isPhoenixProcessName("com.ichi2.anki:phoenix"))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/AppRestartTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/AppRestartTest.kt
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Ashish Yadav <mailtoashish693@gmail.com>
+
+package com.ichi2.anki.multiprofile
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@RunWith(AndroidJUnit4::class)
+class AppRestartTest : RobolectricTest() {
+    @Test
+    fun `only the ProcessPhoenix process is recognised as it`() {
+        assertTrue(isPhoenixProcessName("com.ichi2.anki:phoenix"))
+        assertFalse(isPhoenixProcessName("com.ichi2.anki"))
+        assertFalse(isPhoenixProcessName("com.ichi2.anki:acra"))
+        assertFalse(isPhoenixProcessName(null))
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/ProfileManagerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/ProfileManagerTest.kt
@@ -236,6 +236,27 @@ class ProfileManagerTest {
     }
 
     @Test
+    fun `switching the profile persists synchronously so it survives the process kill`() {
+        val registry = RecordingPreferences(context.getSharedPreferences(PROFILE_REGISTRY_FILENAME, Context.MODE_PRIVATE))
+        val wrapper =
+            object : ContextWrapper(context) {
+                override fun getApplicationContext(): Context? = null
+
+                override fun getSharedPreferences(
+                    name: String,
+                    mode: Int,
+                ): SharedPreferences = if (name == PROFILE_REGISTRY_FILENAME) registry else super.getSharedPreferences(name, mode)
+            }
+        val manager = ProfileManager.create(wrapper)
+        registry.editors.clear()
+
+        with(ProfileManager.ProfileSwitchContext) { manager.switchActiveProfile(ProfileId("p_other")) }
+
+        assertEquals("apply() is async and is lost when the process is killed", 1, registry.editors.sumOf { it.commits })
+        assertEquals(0, registry.editors.sumOf { it.applies })
+    }
+
+    @Test
     fun `ProfileId DEFAULT must be strictly 'default' to preserve legacy compatibility`() {
         assertEquals("default", ProfileId.DEFAULT.value)
     }
@@ -609,6 +630,31 @@ class ProfileManagerTest {
     }
 
     /** Stubs [CookieManager.getInstance]. [completesRemoval] fires the cookie removal callback. */
+    private class RecordingEditor(
+        private val delegate: SharedPreferences.Editor,
+    ) : SharedPreferences.Editor by delegate {
+        var commits = 0
+        var applies = 0
+
+        override fun commit(): Boolean {
+            commits++
+            return delegate.commit()
+        }
+
+        override fun apply() {
+            applies++
+            delegate.apply()
+        }
+    }
+
+    private class RecordingPreferences(
+        private val delegate: SharedPreferences,
+    ) : SharedPreferences by delegate {
+        val editors = mutableListOf<RecordingEditor>()
+
+        override fun edit(): SharedPreferences.Editor = RecordingEditor(delegate.edit()).also { editors += it }
+    }
+
     private fun mockCookieManager(completesRemoval: Boolean = true): CookieManager {
         mockkStatic(CookieManager::class)
         val cookieManager = mockk<CookieManager>(relaxed = true)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/ProfileSwitchChecksTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/ProfileSwitchChecksTest.kt
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Ashish Yadav <mailtoashish693@gmail.com>
+
+package com.ichi2.anki.multiprofile
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.backupLock
+import com.ichi2.anki.multiprofile.ProfileSwitchGuard.BlockReason
+import com.ichi2.anki.worker.UniqueWorkNames
+import com.ichi2.anki.worker.mediaSyncLock
+import com.ichi2.anki.worker.syncLock
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@RunWith(AndroidJUnit4::class)
+class ProfileSwitchChecksTest : RobolectricTest() {
+    private fun enqueueMediaSync() = targetContext.enqueueWaiting(UniqueWorkNames.SYNC_MEDIA)
+
+    private fun enqueueSync() = targetContext.enqueueWaiting(UniqueWorkNames.SYNC)
+
+    @Test
+    fun `no media sync means no reason to block`() =
+        runTest {
+            assertNull(mediaSyncCheck().verify())
+        }
+
+    @Test
+    fun `a media sync waiting for the network does not block the switch`() =
+        runTest {
+            enqueueMediaSync()
+
+            assertNull(mediaSyncCheck().verify(), "queued work has nothing to interrupt")
+        }
+
+    @Test
+    fun `no running backup means no reason to block`() =
+        runTest {
+            assertNull(backupCheck().verify())
+        }
+
+    @Test
+    fun `a running backup blocks the switch`() =
+        runTest {
+            backupLock.withLock { assertEquals(BlockReason.BACKUP_IN_PROGRESS, backupCheck().verify()) }
+        }
+
+    @Test
+    fun `no background sync means no reason to block`() =
+        runTest {
+            assertNull(syncCheck().verify())
+        }
+
+    @Test
+    fun `a sync waiting for the network does not block the switch`() =
+        runTest {
+            enqueueSync()
+
+            assertNull(syncCheck().verify(), "offline, a queued sync would block switching forever")
+        }
+
+    @Test
+    fun `a running sync blocks the switch`() =
+        runTest {
+            syncLock.withLock { assertEquals(BlockReason.SYNC_IN_PROGRESS, syncCheck().verify()) }
+        }
+
+    @Test
+    fun `a running media sync blocks the switch`() =
+        runTest {
+            mediaSyncLock.withLock { assertEquals(BlockReason.MEDIA_SYNC_IN_PROGRESS, mediaSyncCheck().verify()) }
+        }
+
+    @Test
+    fun `a media sync does not count as a collection sync`() =
+        runTest {
+            mediaSyncLock.withLock { assertNull(syncCheck().verify(), "each check reports its own reason") }
+        }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/WaitingWork.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/WaitingWork.kt
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Ashish Yadav <mailtoashish693@gmail.com>
+
+package com.ichi2.anki.multiprofile
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+
+class NeverRuns(
+    context: Context,
+    params: WorkerParameters,
+) : Worker(context, params) {
+    override fun doWork(): Result = Result.success()
+}
+
+/** Queues work that waits on a constraint, as a sync does while offline. */
+fun Context.enqueueWaiting(uniqueWorkName: String) {
+    WorkManager
+        .getInstance(this)
+        .enqueueUniqueWork(
+            uniqueWorkName,
+            ExistingWorkPolicy.KEEP,
+            OneTimeWorkRequestBuilder<NeverRuns>()
+                .setConstraints(Constraints.Builder().setRequiresCharging(true).build())
+                .build(),
+        )
+}
+
+fun Context.workState(uniqueWorkName: String): WorkInfo.State? =
+    WorkManager
+        .getInstance(this)
+        .getWorkInfosForUniqueWork(uniqueWorkName)
+        .get()
+        .singleOrNull()
+        ?.state

--- a/AnkiDroid/src/test/java/com/ichi2/anki/worker/SyncWorkerLockTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/worker/SyncWorkerLockTest.kt
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Ashish Yadav <mailtoashish693@gmail.com>
+
+package com.ichi2.anki.worker
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.work.CoroutineWorker
+import androidx.work.ListenableWorker
+import androidx.work.testing.TestListenableWorkerBuilder
+import com.ichi2.anki.RobolectricTest
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * A [RobolectricTest] because running a worker creates a backend through `TR`, and its
+ * teardown is what discards the backend. A leftover backend defeats tests that swap
+ * the backend factory, such as `BackendEmulatingOpenConflictTest`.
+ */
+@RunWith(AndroidJUnit4::class)
+class SyncWorkerLockTest : RobolectricTest() {
+    private inline fun <reified W : CoroutineWorker> worker(): W = TestListenableWorkerBuilder<W>(targetContext).build()
+
+    private suspend fun assertDroppedWhileSwitching(
+        lock: Mutex,
+        run: suspend () -> ListenableWorker.Result,
+    ) = lock.withLock {
+        assertIs<ListenableWorker.Result.Failure>(run(), "rescheduled, it would run later with the AnkiWeb key of the profile being left")
+        assertTrue(lock.isLocked, "the worker must not release a lock the switch holds")
+    }
+
+    private suspend fun assertReleasesAfterRunning(
+        lock: Mutex,
+        run: suspend () -> ListenableWorker.Result,
+    ) {
+        runCatching { run() }
+        assertFalse(lock.isLocked, "a finished sync must not leave switching blocked")
+    }
+
+    @Test
+    fun `a sync is dropped while a profile switch holds its lock`() =
+        runTest { assertDroppedWhileSwitching(syncLock) { worker<SyncWorker>().doWork() } }
+
+    @Test
+    fun `a media sync is dropped while a profile switch holds its lock`() =
+        runTest { assertDroppedWhileSwitching(mediaSyncLock) { worker<SyncMediaWorker>().doWork() } }
+
+    @Test
+    fun `a sync releases its lock when it finishes`() = runTest { assertReleasesAfterRunning(syncLock) { worker<SyncWorker>().doWork() } }
+
+    @Test
+    fun `a media sync releases its lock when it finishes`() =
+        runTest { assertReleasesAfterRunning(mediaSyncLock) { worker<SyncMediaWorker>().doWork() } }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -112,6 +112,8 @@ mockitoKotlin = "6.3.0"
 mockk = "1.14.11"
 nanohttpd = "2.3.1"
 okhttp = "5.4.0"
+# https://github.com/JakeWharton/ProcessPhoenix/releases
+processPhoenix = "3.0.0"
 # https://github.com/protocolbuffers/protobuf/releases
 protobufKotlinLite = "4.35.1"
 # ../AnkiDroid/robolectricDownload.gradle may need changes - read instructions in that file
@@ -198,6 +200,7 @@ okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 android-lint-api = { module = "com.android.tools.lint:lint-api", version.ref = "lint" }
 android-lint = { module = "com.android.tools.lint:lint", version.ref = "lint" }
 android-lint-tests = { module = "com.android.tools.lint:lint-tests", version.ref = "lint" }
+process-phoenix = { module = "com.jakewharton:process-phoenix", version.ref = "processPhoenix" }
 protobuf-kotlin-lite = { module = "com.google.protobuf:protobuf-kotlin-lite", version.ref = "protobufKotlinLite" }
 search-preference = { module = "com.github.ByteHamster:SearchPreference", version.ref = "searchpreference" }
 seismic = { module = "com.squareup:seismic", version.ref = "seismic" }


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Assisted-by: Claude Opus 5

## Purpose / Description
Switching profiles has to restart the app, because the backend, WebView and SharedPreferences all hold on to the old profile's paths. Nothing did that restart yet, and nothing stopped a switch from killing a sync or backup halfway through. This adds the restart and the checks that guard it. Nothing calls them yet; wiring them to the profile list is the next PR.

## Fixes
* Fixes part to #18117

## Approach
See commits

## How Has This Been Tested?
Unit tests cover the restart

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

## Licenses

| Library | Description | License |
| --- | --- | --- |
| [Process Phoenix](https://github.com/JakeWharton/ProcessPhoenix) | A special activity which facilitates restarting your application process | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |


**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging