### PR TITLE
fix(media-check) use current theme colors

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/mediacheck/MediaCheckFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/mediacheck/MediaCheckFragment.kt
@@ -36,6 +36,7 @@ import androidx.lifecycle.lifecycleScope
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.SingleFragmentActivity
+import com.ichi2.anki.common.utils.android.getColorFromAttr
 import com.ichi2.anki.databinding.FragmentMediaCheckBinding
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.ui.internationalization.sentenceCase
@@ -131,11 +132,19 @@ class MediaCheckFragment : Fragment(R.layout.fragment_media_check) {
     }
 
     private fun updateWebView(report: String) {
+        val backgroundColor = getColorFromAttr(requireContext(), android.R.attr.colorBackground)
+        val textColor = getColorFromAttr(requireContext(), android.R.attr.textColorPrimary)
+
+        val backgroundColorHex = String.format("#%06X", 0xFFFFFF and backgroundColor)
+        val textColorHex = String.format("#%06X", 0xFFFFFF and textColor)
+
         val html =
             """
             <html>
                 <body style="
-                      padding: 0px 8px;
+                    background-color: $backgroundColorHex;
+                    color: $textColorHex;
+                    padding: 0px 8px;
                     font-size:14px;
                     white-space: pre-wrap;">$report
                 </body>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/mediacheck/MediaCheckFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/mediacheck/MediaCheckFragment.kt
@@ -47,6 +47,7 @@ import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
 import com.ichi2.utils.show
 import com.ichi2.utils.title
+import com.ichi2.utils.toRGBHex
 import dev.androidbroadcast.vbpd.viewBinding
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -135,8 +136,8 @@ class MediaCheckFragment : Fragment(R.layout.fragment_media_check) {
         val backgroundColor = getColorFromAttr(requireContext(), android.R.attr.colorBackground)
         val textColor = getColorFromAttr(requireContext(), android.R.attr.textColorPrimary)
 
-        val backgroundColorHex = String.format("#%06X", 0xFFFFFF and backgroundColor)
-        val textColorHex = String.format("#%06X", 0xFFFFFF and textColor)
+        val backgroundColorHex = backgroundColor.toRGBHex()
+        val textColorHex = textColor.toRGBHex()
 
         val html =
             """


### PR DESCRIPTION
> [!NOTE]
> This PR was part of the `swe-productivity` research study. 
> My review was performed: https://github.com/swe-productivity/Anki-Android/pull/11/
> I have cherry-picked these commits and fixed up compile errors due to conflicts

----

> <!--- Please fill the necessary details below -->
> ## Purpose / Description
> 
> The MediaCheck screen uses a web view, but doesn't apply and styling to the view. I've added some simple syling,
> pulling colors from the current theme.
> 
> ## Fixes
> * Fixes #18594
> 
> ## Approach
> 
> I added code to fetch the text and background colors from the current theme, and add them to the inline
> styles in the HTML content.
> 
> ## How Has This Been Tested?
> 
> Reproduction steps:
> 
> - From the main view, select `Check` > `Check Media` from the overflow menu
> - Select `Ok` in the prompt
> 
> The media check view previously always showed black text on a white background, but with these changes, it
> now uses the text and background colors from the currently selected theme.
> 
> Before:
> <img width="270" alt="image" src="https://github.com/user-attachments/assets/f8966231-3e26-46c4-ae58-589ab35180b8" />
> 
> 
> After
> <img width="270" alt="image" src="https://github.com/user-attachments/assets/84cf6d13-9291-4f28-b82c-636ebc938e51" />
> 
> ## Checklist
> 
> - [x] You have a descriptive commit message with a short title (first line, max 50 chars).
> - [x] You have commented your code, particularly in hard-to-understand areas
> - [x] You have performed a self-review of your own code
> - [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
> - [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
> 