### PR TITLE
feat: Deckpicker progress adoption

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -119,6 +119,7 @@ import com.ichi2.anki.databinding.IncludeDeckPickerBinding
 import com.ichi2.anki.databinding.IncludeFloatingAddButtonBinding
 import com.ichi2.anki.deckpicker.BackgroundImage
 import com.ichi2.anki.deckpicker.DeckDeletionResult
+import com.ichi2.anki.deckpicker.DeckPickerProgress
 import com.ichi2.anki.deckpicker.DeckPickerViewModel
 import com.ichi2.anki.deckpicker.DeckPickerViewModel.AnkiDroidEnvironment
 import com.ichi2.anki.deckpicker.DeckPickerViewModel.FlattenedDeckList
@@ -164,6 +165,7 @@ import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.pages.AnkiPackageImporterFragment
 import com.ichi2.anki.pages.CongratsPage
 import com.ichi2.anki.pages.CongratsPage.Companion.onDeckCompleted
+import com.ichi2.anki.progress.observeProgress
 import com.ichi2.anki.receiver.SdCardReceiver
 import com.ichi2.anki.reviewreminders.ReviewReminderScope
 import com.ichi2.anki.reviewreminders.ReviewRemindersDatabase
@@ -624,6 +626,7 @@ open class DeckPicker :
             onReceiveContentListener,
         )
 
+        observeProgress(viewModel) { progress -> progressMessage(progress) }
         setupFlows()
     }
 
@@ -1431,9 +1434,7 @@ open class DeckPicker :
             }
             R.id.action_deck_delete -> {
                 launchCatchingTask {
-                    withProgress(resources.getString(R.string.delete_deck)) {
-                        viewModel.deleteSelectedDeck().join()
-                    }
+                    viewModel.deleteSelectedDeck().join()
                 }
                 return true
             }
@@ -1453,9 +1454,7 @@ open class DeckPicker :
 
     private fun createBackup() {
         launchCatchingTask {
-            withProgress(message = TR.profilesCreatingBackup()) {
-                performBackupInBackground(true)
-            }
+            viewModel.createBackup()
             showThemedToast(this@DeckPicker, TR.profilesBackupCreated(), false)
         }
     }
@@ -2283,17 +2282,13 @@ open class DeckPicker :
      */
     fun deleteDeck(did: DeckId) =
         launchCatchingTask {
-            withProgress(resources.getString(R.string.delete_deck)) {
-                viewModel.deleteDeck(did).join()
-            }
+            viewModel.deleteDeck(did).join()
         }
 
     @NeedsTest("14285: regression test to ensure UI is updated after this call")
     fun rebuildFiltered(did: DeckId) {
         launchCatchingTask {
-            withProgress(resources.getString(R.string.rebuild_filtered_deck)) {
-                viewModel.rebuildFilteredDeck(did).join()
-            }
+            viewModel.rebuildFilteredDeck(did).join()
             updateDeckList()
             tryShowStudyOptionsPanel()
         }
@@ -2301,9 +2296,7 @@ open class DeckPicker :
 
     private fun emptyFiltered(did: DeckId) {
         launchCatchingTask {
-            withProgress {
-                viewModel.emptyFilteredDeck(did).join()
-            }
+            viewModel.emptyFilteredDeck(did).join()
         }
     }
 
@@ -2508,3 +2501,11 @@ class CollectionLoadingErrorDialog :
 
 val ActivityHomescreenBinding.studyoptionsFrame: FragmentContainerView?
     get() = studyoptionsFragment
+
+private fun Context.progressMessage(progress: DeckPickerProgress): String =
+    when (progress) {
+        DeckPickerProgress.DELETING_DECK -> getString(R.string.delete_deck)
+        DeckPickerProgress.REBUILDING_FILTERED_DECK -> getString(R.string.rebuild_filtered_deck)
+        DeckPickerProgress.DELETING_EMPTY_CARDS -> TR.emptyCardsDeleting()
+        DeckPickerProgress.CREATING_BACKUP -> TR.profilesCreatingBackup()
+    }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -38,6 +38,8 @@ import com.ichi2.anki.libanki.utils.extend
 import com.ichi2.anki.notetype.ManageNoteTypesDestination
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.performBackupInBackground
+import com.ichi2.anki.progress.HasProgress
+import com.ichi2.anki.progress.ProgressManager
 import com.ichi2.anki.reviewreminders.ScheduleRemindersDestination
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.syncAuth
@@ -63,7 +65,10 @@ import com.ichi2.anki.common.destinations.Destination as NavigateDestination
  */
 class DeckPickerViewModel :
     ViewModel(),
-    OnErrorListener {
+    OnErrorListener,
+    HasProgress<DeckPickerProgress> {
+    override val progressManager = ProgressManager<DeckPickerProgress>()
+
     val flowOfStartupResponse = MutableStateFlow<StartupResponse?>(null)
 
     private val flowOfDeckDueTree = MutableStateFlow<DeckNode?>(null)
@@ -186,28 +191,26 @@ class DeckPickerViewModel :
     /**
      * Deletes the provided deck, child decks. and all cards inside.
      *
-     * This is a slow operation and should be inside `withProgress`
-     *
      * @param did ID of the deck to delete
      */
-    @CheckResult // This is a slow operation and should be inside `withProgress`
+    @CheckResult
     fun deleteDeck(did: DeckId) =
         viewModelScope.launch {
-            val deckName = withCol { decks.getLegacy(did)!!.name }
-            val changes = undoableOp { decks.remove(listOf(did)) }
-            // After deletion: decks.current() reverts to Default, necessitating `focusedDeck`
-            // to match and avoid unnecessary scrolls in `renderPage()`.
-            focusedDeck = Consts.DEFAULT_DECK_ID
+            progressManager.withProgress(message = DeckPickerProgress.DELETING_DECK) {
+                val deckName = withCol { decks.getLegacy(did)!!.name }
+                val changes = undoableOp { decks.remove(listOf(did)) }
+                // After deletion: decks.current() reverts to Default, necessitating `focusedDeck`
+                // to match and avoid unnecessary scrolls in `renderPage()`.
+                focusedDeck = Consts.DEFAULT_DECK_ID
 
-            deckDeletedNotification.emit(
-                DeckDeletionResult(deckName = deckName, cardsDeleted = changes.count),
-            )
+                deckDeletedNotification.emit(
+                    DeckDeletionResult(deckName = deckName, cardsDeleted = changes.count),
+                )
+            }
         }
 
     /**
      * Deletes the currently selected deck
-     *
-     * This is a slow operation and should be inside `withProgress`
      */
     @CheckResult
     fun deleteSelectedDeck() =
@@ -227,28 +230,31 @@ class DeckPickerViewModel :
         report: EmptyCardsReport,
         preserveNotes: Boolean,
     ) = viewModelScope.launch {
-        // https://github.com/ankitects/anki/blob/39e293b27d36318e00131fd10144755eec8d1922/qt/aqt/emptycards.py#L98-L109
-        val toDelete = mutableListOf<CardId>()
+        progressManager.withProgress(message = DeckPickerProgress.DELETING_EMPTY_CARDS) {
+            // https://github.com/ankitects/anki/blob/39e293b27d36318e00131fd10144755eec8d1922/qt/aqt/emptycards.py#L98-L109
+            val toDelete = mutableListOf<CardId>()
 
-        for (note in report.notesList) {
-            if (preserveNotes && note.willDeleteNote) {
-                // leave first card
-                toDelete.extend(note.cardIdsList.drop(1))
-            } else {
-                toDelete.extend(note.cardIdsList)
+            for (note in report.notesList) {
+                if (preserveNotes && note.willDeleteNote) {
+                    // leave first card
+                    toDelete.extend(note.cardIdsList.drop(1))
+                } else {
+                    toDelete.extend(note.cardIdsList)
+                }
             }
+            val result = undoableOp { removeCardsAndOrphanedNotes(toDelete) }
+            emptyCardsNotification.emit(EmptyCardsResult(cardsDeleted = result.count))
         }
-        val result = undoableOp { removeCardsAndOrphanedNotes(toDelete) }
-        emptyCardsNotification.emit(EmptyCardsResult(cardsDeleted = result.count))
     }
 
-    // TODO: move withProgress to the ViewModel, so we don't return 'Job'
     fun emptyFilteredDeck(deckId: DeckId): Job =
         viewModelScope.launch {
-            Timber.i("empty filtered deck %s", deckId)
-            withCol { decks.select(deckId) }
-            undoableOp { sched.emptyFilteredDeck(decks.selected()) }
-            flowOfDeckCountsChanged.emit(Unit)
+            progressManager.withProgress {
+                Timber.i("empty filtered deck %s", deckId)
+                withCol { decks.select(deckId) }
+                undoableOp { sched.emptyFilteredDeck(decks.selected()) }
+                flowOfDeckCountsChanged.emit(Unit)
+            }
         }
 
     /**
@@ -257,12 +263,14 @@ class DeckPickerViewModel :
     @CheckResult
     fun rebuildFilteredDeck(deckId: DeckId): Job =
         viewModelScope.launch {
-            Timber.i("rebuilding filtered deck %s", deckId)
-            withCol {
-                decks.select(deckId)
-                sched.rebuildFilteredDeck(decks.selected())
+            progressManager.withProgress(message = DeckPickerProgress.REBUILDING_FILTERED_DECK) {
+                Timber.i("rebuilding filtered deck %s", deckId)
+                withCol {
+                    decks.select(deckId)
+                    sched.rebuildFilteredDeck(decks.selected())
+                }
+                flowOfDeckCountsChanged.emit(Unit)
             }
-            flowOfDeckCountsChanged.emit(Unit)
         }
 
     /**
@@ -345,6 +353,11 @@ class DeckPickerViewModel :
     fun scheduleReviewReminders(deckId: DeckId) =
         viewModelScope.launch {
             flowOfDestination.emit(ScheduleRemindersDestination(deckId))
+        }
+
+    suspend fun createBackup() =
+        progressManager.withProgress(message = DeckPickerProgress.CREATING_BACKUP) {
+            performBackupInBackground(force = true)
         }
 
     /**
@@ -661,6 +674,14 @@ class DeckPickerViewModel :
     companion object {
         const val UPGRADE_VERSION_KEY = "lastUpgradeVersion"
     }
+}
+
+/** The operation [DeckPickerViewModel] is running, shown as a progress message by the UI. */
+enum class DeckPickerProgress {
+    DELETING_DECK,
+    REBUILDING_FILTERED_DECK,
+    DELETING_EMPTY_CARDS,
+    CREATING_BACKUP,
 }
 
 /** Result of [DeckPickerViewModel.deleteDeck] */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EmptyCardsDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EmptyCardsDialogFragment.kt
@@ -44,7 +44,6 @@ import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.NoteId
 import com.ichi2.anki.libanki.emptyCids
 import com.ichi2.anki.ui.internationalization.sentenceCase
-import com.ichi2.anki.withProgress
 import com.ichi2.utils.message
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
@@ -299,8 +298,6 @@ fun DeckPicker.startDeletingEmptyCards(
         keepNotes,
     )
     launchCatchingTask {
-        withProgress(TR.emptyCardsDeleting()) {
-            viewModel.deleteEmptyCards(report, keepNotes).join()
-        }
+        viewModel.deleteEmptyCards(report, keepNotes).join()
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LoadingDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LoadingDialogFragment.kt
@@ -65,9 +65,10 @@ class LoadingDialogFragment : DialogFragment() {
  * if it's already showing and the new call doesn't modify input parameters(ex. [cancellable]). In
  * any other cases, the old instance will be removed and a new one will be used.
  *
- * Note: Multiple calls of this method will result in a single dialog being shown, this also
- * implies that a call to [dismissLoadingDialog] will dismiss the dialogs of all calls. Callers need
- * to handle this scenario by combining the loading states and manually handling showing/dismissing.
+ * Note: Multiple calls with the same [tag] will result in a single dialog being shown, this also
+ * implies that a call to [dismissLoadingDialog] with that [tag] will dismiss the dialogs of all
+ * those calls. Callers need to handle this scenario by combining the loading states and manually
+ * handling showing/dismissing, or by using different tags.
  *
  * @param message the message to show along with the [LoadingIndicator] or null to default to
  * use "Processing..."
@@ -78,9 +79,10 @@ class LoadingDialogFragment : DialogFragment() {
 fun AnkiActivity.showLoadingDialog(
     message: String? = null,
     cancellable: Boolean = true,
+    tag: String = LoadingDialogFragment.TAG,
 ) {
     val fragment =
-        supportFragmentManager.findFragmentByTag(LoadingDialogFragment.TAG) as? LoadingDialogFragment
+        supportFragmentManager.findFragmentByTag(tag) as? LoadingDialogFragment
     val isAlreadyShowing = fragment?.dialog?.isShowing == true
     if (isAlreadyShowing) {
         // if a dialog is already showing and it has the same input params then just update the
@@ -97,7 +99,7 @@ fun AnkiActivity.showLoadingDialog(
     removeImmediately(fragment)
     val loadingDialog = LoadingDialogFragment.newInstance(message, cancellable)
     // showNow() avoids a race condition - removal is synchronous
-    loadingDialog.showNow(supportFragmentManager, LoadingDialogFragment.TAG)
+    loadingDialog.showNow(supportFragmentManager, tag)
 }
 
 /** Synchronously removes the provided [LoadingDialogFragment] if valid(not null) */
@@ -108,10 +110,10 @@ private fun AnkiActivity.removeImmediately(fragment: LoadingDialogFragment?) {
 }
 
 /**
- * Dismisses and removes the current displayed [LoadingDialogFragment] if one is present.
+ * Dismisses and removes the [LoadingDialogFragment] shown with [tag] if one is present.
  */
-fun AnkiActivity.dismissLoadingDialog() {
+fun AnkiActivity.dismissLoadingDialog(tag: String = LoadingDialogFragment.TAG) {
     val fragment =
-        supportFragmentManager.findFragmentByTag(LoadingDialogFragment.TAG) as? LoadingDialogFragment
+        supportFragmentManager.findFragmentByTag(tag) as? LoadingDialogFragment
     removeImmediately(fragment)
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/progress/ProgressObserver.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/progress/ProgressObserver.kt
@@ -29,8 +29,8 @@ fun <M : Any> AnkiActivity.observeProgress(
     delayMillis: Duration = 600.milliseconds,
     resolveMessage: Context.(M) -> String,
 ) {
-    var dialogVisible =
-        supportFragmentManager.findFragmentByTag(LoadingDialogFragment.TAG) != null
+    val dialogTag = "${LoadingDialogFragment.TAG}:${viewModel.javaClass.name}"
+    var dialogVisible = supportFragmentManager.findFragmentByTag(dialogTag) != null
 
     lifecycleScope.launch {
         repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -44,15 +44,16 @@ fun <M : Any> AnkiActivity.observeProgress(
                         pendingShow?.cancel()
                         pendingShow = null
                         dialogVisible = false
-                        dismissLoadingDialog()
+                        dismissLoadingDialog(dialogTag)
                     }
                     is ViewModelProgress.Active -> {
                         if (dialogVisible) {
                             showLoadingDialog(
                                 message = formatMessage(state, resolveMessage),
                                 cancellable = state.cancellable,
+                                tag = dialogTag,
                             )
-                            if (state.cancellable) wireCancelListener(viewModel)
+                            if (state.cancellable) wireCancelListener(viewModel, dialogTag)
                         } else if (pendingShow == null) {
                             pendingShow =
                                 launch {
@@ -63,8 +64,9 @@ fun <M : Any> AnkiActivity.observeProgress(
                                         showLoadingDialog(
                                             message = formatMessage(latest, resolveMessage),
                                             cancellable = latest.cancellable,
+                                            tag = dialogTag,
                                         )
-                                        if (latest.cancellable) wireCancelListener(viewModel)
+                                        if (latest.cancellable) wireCancelListener(viewModel, dialogTag)
                                     }
                                     pendingShow = null
                                 }
@@ -76,10 +78,13 @@ fun <M : Any> AnkiActivity.observeProgress(
     }
 }
 
-private fun AnkiActivity.wireCancelListener(viewModel: HasProgress<*>) {
+private fun AnkiActivity.wireCancelListener(
+    viewModel: HasProgress<*>,
+    dialogTag: String,
+) {
     supportFragmentManager.executePendingTransactions()
     val fragment =
-        supportFragmentManager.findFragmentByTag(LoadingDialogFragment.TAG)
+        supportFragmentManager.findFragmentByTag(dialogTag)
             as? LoadingDialogFragment
     fragment?.dialog?.setOnCancelListener {
         viewModel.progressManager.requestCancel()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerViewModelTest.kt
@@ -28,7 +28,11 @@ import com.ichi2.anki.libanki.Consts
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.Note
 import com.ichi2.anki.libanki.emptyCids
+import com.ichi2.anki.progress.ViewModelProgress
 import com.ichi2.testutils.ensureOpsExecuted
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.setMain
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -36,6 +40,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import timber.log.Timber
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 
 /** Test of [DeckPickerViewModel] */
 @RunWith(AndroidJUnit4::class)
@@ -145,6 +150,68 @@ class DeckPickerViewModelTest : RobolectricTest() {
 
             // backend assert
             assertThat("col undo status", col.undoStatus().undo, equalTo("Empty"))
+        }
+    }
+
+    @Test
+    fun `deleteDeck reports progress`() =
+        runProgressTest {
+            val deckId = addDeck("Deleted")
+
+            assertProgressAround(DeckPickerProgress.DELETING_DECK) { deleteDeck(deckId).join() }
+        }
+
+    @Test
+    fun `rebuildFilteredDeck reports progress`() =
+        runProgressTest {
+            val filteredDeckId = moveAllCardsToFilteredDeck()
+
+            assertProgressAround(DeckPickerProgress.REBUILDING_FILTERED_DECK) { rebuildFilteredDeck(filteredDeckId).join() }
+        }
+
+    @Test
+    fun `emptyFilteredDeck reports progress`() =
+        runProgressTest {
+            val filteredDeckId = moveAllCardsToFilteredDeck()
+
+            assertProgressAround { emptyFilteredDeck(filteredDeckId).join() }
+        }
+
+    @Test
+    fun `deleteEmptyCards reports progress`() =
+        runProgressTest {
+            val cardsToEmpty = createEmptyCards()
+
+            assertProgressAround(DeckPickerProgress.DELETING_EMPTY_CARDS) { deleteEmptyCards(cardsToEmpty).join() }
+        }
+
+    @Test
+    fun `createBackup reports progress`() =
+        runProgressTest {
+            assertProgressAround(DeckPickerProgress.CREATING_BACKUP) { createBackup() }
+        }
+
+    /**
+     * [runTest] with a ViewModel built after Main becomes a [StandardTestDispatcher]. The ViewModel's
+     * scope captures Main when it is built, and an inline Main would hide the Active state.
+     */
+    private fun runProgressTest(testBody: suspend DeckPickerViewModel.() -> Unit) =
+        runTest {
+            Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+            DeckPickerViewModel().testBody()
+        }
+
+    private suspend fun DeckPickerViewModel.assertProgressAround(
+        message: DeckPickerProgress? = null,
+        op: suspend () -> Unit,
+    ) {
+        progressManager.progress.test {
+            assertIs<ViewModelProgress.Idle>(awaitItem())
+            op()
+            val active = assertIs<ViewModelProgress.Active<DeckPickerProgress>>(awaitItem())
+            assertEquals(message, active.message)
+            assertIs<ViewModelProgress.Idle>(awaitItem())
+            expectNoEvents()
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/progress/ProgressObserverTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/progress/ProgressObserverTest.kt
@@ -33,6 +33,10 @@ class ProgressObserverTest : RobolectricTest() {
         object : HasProgress<String> {
             override val progressManager = this@ProgressObserverTest.progressManager
         }
+    private val otherViewModel =
+        object : HasProgress<String> {
+            override val progressManager = ProgressManager<String>()
+        }
 
     @Test
     fun `dialog appears after the delay and is dismissed when the op ends`() {
@@ -112,11 +116,60 @@ class ProgressObserverTest : RobolectricTest() {
         op.cancel()
     }
 
+    @Test
+    fun `an idle observer does not dismiss another observer's dialog after a restart`() {
+        val controller = startActivity()
+        val activity = controller.get()
+        activity.observeProgress(viewModel, delayMillis = SHOW_DELAY) { it }
+        activity.observeProgress(otherViewModel, delayMillis = SHOW_DELAY) { it }
+
+        val gate = CompletableDeferred<Unit>()
+        val op = launchOp(gate)
+        idleMainLooper(SHOW_DELAY * 2)
+        assertNotNull(activity.loadingDialog(), "dialog must show for the running op")
+
+        controller.pause().stop()
+        controller.start().resume()
+        idleMainLooper(SHOW_DELAY)
+
+        assertNotNull(activity.loadingDialog(), "the idle observer must not dismiss the running op's dialog")
+
+        gate.complete(Unit)
+        idleMainLooper(SHOW_DELAY)
+        assertNull(activity.loadingDialog(), "dialog must be dismissed once the op ends")
+        op.cancel()
+    }
+
+    @Test
+    fun `an observer whose op ends does not dismiss another observer's dialog`() {
+        val activity = startActivity().get()
+        activity.observeProgress(viewModel, delayMillis = SHOW_DELAY) { it }
+        activity.observeProgress(otherViewModel, delayMillis = SHOW_DELAY) { it }
+
+        val gate = CompletableDeferred<Unit>()
+        val otherGate = CompletableDeferred<Unit>()
+        val op = launchOp(gate)
+        val otherOp = launchOp(otherGate, manager = otherViewModel.progressManager)
+        idleMainLooper(SHOW_DELAY * 2)
+
+        otherGate.complete(Unit)
+        idleMainLooper(SHOW_DELAY)
+
+        assertNotNull(activity.loadingDialog(), "the running op's dialog must stay")
+
+        gate.complete(Unit)
+        idleMainLooper(SHOW_DELAY)
+        assertNull(activity.loadingDialog(), "dialog must be dismissed once both ops end")
+        op.cancel()
+        otherOp.cancel()
+    }
+
     private fun launchOp(
         gate: CompletableDeferred<Unit>,
         message: String = "op",
+        manager: ProgressManager<String> = progressManager,
     ) = CoroutineScope(Dispatchers.Unconfined).launch {
-        progressManager.withProgress(message = message) { gate.await() }
+        manager.withProgress(message = message) { gate.await() }
     }
 
     private fun startActivity(): ActivityController<EmptyAnkiActivity> =
@@ -125,7 +178,8 @@ class ProgressObserverTest : RobolectricTest() {
             .setup()
             .also { saveControllerForCleanup(it) }
 
-    private fun EmptyAnkiActivity.loadingDialog() = supportFragmentManager.findFragmentByTag(LoadingDialogFragment.TAG)
+    private fun EmptyAnkiActivity.loadingDialog() =
+        supportFragmentManager.fragments.filterIsInstance<LoadingDialogFragment>().singleOrNull()
 
     private fun EmptyAnkiActivity.loadingDialogText() =
         (loadingDialog() as? DialogFragment)


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

> [!NOTE]
> Assisted-by: Claude Opus 5

## Purpose / Description
Adopt progress for DeckPicker i.e. the ViewModel reports its own progress and the fragment observes it

## Fixes
- Part of #19460

## Approach
See commit

## How Has This Been Tested?
Unit testing only

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->